### PR TITLE
Mobile dock: drag-to-navigate with press-to-expand pill

### DIFF
--- a/site_src/Assets/app.src.js
+++ b/site_src/Assets/app.src.js
@@ -142,9 +142,13 @@
     // Navigation is driven entirely by pointerup (a genuine finger-lift) so we
     // never navigate mid-drag. Anchors would otherwise navigate on their native
     // click, so swallow it — but let modifier/middle clicks open a new tab.
+    const hasModifier = (e) => e.metaKey || e.ctrlKey || e.shiftKey || e.altKey;
     tiles.forEach((tile) => {
       tile.addEventListener('click', (e) => {
-        if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button === 1) return;
+        if (hasModifier(e) || e.button === 1) return;
+        // Keyboard / AT activation (Enter/Space) reports detail === 0 and never
+        // goes through the pointer drag path — let it navigate natively.
+        if (e.detail === 0) return;
         e.preventDefault();
       });
     });
@@ -185,6 +189,9 @@
 
     dock.addEventListener('pointerdown', (e) => {
       if (e.button && e.button !== 0) return;
+      // Let modifier-clicks fall through to the native anchor (open in new tab)
+      // — don't start a drag, or pointerup would also navigate the current tab.
+      if (hasModifier(e)) return;
       const dr = dock.getBoundingClientRect();
       const localX = e.clientX - dr.left;
       // Snapshot geometry up front; reused for the whole drag (see dragGeom note).

--- a/site_src/Assets/app.src.js
+++ b/site_src/Assets/app.src.js
@@ -99,14 +99,18 @@
   );
   if (dock && pill && dockVisible) {
     const tiles = Array.from(dock.querySelectorAll('.nav-link'));
-    const NAV_DELAY = 320;
+    const NAV_DELAY = 200;
     const SPRING = '0.4s cubic-bezier(0.34, 1.56, 0.64, 1)';
+    // How much the pill grows while a finger is pressed/dragging — gives the
+    // "bubble expands under your thumb" feel.
+    const PRESS_SCALE = 1.12;
 
     let activeIdx = tiles.findIndex((t) => t.classList.contains('active'));
     if (activeIdx < 0) activeIdx = 0;
     let pillX = 0;
     let pillW = 0;
     let pendingNav = null;
+    let pressed = false;
 
     const tileGeom = (tile) => {
       const dr = dock.getBoundingClientRect();
@@ -114,21 +118,18 @@
       return { x: tr.left - dr.left, w: tr.width };
     };
 
+    // Transform carries both position (translateX) and the press scale, so they
+    // can animate together. transform-origin defaults to center → grows evenly.
+    const applyPillTransform = (x) => {
+      pill.style.transform = 'translateX(' + x + 'px) scale(' + (pressed ? PRESS_SCALE : 1) + ')';
+    };
+
     const placePill = (idx, animate) => {
       const g = tileGeom(tiles[idx]);
       pillX = g.x; pillW = g.w;
       pill.style.transition = animate ? 'transform ' + SPRING + ', width ' + SPRING : 'none';
       pill.style.width = g.w + 'px';
-      pill.style.transform = 'translateX(' + g.x + 'px)';
-    };
-
-    const setActive = (idx) => {
-      if (idx === activeIdx) return;
-      tiles[activeIdx].classList.remove('active');
-      tiles[activeIdx].removeAttribute('aria-current');
-      tiles[idx].classList.add('active');
-      tiles[idx].setAttribute('aria-current', 'page');
-      activeIdx = idx;
+      applyPillTransform(g.x);
     };
 
     const navigate = (idx) => {
@@ -138,25 +139,25 @@
 
     requestAnimationFrame(() => placePill(activeIdx, false));
 
-    // Tap a tile → slide pill + navigate (skip if it was a drag-induced click)
-    tiles.forEach((tile, i) => {
+    // Navigation is driven entirely by pointerup (a genuine finger-lift) so we
+    // never navigate mid-drag. Anchors would otherwise navigate on their native
+    // click, so swallow it — but let modifier/middle clicks open a new tab.
+    tiles.forEach((tile) => {
       tile.addEventListener('click', (e) => {
-        if (suppressClick) { suppressClick = false; e.preventDefault(); e.stopPropagation(); return; }
-        if (i === activeIdx) return;
         if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button === 1) return;
         e.preventDefault();
-        setActive(i);
-        placePill(i, true);
-        navigate(i);
       });
     });
 
-    // ── Drag the pill to slide focus ─────────────────────────────
+    // Kill the browser's native link/image drag so a mouse drag scrubs the pill
+    // instead of tearing the anchor out as a draggable URL ghost.
+    dock.addEventListener('dragstart', (e) => e.preventDefault());
+
+    // ── Press & drag the pill to slide focus ─────────────────────
     let dragging = false;
     let dragStartX = 0;
     let dragOriginX = 0;
     let dragMoved = false;
-    let suppressClick = false;
     // Geometry snapshot taken once on pointerdown so the move loop never calls
     // getBoundingClientRect (each call forces a synchronous reflow; doing it per
     // tile, per pointermove at 60–120Hz is the classic layout-thrash jank).
@@ -173,62 +174,82 @@
       return nearest;
     };
 
+    const PAD = 4;
+    const clampX = (x) => {
+      const minX = PAD;
+      const maxX = dragGeom.dockWidth - pillW - PAD;
+      if (x < minX) return minX;
+      if (x > maxX) return maxX;
+      return x;
+    };
+
     dock.addEventListener('pointerdown', (e) => {
-      // Only initiate drag when the pointer lands on the pill itself.
+      if (e.button && e.button !== 0) return;
       const dr = dock.getBoundingClientRect();
       const localX = e.clientX - dr.left;
-      if (localX < pillX || localX > pillX + pillW) return;
-      dragging = true;
-      dragMoved = false;
-      dragStartX = e.clientX;
-      dragOriginX = pillX;
       // Snapshot geometry up front; reused for the whole drag (see dragGeom note).
       dragGeom = {
         centers: tiles.map((t) => { const g = tileGeom(t); return g.x + g.w / 2; }),
         dockWidth: dr.width,
       };
+      dragging = true;
+      dragMoved = false;
+      dragStartX = e.clientX;
+      pressed = true;
       pill.classList.add('dragging');
-      pill.style.transition = 'none';
+      // Pop the pill open; if the press landed away from the pill, slide it under
+      // the finger. Both animate via the spring transition set here.
+      pill.style.transition = 'transform ' + SPRING + ', width ' + SPRING;
+      if (localX < pillX || localX > pillX + pillW) {
+        pillX = clampX(localX - pillW / 2);
+        const nearest = nearestTo(pillX + pillW / 2);
+        tiles.forEach((t, i) => t.classList.toggle('active', i === nearest));
+      }
+      dragOriginX = pillX;
+      applyPillTransform(pillX);
       try { dock.setPointerCapture(e.pointerId); } catch (_) {}
     });
 
     dock.addEventListener('pointermove', (e) => {
       if (!dragging) return;
       const dx = e.clientX - dragStartX;
-      if (Math.abs(dx) > 4) dragMoved = true;
-      // Pad inside the dock so the pill never overlaps the curved edge
-      const pad = 4;
-      const minX = pad;
-      const maxX = dragGeom.dockWidth - pillW - pad;
-      let nx = dragOriginX + dx;
-      if (nx < minX) nx = minX;
-      if (nx > maxX) nx = maxX;
+      if (!dragMoved && Math.abs(dx) > 4) {
+        dragMoved = true;
+        // Once a real drag begins, the pill must track the finger 1:1 — drop the
+        // spring transition so it follows instantly instead of lagging behind.
+        pill.style.transition = 'none';
+      }
+      const nx = clampX(dragOriginX + dx);
       pillX = nx;
-      pill.style.transform = 'translateX(' + nx + 'px)';
+      applyPillTransform(nx);
 
       // Live preview: brighten whichever tile the pill center is closest to
       const nearest = nearestTo(nx + pillW / 2);
       tiles.forEach((t, i) => t.classList.toggle('active', i === nearest));
     });
 
-    const endDrag = (e) => {
-      if (!dragging) return;
+    // Reset to the currently-active tile and shrink the pill back. Shared by the
+    // "abort" paths (pointercancel) where we must NOT navigate.
+    const settleToActive = (e) => {
       dragging = false;
+      pressed = false;
       pill.classList.remove('dragging');
       try { dock.releasePointerCapture(e.pointerId); } catch (_) {}
-      if (!dragMoved) {
-        // No real drag — restore pill under the previously-active tile.
-        tiles.forEach((t, i) => t.classList.toggle('active', i === activeIdx));
-        if (activeIdx >= 0) tiles[activeIdx].setAttribute('aria-current', 'page');
-        placePill(activeIdx, true);
-        return;
-      }
-      // Snap to nearest tile, navigate if changed. Reuse the drag snapshot.
-      suppressClick = true;
-      setTimeout(() => { suppressClick = false; }, 400);
+      tiles.forEach((t, i) => t.classList.toggle('active', i === activeIdx));
+      if (activeIdx >= 0) tiles[activeIdx].setAttribute('aria-current', 'page');
+      placePill(activeIdx, true);
+    };
+
+    // Finger genuinely lifted: snap to the tile under the pill and navigate to
+    // it. This is the ONLY path that navigates — a tap, or a drag-then-release.
+    dock.addEventListener('pointerup', (e) => {
+      if (!dragging) return;
+      dragging = false;
+      pressed = false;
+      pill.classList.remove('dragging');
+      try { dock.releasePointerCapture(e.pointerId); } catch (_) {}
       const nearest = nearestTo(pillX + pillW / 2);
       const changed = nearest !== activeIdx;
-      // Update aria-current on the new active tile
       tiles.forEach((t, i) => {
         t.classList.toggle('active', i === nearest);
         if (i === nearest) t.setAttribute('aria-current', 'page');
@@ -237,10 +258,14 @@
       activeIdx = nearest;
       placePill(nearest, true);
       if (changed) navigate(nearest);
-    };
+    });
 
-    dock.addEventListener('pointerup', endDrag);
-    dock.addEventListener('pointercancel', endDrag);
+    // Pointer was cancelled by the browser (e.g. a scroll/gesture took over) —
+    // treat it as "never lifted off the selection": abort without navigating.
+    dock.addEventListener('pointercancel', (e) => {
+      if (!dragging) return;
+      settleToActive(e);
+    });
 
     window.addEventListener('resize', () => placePill(activeIdx, false));
   }

--- a/site_src/Assets/input.css
+++ b/site_src/Assets/input.css
@@ -494,12 +494,20 @@ code, pre, kbd, .font-mono {
       z-index: 0;
       will-change: transform, width;
     }
+    /* While pressed/dragging the pill scales up (transform driven by JS) and
+       its glow intensifies so the "bubble" feels like it lifts toward you. */
     #nav-mobile .dock-pill.dragging {
       cursor: grabbing;
+      background: linear-gradient(90deg, color-mix(in oklab, var(--accent) 38%, transparent), color-mix(in oklab, var(--accent-pale) 38%, transparent));
+      border-color: color-mix(in oklab, var(--accent) 65%, transparent);
       box-shadow:
         inset 0 1px 0 rgba(255, 255, 255, 0.5),
         inset 0 -1px 0 rgba(0, 0, 0, 0.1),
-        0 4px 16px color-mix(in oklab, var(--accent) 40%, transparent);
+        0 6px 22px color-mix(in oklab, var(--accent) 50%, transparent),
+        0 0 18px color-mix(in oklab, var(--accent) 35%, transparent);
+      transition: background 0.4s cubic-bezier(0.34, 1.56, 0.64, 1),
+        border-color 0.4s cubic-bezier(0.34, 1.56, 0.64, 1),
+        box-shadow 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
     }
 
     /* Tile = icon + label, stacked. Sits above the pill in z-stack. */
@@ -518,7 +526,15 @@ code, pre, kbd, .font-mono {
       position: relative;
       z-index: 1;
       transition: color 0.32s cubic-bezier(0.4, 0, 0.2, 1);
+      /* Suppress native link-drag + text selection so a mouse/finger drag scrubs
+         the pill instead of pulling the URL out as a draggable ghost. */
+      -webkit-user-drag: none;
+      user-select: none;
+      -webkit-user-select: none;
+      -webkit-touch-callout: none;
     }
+    #nav-mobile .nav-link svg,
+    #nav-mobile .nav-link .label { pointer-events: none; }
     #nav-mobile .nav-link svg {
       width: 22px;
       height: 22px;

--- a/site_src/components/navbar.ts
+++ b/site_src/components/navbar.ts
@@ -66,7 +66,7 @@ export function Navbar(active: NavActive | undefined, lv999?: boolean, user?: Na
   const dockLink = (href: string, label: string, key: keyof typeof ICONS) => {
     const isActive = active === key;
     const cls = `nav-link no-underline${isActive ? ' active' : ''}`;
-    return html`<a href="${href}" class="${cls}" aria-label="${label}"${isActive ? raw(' aria-current="page"') : ''}>${ICONS[key]}<span class="label">${label}</span></a>`;
+    return html`<a href="${href}" class="${cls}" aria-label="${label}" draggable="false"${isActive ? raw(' aria-current="page"') : ''}>${ICONS[key]}<span class="label">${label}</span></a>`;
   };
 
   // The "Home" tab was retired — the public tab now goes to /about for everyone,


### PR DESCRIPTION
## What

Reworks the mobile bottom-dock navbar interaction so dragging the highlight pill feels fluid and only navigates when you lift off.

## Why

Previously the dock would navigate after the pill was dragged past a certain point — caused by `pointercancel` (fired when the browser's scroll/gesture took over mid-drag) running the same commit path as `pointerup`. The ask was: let me freely drag the pill, and navigate only when my finger lifts off — plus make the highlight bubble expand on press for a more tactile feel.

## Changes

- **Navigate only on `pointerup`** (a genuine finger-lift). `pointercancel` now aborts and resets to the active tile *without* navigating.
- **Press anywhere on the dock** to grab the pill; it slides under the finger and you can scrub freely across all tiles with live highlight preview — no premature navigation.
- **Press-to-expand pill**: scales up (`PRESS_SCALE`) with intensified glow on press, snaps back on release. The spring transition is dropped mid-drag so the pill tracks the pointer 1:1, then re-enabled for the snap.
- **Suppress native link-drag**: `draggable="false"` on dock anchors + `-webkit-user-drag`/`user-select: none` + a `dragstart` `preventDefault` fallback, and `pointer-events: none` on the icon/label. Without this a mouse drag tore the URL out as a draggable ghost.

## Notes for reviewers

- Source files only — `app.js`/`styles.css` are gitignored and regenerated at startup via `build:js`/`build:css`.
- Testable with a mouse: narrow the window to ≤1024px (Pointer Events fire for mouse too). Avoid Chrome device-emulation mode — its synthetic touch can fire spurious `pointercancel`s, which is exactly the path that intentionally no longer navigates.
- A plain tap (press + release in place) still navigates to that tile. Modifier/middle-clicks still open in a new tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved mobile navbar dock drag interaction with faster navigation response (37% reduction) and prevented accidental link activation during dragging.

* **Style**
  * Enhanced mobile navbar visual feedback with improved glow effects, gradients, and smooth scaling during drag interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->