### PR TITLE
Fix(website): security fixes

### DIFF
--- a/site_src/auth/discord-oauth.ts
+++ b/site_src/auth/discord-oauth.ts
@@ -69,7 +69,9 @@ export async function exchangeCode(code: string): Promise<{ accessToken: string 
     body,
   }, 'Discord token exchange');
   if (!res.ok) {
-    throw new Error(`Discord token exchange failed: ${res.status} ${await res.text()}`);
+    // Body intentionally not interpolated: Discord echoes the OAuth `code` on
+    // invalid_grant, and that ends up in persistence/logs_error.txt.
+    throw new Error(`Discord token exchange failed: ${res.status}`);
   }
   const json = await res.json() as { access_token?: string };
   if (!json.access_token) throw new Error('Discord token response missing access_token');
@@ -81,7 +83,7 @@ export async function fetchDiscordMe(accessToken: string): Promise<DiscordMe> {
     headers: { authorization: `Bearer ${accessToken}` },
   }, 'Discord /users/@me');
   if (!res.ok) {
-    throw new Error(`Discord /users/@me failed: ${res.status} ${await res.text()}`);
+    throw new Error(`Discord /users/@me failed: ${res.status}`);
   }
   return await res.json() as DiscordMe;
 }

--- a/site_src/auth/session.ts
+++ b/site_src/auth/session.ts
@@ -4,9 +4,17 @@ import { getCookie, setCookie, deleteCookie } from 'hono/cookie';
 import type { Silverwolf } from '../../classes/silverwolf';
 import type { WebSession } from '../../database/models/WebSessionModel';
 
-export const SESSION_COOKIE = 'sw_session';
-export const OAUTH_STATE_COOKIE = 'sw_oauth_state';
+// __Host- prefix locks the cookie to Secure + Path=/ + no Domain — browsers
+// reject anything else under that name. We only apply it in prod because the
+// prefix demands Secure, and dev runs HTTP.
+const USE_HOST_PREFIX = process.env.NODE_ENV === 'production';
+const HOST_PREFIX = USE_HOST_PREFIX ? '__Host-' : '';
+export const SESSION_COOKIE = `${HOST_PREFIX}sw_session`;
+export const OAUTH_STATE_COOKIE = `${HOST_PREFIX}sw_oauth_state`;
 export const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+// Absolute ceiling on session age regardless of activity. A leaked cookie kept
+// alive by sliding TTL is invalidated once the underlying row crosses this.
+export const SESSION_ABSOLUTE_MAX_MS = 90 * 24 * 60 * 60 * 1000;
 export const OAUTH_STATE_TTL_S = 5 * 60;
 
 function getSecret(): string {
@@ -90,7 +98,8 @@ export async function loadSession(
 ): Promise<WebSession | null> {
   const session = await silverwolf.db.webSession.getSession(sessionId);
   if (!session) return null;
-  if (session.expiresAt < Date.now()) {
+  const now = Date.now();
+  if (session.expiresAt < now || now - session.createdAt > SESSION_ABSOLUTE_MAX_MS) {
     await silverwolf.db.webSession.deleteSession(sessionId);
     return null;
   }

--- a/site_src/components/navbar.ts
+++ b/site_src/components/navbar.ts
@@ -56,6 +56,10 @@ export type NavActive = 'home' | 'leaderboards' | 'birthdays' | 'games';
 export interface NavUser {
   username: string;
   avatarURL: string | null;
+  // Per-session token embedded in the logout form. Validated server-side
+  // against WebSession.csrf_token to prevent forged POST /auth/logout
+  // calls (defence-in-depth on top of SameSite=Lax).
+  csrf: string;
 }
 
 const navbarExtras = (nonce: string) => raw(`
@@ -434,6 +438,7 @@ export function Navbar(active: NavActive | undefined, nonce: string, lv999?: boo
             ${user.avatarURL ? html`<img class="nav-avatar" src="${user.avatarURL}" alt="${user.username}" width="32" height="32" />` : ''}
             <span class="nav-username">@${user.username}</span>
             <form action="/auth/logout" method="POST" style="display:inline;margin:0;">
+              <input type="hidden" name="csrf" value="${user.csrf}" />
               <button type="submit" class="nav-auth-link" style="background:none;cursor:pointer;font-family:inherit;">Logout</button>
             </form>
           </div>

--- a/site_src/inline.ts
+++ b/site_src/inline.ts
@@ -1,0 +1,18 @@
+// Safely embed a value as a JS literal inside an inline <script> block.
+//
+// JSON.stringify alone is unsafe in two ways:
+//  1. The substring "</script>" inside any string would close the surrounding
+//     <script> tag and start an HTML-injection attack. Escaping "<" prevents it.
+//  2. JSON allows the raw line-terminator codepoints U+2028 / U+2029 inside
+//     strings, but JS engines pre-ES2019 (and some embedded WebViews) treat
+//     them as line terminators, breaking the script. Escaping defends portability.
+//
+// Inputs today are all developer-controlled JSON files, but this is the kind
+// of helper that must already be in place before any user-controlled value
+// gets near a <script> body.
+export function inlineJSON(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/</g, '\\u003c')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}

--- a/site_src/pages/games/8ball.ts
+++ b/site_src/pages/games/8ball.ts
@@ -1,5 +1,6 @@
 import { html, raw } from 'hono/html';
 import { Layout } from '../../components/layout';
+import { inlineJSON } from '../../inline';
 
 export function EightBallPage(opts: { normal: string[]; savage: string[]; nonce: string; lv999?: boolean; user?: import('../../components/navbar').NavUser | null }) {
   const {
@@ -92,8 +93,8 @@ export function EightBallPage(opts: { normal: string[]; savage: string[]; nonce:
 </style>
 <script nonce="${nonce}">
 (() => {
-  const normal = ${JSON.stringify(normal).replace(/</g, '\\u003c')};
-  const savage = ${JSON.stringify(savage).replace(/</g, '\\u003c')};
+  const normal = ${inlineJSON(normal)};
+  const savage = ${inlineJSON(savage)};
   const btn = document.getElementById('ask-btn');
   const input = document.getElementById('question-input');
   const inner = document.getElementById('eightball-text');

--- a/site_src/pages/games/fortune.ts
+++ b/site_src/pages/games/fortune.ts
@@ -1,5 +1,6 @@
 import { html, raw } from 'hono/html';
 import { Layout } from '../../components/layout';
+import { inlineJSON } from '../../inline';
 
 export function FortunePage(opts: { fortunes: string[]; nonce: string; lv999?: boolean; user?: import('../../components/navbar').NavUser | null }) {
   const {
@@ -116,7 +117,7 @@ export function FortunePage(opts: { fortunes: string[]; nonce: string; lv999?: b
 </style>
 <script nonce="${nonce}">
 (() => {
-  const fortunes = ${JSON.stringify(fortunes).replace(/</g, '\\u003c')};
+  const fortunes = ${inlineJSON(fortunes)};
 
   const svg = document.getElementById('fortune-svg');
 

--- a/site_src/server.ts
+++ b/site_src/server.ts
@@ -92,16 +92,25 @@ STATIC_ASSETS['/static/svg/fortune-cookie-svgrepo-com.svg'] = { path: path.join(
 async function serveStatic(entry: StaticEntry) {
   const file = Bun.file(entry.path);
   if (!(await file.exists())) return new Response('not found', { status: 404 });
-  return new Response(file, {
-    headers: { 'content-type': entry.contentType, 'cache-control': IMMUTABLE_CACHE },
-  });
+  const headers: Record<string, string> = {
+    'content-type': entry.contentType,
+    'cache-control': IMMUTABLE_CACHE,
+  };
+  // SVGs can carry <script> if served as a top-level document. Lock them down
+  // so even a future malicious-SVG drop in Assets/svg/ can't run JS.
+  if (entry.contentType === 'image/svg+xml') {
+    headers['content-security-policy'] = "default-src 'none'; style-src 'unsafe-inline'; sandbox";
+  }
+  return new Response(file, { headers });
 }
 
 function buildCsp(nonce: string): string {
   return [
     "default-src 'self'",
     `script-src 'self' 'nonce-${nonce}'`,
-    // style-src keeps 'unsafe-inline' to cover the many style="" attributes used across pages.
+    // TODO(security): drop 'unsafe-inline' once every inline style="…" / <style>
+    // block is migrated to a class or hash. Today this allowance gives any future
+    // XSS a CSS-injection exfil channel (background-image: url(...) leaks).
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: https://cdn.discordapp.com",
     "font-src 'self'",
@@ -136,10 +145,29 @@ function clientIp(c: any): string {
   return peer?.address ?? 'unknown';
 }
 
+// IPv6 ISPs hand out /64 subnets (2^64 addresses) per customer. Per-IP rate
+// limiting on raw IPv6 means an attacker can rotate addresses inside their
+// /64 and bypass the limit forever. Bucket by /64 instead.
+function rateLimitKey(ip: string): string {
+  if (!ip.includes(':')) return ip;
+  // Expand "::" if present so we can grab the first 4 hextets reliably.
+  const [head, tail] = ip.split('::', 2);
+  let hextets: string[];
+  if (tail !== undefined) {
+    const headParts = head ? head.split(':') : [];
+    const tailParts = tail ? tail.split(':') : [];
+    const fillCount = 8 - headParts.length - tailParts.length;
+    hextets = [...headParts, ...Array(Math.max(0, fillCount)).fill('0'), ...tailParts];
+  } else {
+    hextets = ip.split(':');
+  }
+  return `${hextets.slice(0, 4).join(':')}::/64`;
+}
+
 function rateLimiter(limit: number, windowMs: number) {
   return async (c: any, next: any) => {
     if (c.req.path.startsWith('/static/')) return next();
-    const ip = clientIp(c);
+    const ip = rateLimitKey(clientIp(c));
     const now = Date.now();
     let record = rateLimitMap.get(ip);
     if (!record || record.resetAt < now) {
@@ -161,6 +189,7 @@ function rateLimiter(limit: number, windowMs: number) {
 interface SessionUser {
   discordId: string;
   sessionId: string;
+  csrfToken: string;
   nav: NavUser;
 }
 
@@ -185,6 +214,12 @@ export function startWebsite(silverwolf: Silverwolf) {
     c.header('X-Content-Type-Options', 'nosniff');
     c.header('Referrer-Policy', 'strict-origin-when-cross-origin');
     c.header('X-Frame-Options', 'DENY');
+    // Per-user / nonce-bearing HTML must never be cached by intermediaries.
+    // A single CF "Cache Everything" misconfiguration would otherwise reuse one
+    // user's nonce (and /me payload) across visitors.
+    c.header('Cache-Control', 'private, no-store');
+    c.header('Strict-Transport-Security', 'max-age=63072000; includeSubDomains; preload');
+    c.header('Permissions-Policy', 'camera=(), microphone=(), geolocation=(), interest-cohort=()');
   });
 
   // Session middleware: populate c.var.user from cookie. Skips static assets.
@@ -205,7 +240,8 @@ export function startWebsite(silverwolf: Silverwolf) {
         c.set('user', {
           discordId: session.discordId,
           sessionId: session.id,
-          nav: { username: display.username, avatarURL: display.avatarURL },
+          csrfToken: session.csrfToken,
+          nav: { username: display.username, avatarURL: display.avatarURL, csrf: session.csrfToken },
         });
         // Sliding expiry: bump server-side TTL and re-issue the cookie so the
         // browser's maxAge stays in sync with the DB expiry.
@@ -257,6 +293,20 @@ export function startWebsite(silverwolf: Silverwolf) {
   app.post('/auth/logout', async (c) => {
     const user = c.get('user');
     if (user) {
+      // CSRF: validate the form-supplied token against the per-session
+      // token. SameSite=Lax already blocks cross-origin POST cookies, but
+      // this closes any future hole if a sibling endpoint relaxes that.
+      let formToken = '';
+      try {
+        const body = await c.req.parseBody();
+        const raw = (body as Record<string, unknown>).csrf;
+        formToken = typeof raw === 'string' ? raw : '';
+      } catch {
+        formToken = '';
+      }
+      if (!formToken || !constantTimeEqual(formToken, user.csrfToken)) {
+        return c.text('CSRF check failed', 403);
+      }
       try {
         await silverwolf.db.webSession.deleteSession(user.sessionId);
       } catch (err) {


### PR DESCRIPTION
site_src/server.ts — Cache-Control, HSTS, Permissions-Policy, SVG CSP, IPv6 /64 normalisation, SessionUser.csrfToken, CSRF validation in /auth/logout, unsafe-inline TODO site_src/auth/session.ts — __Host- prefix (prod-gated), SESSION_ABSOLUTE_MAX_MS = 90d, absolute-age check in loadSession site_src/auth/discord-oauth.ts — error messages stripped of Discord response bodies site_src/components/navbar.ts — NavUser.csrf, <input name="csrf"> in logout form site_src/inline.ts — new inlineJSON helper
site_src/pages/games/8ball.ts, site_src/pages/games/fortune.ts — switched to inlineJSON

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CSRF token protection to logout functionality
  * Implemented stricter content security policies for embedded resources
  * Added security headers (HSTS and Permissions-Policy)

* **Bug Fixes**
  * Enforced absolute maximum session duration (90 days) to prevent indefinitely extended sessions
  * Improved error handling to prevent sensitive information leakage
  * Enhanced IPv6 rate limiting with subnet-based bucketing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->