### PR TITLE
feat: /balls Unsplash command + AI label in /ai view

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,6 @@ PUBLIC_ORIGIN=https://your-domain.example
 
 # Unsplash (used by /balls)
 UNSPLASH_ACCESS_KEY=your-unsplash-access-key
-UNSPLASH_SECRET_KEY=your-unsplash-secret-key
 
 # Runtime
 NODE_ENV=development

--- a/.env.example
+++ b/.env.example
@@ -29,5 +29,9 @@ OPENROUTER_API_KEY=your-openrouter-api-key
 # x-forwarded-* headers can't redirect link previews to another domain.
 PUBLIC_ORIGIN=https://your-domain.example
 
+# Unsplash (used by /balls)
+UNSPLASH_ACCESS_KEY=your-unsplash-access-key
+UNSPLASH_SECRET_KEY=your-unsplash-secret-key
+
 # Runtime
 NODE_ENV=development

--- a/commands/ai_view.ts
+++ b/commands/ai_view.ts
@@ -1,6 +1,7 @@
 import { EmbedBuilder } from 'discord.js';
 import { Command } from './classes/Command';
 import { logError } from '../utils/log';
+import { getPersonaInvokeLabel } from '../utils/ai';
 
 class AiView extends Command {
   constructor(client: any) {
@@ -41,7 +42,8 @@ class AiView extends Command {
         const date = new Date(s.createdAt).toLocaleDateString('en-GB', {
           year: 'numeric', month: 'short', day: 'numeric',
         });
-        return `**[${s.sessionId}]** ${s.title || s.personaName} · ${status} · ${messageCount} ${messageLabel} · Created ${date}`;
+        const ai = getPersonaInvokeLabel(s.personaName);
+        return `**[${s.sessionId}]** ${s.title || s.personaName} · ${status} · ${messageCount} ${messageLabel} · Created ${date} · ${ai}`;
       });
 
       const description = rows.join('\n')

--- a/commands/balls.ts
+++ b/commands/balls.ts
@@ -22,7 +22,9 @@ class Balls extends Command {
 
     try {
       const url = `https://api.unsplash.com/photos/random?query=${encodeURIComponent('balls')}&orientation=landscape`;
+      const timeoutMs = Number(process.env.DISCORD_FETCH_TIMEOUT_MS ?? 10000);
       const response = await fetch(url, {
+        signal: AbortSignal.timeout(timeoutMs),
         headers: {
           Authorization: `Client-ID ${accessKey}`,
           'Accept-Version': 'v1',
@@ -38,7 +40,9 @@ class Balls extends Command {
       // Trigger a download event so the photographer gets credited, as Unsplash requires.
       const downloadLocation = photo?.links?.download_location;
       if (downloadLocation) {
-        fetch(`${downloadLocation}&client_id=${accessKey}`).catch(() => {});
+        const attributionUrl = new URL(downloadLocation);
+        attributionUrl.searchParams.set('client_id', accessKey);
+        fetch(attributionUrl.toString()).catch(() => {});
       }
 
       const photographer = photo?.user?.name || 'Unknown';

--- a/commands/balls.ts
+++ b/commands/balls.ts
@@ -1,0 +1,74 @@
+import { EmbedBuilder } from 'discord.js';
+import { Command } from './classes/Command';
+import { logError } from '../utils/log';
+
+// Unsplash requires attribution back to the photographer and to Unsplash, with
+// the UTM params below, per their API guidelines:
+// https://help.unsplash.com/en/articles/2511315-guideline-attribution
+const UTM = 'utm_source=silverwolf&utm_medium=referral';
+
+class Balls extends Command {
+  constructor(client: any) {
+    super(client, 'balls', 'Fetch a random picture of balls', [], { blame: 'xei' });
+  }
+
+  async run(interaction: any): Promise<void> {
+    const accessKey = process.env.UNSPLASH_ACCESS_KEY;
+    if (!accessKey) {
+      logError('Balls: UNSPLASH_ACCESS_KEY is not set');
+      await interaction.editReply({ content: 'Balls are unavailable right now (missing API key).' });
+      return;
+    }
+
+    try {
+      const url = `https://api.unsplash.com/photos/random?query=${encodeURIComponent('balls')}&orientation=landscape`;
+      const response = await fetch(url, {
+        headers: {
+          Authorization: `Client-ID ${accessKey}`,
+          'Accept-Version': 'v1',
+        },
+      });
+
+      if (!response.ok) throw new Error(`Unsplash responded ${response.status}`);
+
+      const photo = await response.json();
+      const imageUrl = photo?.urls?.regular;
+      if (!imageUrl) throw new Error('No image in Unsplash response');
+
+      // Trigger a download event so the photographer gets credited, as Unsplash requires.
+      const downloadLocation = photo?.links?.download_location;
+      if (downloadLocation) {
+        fetch(`${downloadLocation}&client_id=${accessKey}`).catch(() => {});
+      }
+
+      const photographer = photo?.user?.name || 'Unknown';
+      const photographerLink = photo?.user?.links?.html
+        ? `${photo.user.links.html}?${UTM}`
+        : null;
+      const photoLink = photo?.links?.html ? `${photo.links.html}?${UTM}` : null;
+      const credit = photographerLink
+        ? `[${photographer}](${photographerLink})`
+        : photographer;
+
+      const embed = new EmbedBuilder()
+        .setColor(0x3498db)
+        .setTitle('Balls ⚽')
+        .setImage(imageUrl)
+        .setDescription(
+          `Photo by ${credit} on [Unsplash](https://unsplash.com/?${UTM})`,
+        );
+
+      if (photo?.description || photo?.alt_description) {
+        embed.setFooter({ text: photo.description || photo.alt_description });
+      }
+      if (photoLink) embed.setURL(photoLink);
+
+      await interaction.editReply({ embeds: [embed] });
+    } catch (error) {
+      logError('Error fetching balls from Unsplash:', error);
+      await interaction.editReply({ content: 'Sorry, I couldn\'t fetch any balls. Please try again later.' });
+    }
+  }
+}
+
+export default Balls;

--- a/commands/balls.ts
+++ b/commands/balls.ts
@@ -9,7 +9,12 @@ const UTM = 'utm_source=silverwolf&utm_medium=referral';
 
 class Balls extends Command {
   constructor(client: any) {
-    super(client, 'balls', 'Fetch a random picture of balls', [], { blame: 'xei' });
+    super(client, 'balls', 'Fetch a random picture of balls', [], {
+      ephemeral: false,
+      skipDefer: false,
+      isSubcommandOf: null,
+      blame: 'xei',
+    });
   }
 
   async run(interaction: any): Promise<void> {

--- a/utils/ai.ts
+++ b/utils/ai.ts
@@ -193,6 +193,19 @@ async function getPersonaByName(name: string): Promise<Persona | undefined> {
 }
 
 /**
+ * Returns a short uppercase label identifying which AI a persona is invoked
+ * by, derived from its primary trigger prefix (e.g. `@gpt` -> "GPT",
+ * `@ds` -> "DS"). Falls back to the persona name when it has no triggers.
+ */
+function getPersonaInvokeLabel(personaName: string): string {
+  const personas: Persona[] = personasConfig.personas || [];
+  const found = personas.find((p) => p.name.toLowerCase() === String(personaName).toLowerCase());
+  const trigger = found?.triggers?.find((t) => String(t).trim().length > 0);
+  if (!trigger) return String(personaName).toUpperCase();
+  return String(trigger).replace(/^@/, '').toUpperCase();
+}
+
+/**
  * Generates content (text and/or images) from the specified AI provider and model.
  */
 /**
@@ -734,4 +747,5 @@ export {
   getGeminiAI,
   getOpenRouterClient,
   getPersonaByName,
+  getPersonaInvokeLabel,
 };


### PR DESCRIPTION
## What changed

### `/balls` — new slash command
Fetches a random picture of balls from the **Unsplash API** (`GET /photos/random?query=balls`) and posts it in an embed.

**Attribution** (per [Unsplash API guidelines](https://help.unsplash.com/en/articles/2511315-guideline-attribution)):
- Embed credits the photographer and Unsplash, with links carrying the required `utm_source`/`utm_medium` referral params.
- Triggers the photo's `download_location` endpoint (fire-and-forget) so the photographer is properly credited.

Reads `UNSPLASH_ACCESS_KEY` from env; fails gracefully with a friendly message if the key is missing or the API errors. Added `UNSPLASH_ACCESS_KEY` / `UNSPLASH_SECRET_KEY` to `.env.example`.

### `/ai view` — show which AI each session uses
Each session row now ends with a short label for the AI it's invoked by, derived from the persona's primary trigger prefix (`@gpt` → `GPT`, `@ds` → `DS`). Added a reusable `getPersonaInvokeLabel` helper in `utils/ai.ts`.

Example:
```
[123] Fighter Aircraft Dogfight Performance Comparison · ⚫ Inactive · 11 messages · Created 30 May 2026 · GPT
[112] Xi Trump Summit 2026 Outcomes · ⚫ Inactive · 6 messages · Created 19 May 2026 · DS
```

## Reviewer notes
- `/balls` only needs the access key (public random fetch); the secret key isn't used server-side.
- The label reflects the invoke prefix, not the underlying provider/model (e.g. Deepseek runs on OpenRouter but shows `DS`).
- Typecheck and ESLint pass clean for the new/changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new command to fetch and display random photos with full artist attribution and credit information
  * Session display now shows persona labels for improved context identification

* **Chores**
  * Added configuration support for external photography service integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->