### PR TITLE
TCG x WebsiteSlop++: Chat, spectate, match history, deck slots, and more

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -539,26 +539,44 @@ cyclic-tic-tac-toe multiplayer pattern.
  executors (except `chat` → `tcgRoomManager.postChat`). Broadcasts are **per-socket viewer-aware
  snapshots** (hands stay private; spectators share one hand-less snapshot). Same burst rate-limit as
  the cyclic socket. `chat` is open to any seated player **or spectator** regardless of turn; text is
- control-char-stripped + length-capped (`TCG_CHAT_MAX_LEN`) and kept in a per-room ring buffer
- (`TCG_CHAT_HISTORY`). Each `TcgChatMessage` carries `{ kind: 'chat'|'system', senderId, username,
- isPlayer, … }`; the client interleaves chat + action-log into one feed and marks `isPlayer` chatters
- with an icon.
+ control-char-stripped + length-capped (`TCG_CHAT_MAX_LEN`). The room maintains the single source of
+ truth `room.feed` (combined log + chat in arrival order); the snapshot ships a recent slice as
+ `feed: TcgFeedItem[]` and the client **renders straight from `state.feed`** (so a re-joining client
+ shows full history and never replays the last action). Each chat `TcgChatMessage` carries
+ `{ kind: 'chat'|'system', senderId, username, isPlayer, isDev, … }`; the client marks `isPlayer`/`isDev`
+ chatters with icons.
+- **Room lifecycle** — a battle *ending* (`endBattle`: victory/timeout/forfeit/disconnect) only sets
+ `status:'ended'` + result; the **room stays open** for rematch/chat. The room **closes** (→ history)
+ only once it's empty — every player *and* spectator has left — after a `TCG_EMPTY_CLOSE_MS` grace
+ (`maybeScheduleClose`/`closeRoom`; a `sweep` backstop closes long-idle empty rooms). Presence drives
+ `system` chat lines: `joined` (first connect), `reconnected`, `disconnected` (drop; mid-battle PvP
+ also arms the disconnect-forfeit grace), `left` (explicit Leave), and spectator `started/stopped
+ spectating`. `listActive()` returns **all** in-memory rooms (any status) for the browse list.
+- **Match history** — `closeRoom` → `db.tcgMatch.recordMatch` persists the **final, un-editable**
+ state (table `TcgMatch`: mode, both players' id/username/team-slugs, winner side, end reason, rounds,
+ timestamps, plus `final_state` — JSON `{ snapshot: hand-less BattleSnapshot, feed: TcgFeedItem[] }`:
+ the final board + the cumulative combined log/chat feed, so the record renders **identically to the
+ live battle**). The match id **is the room id**, so a closed room's old `/games/tcg/:id` link
+ redirects to `/games/tcg/match/:id`. This is the **only** durable TCG state (rooms are in-memory).
+ `getRecent` feeds the browse history list; `getById` feeds the clickable match-detail page (static
+ board + feed re-rendered server-side). Rooms that never started a battle aren't recorded.
 - **Routes** — `site_src/tcg/routes.ts` (`registerTcgBattleRoutes`, wired in `server.ts`
- with `upgradeWebSocket` + `tcgRoomManager.init`): `GET /games/tcg` (landing),
- `POST /games/tcg/create`, `GET /games/tcg/:id` (room — renders the battle client for seated
- players, a team-picker for an eligible PvP joiner, or a not-found notice otherwise),
- `POST /games/tcg/:id/join`, `GET /games/tcg/ws/:id` (origin pre-check + upgrade),
- `GET /games/tcg/deck` + `POST /games/tcg/deck/save` (deck builder). All POSTs use
+ with `upgradeWebSocket` + `tcgRoomManager.init`): `GET /games/tcg` (**browse** — all in-progress
+ rooms via `tcgRoomManager.listActive()` + recent history, the default page), `GET /games/tcg/create`
+ (create form — registered before `:id`), `POST /games/tcg/create`, `GET /games/tcg/match/:id`
+ (permanent match-detail view, before `:id`), `GET /games/tcg/:id` (room —
+ renders the battle client for seated players, a team-picker for an eligible PvP joiner, else a
+ read-only **spectator** view), `POST /games/tcg/:id/join`, `GET /games/tcg/ws/:id` (origin pre-check
+ + upgrade), `GET /games/tcg/deck` + `POST /games/tcg/deck/save` (deck builder). All POSTs use
  `authedGameRequest` (CSRF); deck save re-runs `validateDeckComposition` server-side.
-- **Pages** — `site_src/tcg/pages/` (`landing.ts`, `room.ts`, `deck-builder.ts`, `detail.ts`;
- HTML templates in `site_src/tcg/html/`; client JS in `site_src/tcg/assets/`). Battle client
- renders over WS: card-PNG board with live HP/energy/effect overlays, active-slot glow,
- availability-driven skill buttons with targeting, hand tray, end-turn, action log, result
- banner, rematch/leave). The **Log/Chat panel** is a single persistent, tabbed element (built once,
- updated in place so the chat input keeps focus across re-renders): a wide right-hand column
- ≥920px, and a floating-launcher modal below that width (so the board + skills stay above the fold).
- Decks persist via `tcg/deckStorage.ts` — the **same** `User.tcg_deck` the Discord
- `/tcgbattle deckset` uses.
+- **Pages** — `site_src/tcg/pages/` (`landing.ts` = `TcgBrowsePage` + `TcgCreatePage`, `room.ts`,
+ `deck-builder.ts`, `detail.ts`; HTML templates in `site_src/tcg/html/`; client JS in
+ `site_src/tcg/assets/`). Battle client renders over WS: card-PNG board with live HP/energy/effect
+ overlays, active-slot glow, availability-driven skill buttons with targeting, hand tray, end-turn,
+ action log, result banner, rematch/leave). The **Log/Chat panel** is a single persistent element
+ (built once, updated in place so the chat input keeps focus across re-renders): a wide right-hand
+ column ≥920px, and a floating-launcher modal below that width. Decks persist via
+ `tcg/deckStorage.ts` — the **same** `User.tcg_deck` the Discord `/tcgbattle deckset` uses.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Bun process**. It serves fun/games both as slash commands and as web pages, plus
 **The website is public, so security and performance are first-class concerns — code defensively:
 validate every input, never trust client data, keep the CSP tight.**
 
-**Last updated: 2026-06-22**
+**Last updated: 2026-06-30**
 
 > **Maintenance rules.** Edit this file when something here becomes factually wrong, or when you
 > make a qualifying structural change. Rules differ by area:
@@ -213,7 +213,8 @@ all alive cards (this is when effect durations tick) and draws 2 cards per side.
 #### Items
 
 - `DECK_SIZE = 25`, `STARTING_HAND = 5`, `DRAW_PER_ROUND = 2`.
-- Decks are persisted per Discord user in `User.tcg_deck` (JSON `{itemId: count}`).
+- Decks are persisted per user inside their **active team slot** (`User.tcg_teams` — see §6.11;
+  JSON `{itemId: count}`), accessed via `tcg/deckStorage.ts`.
 - A **legal deck** is exactly 25 known items, each with count `0..PER_CARD_MAX (10)`, at most
   **5** copies at 5★+, and at most **15** copies at 4★+ (the 5★ cap counts toward the 4★ cap).
   See `validateDeckComposition` in `tcg/items/deck.ts`.
@@ -575,8 +576,22 @@ cyclic-tic-tac-toe multiplayer pattern.
  overlays, active-slot glow, availability-driven skill buttons with targeting, hand tray, end-turn,
  action log, result banner, rematch/leave). The **Log/Chat panel** is a single persistent element
  (built once, updated in place so the chat input keeps focus across re-renders): a wide right-hand
- column ≥920px, and a floating-launcher modal below that width. Decks persist via
- `tcg/deckStorage.ts` — the **same** `User.tcg_deck` the Discord `/tcgbattle deckset` uses.
+ column ≥920px, and a floating-launcher modal below that width.
+- **Team slots** — each user has **five loadout slots** (`{active, slots: [{team, deck}]}` in
+ `User.tcg_teams`, via `tcg/teamSlotStorage.ts`); **every battle plays from the active slot** — the
+ web create/join POSTs take no team from the client, they rebuild it server-side from the active
+ slot. The create/join pages render a slot bar (`tcg-team-slots.lib.js`): selecting a slot
+ (`POST /games/tcg/teams/select`) makes it active + loads its lineup into the picker; picker edits
+ auto-save (debounced, flushed before create/join) via `POST /games/tcg/teams/lineup`. **Decks live
+ inside slots**: `tcg/deckStorage.ts`'s load/save route to the active slot's deck (`null` =
+ default deck), so the web deck builder (which **auto-syncs on every change** — debounced, with a
+ `pagehide` keepalive flush; no save button) and Discord `/tcgbattle deckset` edit the active slot
+ without knowing about slots. A legacy `User.tcg_deck` is migrated into slot 1 on first load.
+ **Slots save anything** — partial lineups and illegal decks persist as-is; legality is
+ display-only (red `x/3` / `y/25` readiness on the slot chips, red badge in the deck builder)
+ and enforced only at battle time (web create/join reject; Discord `buildDeckForUser` falls back
+ to the default deck). Clients only ever receive `{active, deckSize, slots:[{team, deckCount,
+ deckLegal}]}` briefs (deck contents stay server-side).
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -527,14 +527,22 @@ cyclic-tic-tac-toe multiplayer pattern.
  roster values (`buildTeamOfThree`) and the user's saved `User.tcg_deck` (`expandDeckComposition`);
  client card data is never trusted. PvP has a turn timer (`TCG_TURN_TIMER_MS`) and a
  disconnect grace window; GC sweeps lobby/ended/abandoned rooms.
+- **Spectators** — any other logged-in user who opens a room link (and isn't the PvP joiner offered
+ the team-picker) attaches as a **spectator** (`room.spectators`, capped at `TCG_MAX_SPECTATORS`).
+ `attachSocket` routes non-seated users here; their snapshot is built with `buildBattleSnapshot(…,
+ spectator: true)` so **no hand is included** and `yourSide` is just the layout side. Spectators
+ can't act (`actionGuard` rejects them) but **can chat**; first-socket-join / last-socket-leave emit
+ a `system` chat notice. The room snapshot carries `spectator: boolean` + `spectatorCount`.
 - **WebSocket** — `site_src/tcg/ws.ts` (`createTcgWsEvents`). First message must be
  `join` carrying the CSRF token (`constantTimeEqual`); then `use_skill` / `use_item` /
  `end_turn` / `rematch_request` / `chat` / `leave` / `ping`, each routed through the `battleCore`
  executors (except `chat` → `tcgRoomManager.postChat`). Broadcasts are **per-socket viewer-aware
- snapshots** (hands stay private). Same burst rate-limit as the cyclic socket. `chat` is open to any
- seated player regardless of turn; text is control-char-stripped + length-capped
- (`TCG_CHAT_MAX_LEN`) and kept in a per-room ring buffer (`TCG_CHAT_HISTORY`) surfaced on the room
- snapshot as `chat: TcgChatMessage[]`.
+ snapshots** (hands stay private; spectators share one hand-less snapshot). Same burst rate-limit as
+ the cyclic socket. `chat` is open to any seated player **or spectator** regardless of turn; text is
+ control-char-stripped + length-capped (`TCG_CHAT_MAX_LEN`) and kept in a per-room ring buffer
+ (`TCG_CHAT_HISTORY`). Each `TcgChatMessage` carries `{ kind: 'chat'|'system', senderId, username,
+ isPlayer, … }`; the client interleaves chat + action-log into one feed and marks `isPlayer` chatters
+ with an icon.
 - **Routes** — `site_src/tcg/routes.ts` (`registerTcgBattleRoutes`, wired in `server.ts`
  with `upgradeWebSocket` + `tcgRoomManager.init`): `GET /games/tcg` (landing),
  `POST /games/tcg/create`, `GET /games/tcg/:id` (room — renders the battle client for seated

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Bun process**. It serves fun/games both as slash commands and as web pages, plus
 **The website is public, so security and performance are first-class concerns — code defensively:
 validate every input, never trust client data, keep the CSP tight.**
 
-**Last updated: 2026-06-19**
+**Last updated: 2026-06-22**
 
 > **Maintenance rules.** Edit this file when something here becomes factually wrong, or when you
 > make a qualifying structural change. Rules differ by area:
@@ -529,9 +529,12 @@ cyclic-tic-tac-toe multiplayer pattern.
  disconnect grace window; GC sweeps lobby/ended/abandoned rooms.
 - **WebSocket** — `site_src/tcg/ws.ts` (`createTcgWsEvents`). First message must be
  `join` carrying the CSRF token (`constantTimeEqual`); then `use_skill` / `use_item` /
- `end_turn` / `rematch_request` / `leave` / `ping`, each routed through the `battleCore`
- executors. Broadcasts are **per-socket viewer-aware snapshots** (hands stay private). Same
- burst rate-limit as the cyclic socket.
+ `end_turn` / `rematch_request` / `chat` / `leave` / `ping`, each routed through the `battleCore`
+ executors (except `chat` → `tcgRoomManager.postChat`). Broadcasts are **per-socket viewer-aware
+ snapshots** (hands stay private). Same burst rate-limit as the cyclic socket. `chat` is open to any
+ seated player regardless of turn; text is control-char-stripped + length-capped
+ (`TCG_CHAT_MAX_LEN`) and kept in a per-room ring buffer (`TCG_CHAT_HISTORY`) surfaced on the room
+ snapshot as `chat: TcgChatMessage[]`.
 - **Routes** — `site_src/tcg/routes.ts` (`registerTcgBattleRoutes`, wired in `server.ts`
  with `upgradeWebSocket` + `tcgRoomManager.init`): `GET /games/tcg` (landing),
  `POST /games/tcg/create`, `GET /games/tcg/:id` (room — renders the battle client for seated
@@ -543,8 +546,11 @@ cyclic-tic-tac-toe multiplayer pattern.
  HTML templates in `site_src/tcg/html/`; client JS in `site_src/tcg/assets/`). Battle client
  renders over WS: card-PNG board with live HP/energy/effect overlays, active-slot glow,
  availability-driven skill buttons with targeting, hand tray, end-turn, action log, result
- banner, rematch/leave). Decks persist via `tcg/deckStorage.ts` — the **same** `User.tcg_deck`
- the Discord `/tcgbattle deckset` uses.
+ banner, rematch/leave). The **Log/Chat panel** is a single persistent, tabbed element (built once,
+ updated in place so the chat input keeps focus across re-renders): a wide right-hand column
+ ≥920px, and a floating-launcher modal below that width (so the board + skills stay above the fold).
+ Decks persist via `tcg/deckStorage.ts` — the **same** `User.tcg_deck` the Discord
+ `/tcgbattle deckset` uses.
 
 ---
 

--- a/classes/silverwolf.ts
+++ b/classes/silverwolf.ts
@@ -197,6 +197,20 @@ All wrongs reserved.
   }
 
   async processInteraction(interaction: any): Promise<void> {
+    if (interaction.isAutocomplete && interaction.isAutocomplete()) {
+      try {
+        // Resolve to the subcommand when the top-level entry is a group.
+        let cmd = this.commands.get(interaction.commandName);
+        let sub: string | null = null;
+        try { sub = interaction.options.getSubcommand(false); } catch { sub = null; }
+        if (sub) cmd = this.commands.get(`${interaction.commandName}.${sub}`) || cmd;
+        if (cmd && typeof cmd.autocomplete === 'function') await cmd.autocomplete(interaction);
+        else await interaction.respond([]);
+      } catch (error) {
+        logError('Error processing autocomplete:', error);
+      }
+      return;
+    }
     if (interaction.isCommand()) {
       if (!interaction.guild) {
         await interaction.reply('commands can only be used in servers.');

--- a/commands/tcgbattle_deckset.ts
+++ b/commands/tcgbattle_deckset.ts
@@ -58,23 +58,14 @@ class TcgbattleDeckset extends Command {
     const previous = composition[itemId] ?? 0;
     composition[itemId] = count;
 
-    const validation = validateDeckComposition(composition);
-    if (!validation.ok) {
-      const text = formatDeckComposition(composition);
-      await interaction.editReply([
-        `Did not save: ${validation.reason}`,
-        '',
-        text,
-        '',
-        `_Tip: previous count for **${item.name}** was ${previous}._`,
-      ].join('\n').slice(0, 1900));
-      return;
-    }
-
+    // Illegal intermediate states save fine (matches the website): legality is only
+    // enforced when a battle starts, so decks can be restructured step by step.
     await saveDeckCompositionForUser(this.client.db, interaction.user.id, composition);
+    const validation = validateDeckComposition(composition);
     const text = formatDeckComposition(composition);
     await interaction.editReply([
       `Saved: **${item.name}** is now ${count}× in your deck (was ${previous}×).`,
+      ...(validation.ok ? [] : [`⚠️ Deck is currently illegal: ${validation.reason} Battles will use the default deck until it's fixed.`]),
       '',
       text,
     ].join('\n').slice(0, 1900));

--- a/commands/tcgbattle_deckset.ts
+++ b/commands/tcgbattle_deckset.ts
@@ -18,11 +18,12 @@ class TcgbattleDeckset extends Command {
   constructor(client: any) {
     super(client, 'deckset', 'Set how many copies of an item are in your deck', [
       {
+        // The catalog exceeds Discord's 25-choice cap, so use autocomplete instead.
         name: 'item',
-        description: 'Which item to adjust',
+        description: 'Which item to adjust (type to search)',
         type: 3,
         required: true,
-        choices: ITEM_DISCORD_CHOICES,
+        autocomplete: true,
       },
       {
         name: 'count',
@@ -33,6 +34,15 @@ class TcgbattleDeckset extends Command {
         max_value: PER_CARD_MAX,
       },
     ], { isSubcommandOf: 'tcgbattle', blame: 'ei', ephemeral: true });
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  async autocomplete(interaction: any): Promise<void> {
+    const focused = String(interaction.options.getFocused() || '').toLowerCase();
+    const matches = ITEM_DISCORD_CHOICES
+      .filter((c) => !focused || c.name.toLowerCase().includes(focused) || c.value.toLowerCase().includes(focused))
+      .slice(0, 25);
+    try { await interaction.respond(matches); } catch { /* interaction expired */ }
   }
 
   async run(interaction: any): Promise<void> {

--- a/database/Database.ts
+++ b/database/Database.ts
@@ -19,6 +19,7 @@ import type ServerRolesModel from './models/ServerRolesModel';
 import type BirthdayReminderModel from './models/BirthdayReminderModel';
 import type PoopModel from './models/PoopModel';
 import type WebSessionModel from './models/WebSessionModel';
+import type TcgMatchModel from './models/TcgMatchModel';
 
 class Database {
   db!: BunDatabase;
@@ -167,6 +168,12 @@ class Database {
       ON CyclicTttMatch (o_discord_id, ended_at DESC)
     `);
 
+    // Back the TCG match-history list (GET_RECENT, ordered by ended_at DESC).
+    this.db.run(`
+      CREATE INDEX IF NOT EXISTS idx_tcg_match_ended_at
+      ON TcgMatch (ended_at DESC)
+    `);
+
     // Initialize models
     Object.entries(modelClasses).forEach(([modelName, ModelClass]) => {
       this.models[modelName] = new (ModelClass as any)(this);
@@ -287,6 +294,7 @@ class Database {
   get pokemon(): PokemonModel { return this.models.PokemonModel; }
   get poop(): PoopModel { return this.models.PoopModel; }
   get serverRoles(): ServerRolesModel { return this.models.ServerRolesModel; }
+  get tcgMatch(): TcgMatchModel { return this.models.TcgMatchModel; }
   get user(): UserModel { return this.models.UserModel; }
   get webSession(): WebSessionModel { return this.models.WebSessionModel; }
 }

--- a/database/models/TcgMatchModel.ts
+++ b/database/models/TcgMatchModel.ts
@@ -1,0 +1,68 @@
+import tcgMatchQueries from '../queries/tcgMatchQueries';
+import type Database from '../Database';
+
+export interface RecordTcgMatchInput {
+  id: string;
+  mode: 'pvp' | 'solo';
+  p1DiscordId: string;
+  p1Username: string;
+  p1Team: string[];
+  p2DiscordId: string;
+  p2Username: string;
+  p2Team: string[];
+  winner: 'p1' | 'p2' | 'draw' | null;
+  endReason: string;
+  rounds: number;
+  createdAt: number;
+  endedAt: number;
+  /** JSON blob of the final board snapshot + full chat + full battle log. */
+  finalState: string | null;
+}
+
+class TcgMatchModel {
+  private db: Database;
+
+  constructor(database: Database) {
+    this.db = database;
+  }
+
+  async recordMatch(input: RecordTcgMatchInput): Promise<void> {
+    await this.db.executeQuery(
+      tcgMatchQueries.INSERT_MATCH,
+      [
+        input.id,
+        input.mode,
+        input.p1DiscordId,
+        input.p1Username,
+        JSON.stringify(input.p1Team),
+        input.p2DiscordId,
+        input.p2Username,
+        JSON.stringify(input.p2Team),
+        input.winner,
+        input.endReason,
+        input.rounds,
+        input.createdAt,
+        input.endedAt,
+        input.finalState,
+      ],
+    );
+  }
+
+  /** Most recent matches across everyone (for the public history list). */
+  async getRecent(limit = 30, offset = 0): Promise<Record<string, any>[]> {
+    return this.db.executeSelectAllQuery(tcgMatchQueries.GET_RECENT, [limit, offset]);
+  }
+
+  async getById(id: string): Promise<Record<string, any> | null> {
+    return this.db.executeSelectQuery(tcgMatchQueries.GET_BY_ID, [id]);
+  }
+
+  async getRecentForUser(discordId: string, limit = 20): Promise<Record<string, any>[]> {
+    return this.db.executeSelectAllQuery(
+      tcgMatchQueries.GET_RECENT_FOR_USER,
+      [discordId, discordId, limit],
+    );
+  }
+}
+
+export default TcgMatchModel;

--- a/database/models/TcgMatchModel.ts
+++ b/database/models/TcgMatchModel.ts
@@ -27,7 +27,9 @@ class TcgMatchModel {
   }
 
   async recordMatch(input: RecordTcgMatchInput): Promise<void> {
-    await this.db.executeQuery(
+    // executeQuery swallows SQL errors and reports changes:0, so inspect the result
+    // and throw — otherwise callers' .catch (e.g. closeRoom) never sees the failure.
+    const res = await this.db.executeQuery(
       tcgMatchQueries.INSERT_MATCH,
       [
         input.id,
@@ -46,6 +48,9 @@ class TcgMatchModel {
         input.finalState,
       ],
     );
+    if (!res || res.changes < 1) {
+      throw new Error(`TcgMatch insert affected no rows (id=${input.id}, mode=${input.mode})`);
+    }
   }
 
   /** Most recent matches across everyone (for the public history list). */

--- a/database/models/index.ts
+++ b/database/models/index.ts
@@ -10,6 +10,7 @@ import MarriageModel from './MarriageModel';
 import PokemonModel from './PokemonModel';
 import PoopModel from './PoopModel';
 import ServerRolesModel from './ServerRolesModel';
+import TcgMatchModel from './TcgMatchModel';
 import UserModel from './UserModel';
 import WebSessionModel from './WebSessionModel';
 
@@ -26,6 +27,7 @@ export {
   PokemonModel,
   PoopModel,
   ServerRolesModel,
+  TcgMatchModel,
   UserModel,
   WebSessionModel,
 };

--- a/database/queries/tcgMatchQueries.ts
+++ b/database/queries/tcgMatchQueries.ts
@@ -1,0 +1,24 @@
+const tcgMatchQueries = {
+  INSERT_MATCH: `
+    INSERT INTO TcgMatch
+      (id, mode, p1_discord_id, p1_username, p1_team,
+       p2_discord_id, p2_username, p2_team, winner, end_reason, rounds, created_at, ended_at, final_state)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `,
+  GET_BY_ID: `
+    SELECT * FROM TcgMatch WHERE id = ?
+  `,
+  GET_RECENT: `
+    SELECT * FROM TcgMatch
+    ORDER BY ended_at DESC
+    LIMIT ? OFFSET ?
+  `,
+  GET_RECENT_FOR_USER: `
+    SELECT * FROM TcgMatch
+    WHERE p1_discord_id = ? OR p2_discord_id = ?
+    ORDER BY ended_at DESC
+    LIMIT ?
+  `,
+};
+
+export default tcgMatchQueries;

--- a/database/tables/index.ts
+++ b/database/tables/index.ts
@@ -12,6 +12,7 @@ import pokemonTable from './pokemonTable';
 import poopEntryTable from './poopEntryTable';
 import poopProfileTable from './poopProfileTable';
 import serverRolesTable from './serverRolesTable';
+import tcgMatchTable from './tcgMatchTable';
 import userTable from './userTable';
 import webSessionTable from './webSessionTable';
 
@@ -30,6 +31,7 @@ export {
   poopEntryTable,
   poopProfileTable,
   serverRolesTable,
+  tcgMatchTable,
   userTable,
   webSessionTable,
 };
@@ -47,5 +49,6 @@ export type { MarriageRow } from './marriageTable';
 export type { PokemonRow } from './pokemonTable';
 export type { PoopEntryRow } from './poopEntryTable';
 export type { ServerRolesRow } from './serverRolesTable';
+export type { TcgMatchRow } from './tcgMatchTable';
 export type { UserRow, UserStatsRow } from './userTable';
 export type { WebSessionRow } from './webSessionTable';

--- a/database/tables/tcgMatchTable.ts
+++ b/database/tables/tcgMatchTable.ts
@@ -1,0 +1,44 @@
+import type { TableDefinition } from '../types';
+
+export interface TcgMatchRow {
+  id: string;
+  mode: string;
+  p1_discord_id: string;
+  p1_username: string;
+  p1_team: string; // JSON array of character slugs
+  p2_discord_id: string;
+  p2_username: string;
+  p2_team: string; // JSON array of character slugs
+  winner: string | null; // 'p1' | 'p2' | 'draw'
+  end_reason: string;
+  rounds: number;
+  created_at: number;
+  ended_at: number;
+  /** JSON: { snapshot: BattleSnapshot, chat: TcgChatMessage[], log: BattleLogEntry[] }. */
+  final_state: string | null;
+}
+
+const tcgMatchTable: TableDefinition = {
+  name: 'TcgMatch',
+  columns: [
+    { name: 'id', type: 'VARCHAR PRIMARY KEY' },
+    { name: 'mode', type: 'VARCHAR NOT NULL' },
+    { name: 'p1_discord_id', type: 'VARCHAR NOT NULL' },
+    { name: 'p1_username', type: 'VARCHAR NOT NULL' },
+    { name: 'p1_team', type: 'TEXT NOT NULL' },
+    { name: 'p2_discord_id', type: 'VARCHAR NOT NULL' },
+    { name: 'p2_username', type: 'VARCHAR NOT NULL' },
+    { name: 'p2_team', type: 'TEXT NOT NULL' },
+    { name: 'winner', type: 'VARCHAR' },
+    { name: 'end_reason', type: 'VARCHAR NOT NULL' },
+    { name: 'rounds', type: 'INTEGER NOT NULL' },
+    { name: 'created_at', type: 'INTEGER NOT NULL' },
+    { name: 'ended_at', type: 'INTEGER NOT NULL' },
+    { name: 'final_state', type: 'TEXT' },
+  ],
+  primaryKey: ['id'],
+  specialConstraints: [],
+  constraints: [],
+};
+
+export default tcgMatchTable;

--- a/database/tables/userTable.ts
+++ b/database/tables/userTable.ts
@@ -51,8 +51,10 @@ export interface UserRow {
   last_murder: string | null;
   murder_success: number;
   murder_fail: number;
-  /** JSON-encoded {itemId: count}; null/empty means "use default deck". */
+  /** Legacy single deck (JSON {itemId: count}); migrated into slot 1 of tcg_teams on first load. */
   tcg_deck: string | null;
+  /** JSON-encoded team slots: { active: 0..4, slots: [{team, deck}] } — see tcg/teamSlotStorage.ts. */
+  tcg_teams: string | null;
 }
 
 /** Extended row returned by GET_USER_STATS (includes computed join columns). */
@@ -121,6 +123,7 @@ const userTable: TableDefinition = {
     { name: 'murder_success', type: 'INTEGER DEFAULT 0' },
     { name: 'murder_fail', type: 'INTEGER DEFAULT 0' },
     { name: 'tcg_deck', type: 'TEXT DEFAULT NULL' },
+    { name: 'tcg_teams', type: 'TEXT DEFAULT NULL' },
   ],
   primaryKey: ['id'],
   specialConstraints: [],

--- a/site_src/Assets/input.css
+++ b/site_src/Assets/input.css
@@ -912,6 +912,41 @@ code, pre, kbd, .font-mono {
 .tcg-room-opp { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .tcg-room-actions { display: flex; gap: 0.4rem; flex-wrap: wrap; }
 .tcg-empty { color: var(--fog-400); font-style: italic; text-align: center; font-size: 0.9rem; margin: 0.75rem 0; }
+/* ── Browse page (in-progress battles + match history) ─────────────────────── */
+.tcg-browse-actions { display: flex; justify-content: center; gap: 0.6rem; flex-wrap: wrap; }
+/* These are two distinct actions, not a tab group: kill the resting glow (which read as
+   an "active tab") and make Create a solid CTA vs Deck Builder's plain outline. */
+.tcg-browse-actions .tcg-btn { box-shadow: none; }
+.tcg-browse-actions .tcg-btn:hover { box-shadow: 0 0 14px var(--glow-bright); }
+.tcg-browse-actions .tcg-btn-primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-pale));
+  border-color: var(--accent); color: #04121a;
+}
+.tcg-browse-actions .tcg-btn-primary:hover { color: #04121a; }
+.tcg-vs { color: var(--fog-500); font-size: 0.78em; margin: 0 0.15rem; }
+.tcg-link { color: var(--accent-light); text-decoration: none; }
+.tcg-link:hover { color: #fff; text-decoration: underline; }
+.tcg-room-watch {
+  flex: 0 0 auto; font-family: 'JetBrains Mono', monospace; font-size: 0.66rem; color: var(--fog-400);
+  border: 1px solid var(--ink-600); border-radius: 999px; padding: 0.04rem 0.42rem;
+}
+/* Match-history rows (clickable → /games/tcg/match/:id) */
+.tcg-hist { gap: 0.5rem 0.7rem; text-decoration: none; color: inherit; cursor: pointer; }
+.tcg-hist-matchup { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--fog-100); }
+.tcg-hist-result { font-size: 0.78rem; }
+.tcg-hist-result.win { color: #6ee7a0; }
+.tcg-hist-result.draw { color: var(--fog-400); }
+.tcg-hist-time { flex: 0 0 auto; font-family: 'JetBrains Mono', monospace; font-size: 0.68rem; color: var(--fog-500); }
+/* Match detail page */
+.tcg-match-summary {
+  display: flex; align-items: baseline; justify-content: center; flex-wrap: wrap;
+  gap: 0.5rem 0.9rem; margin: 0 0 0.6rem; font-family: 'JetBrains Mono', monospace; font-size: 0.9rem;
+}
+.tcg-match-matchup { color: var(--fog-100); font-weight: 700; }
+.tcg-match-meta { color: var(--fog-400); font-size: 0.78rem; }
+.tcg-feed-static { max-height: 340px; }
+/* Static board (match detail): no hover/cursor affordances. */
+.tcg-arena-static .tcg-char { cursor: default; }
 .tcg-deck-summary {
   position: sticky; top: 0.5rem; z-index: 5;
   display: flex; flex-direction: column; gap: 0.6rem;

--- a/site_src/Assets/input.css
+++ b/site_src/Assets/input.css
@@ -1435,7 +1435,7 @@ code, pre, kbd, .font-mono {
   font-family: 'JetBrains Mono', monospace; font-size: 0.72rem; color: var(--fog-300);
 }
 /* Chat shows as a plain "name: message" line in the feed (not a bubble). */
-.tcg-chat-line { line-height: 1.4; margin: 0.06rem 0; word-break: break-word; overflow-wrap: anywhere; }
+.tcg-chat-line { line-height: 1.4; margin: 0.06rem 0; overflow-wrap: anywhere; }
 .tcg-chat-author { font-weight: 800; color: var(--accent-light); }
 .tcg-chat-line.me .tcg-chat-author { color: #6ee7a0; }
 .tcg-chat-text { color: var(--fog-100); }

--- a/site_src/Assets/input.css
+++ b/site_src/Assets/input.css
@@ -1404,6 +1404,24 @@ code, pre, kbd, .font-mono {
 .tcg-chat-author { font-weight: 800; color: var(--accent-light); }
 .tcg-chat-line.me .tcg-chat-author { color: #6ee7a0; }
 .tcg-chat-text { color: var(--fog-100); }
+/* Player marker before a chatter's name (spectators have none). */
+.tcg-chat-pico { margin-right: 0.22rem; color: var(--accent-light); font-size: 0.85em; }
+.tcg-chat-line.me .tcg-chat-pico { color: #6ee7a0; }
+/* System notices (spectator joined/left). */
+.tcg-feed-system {
+  margin: 0.1rem 0; text-align: center; font-style: italic; font-size: 0.68rem;
+  color: var(--fog-500); line-height: 1.4;
+}
+/* Spectator action bar + watcher count. */
+.tcg-spectate-bar { align-items: center; }
+.tcg-spectate-note {
+  display: inline-flex; align-items: center; gap: 0.4rem; color: var(--fog-300);
+  font-family: 'JetBrains Mono', monospace; font-size: 0.8rem;
+}
+.tcg-watchers {
+  font-family: 'JetBrains Mono', monospace; font-size: 0.66rem; font-weight: 700; color: var(--fog-300);
+  border: 1px solid var(--ink-600); border-radius: 999px; padding: 0.05rem 0.45rem;
+}
 .tcg-chat-composer { display: flex; gap: 0.4rem; }
 .tcg-chat-input {
   flex: 1 1 auto; min-width: 0; padding: 0.45rem 0.65rem; font: inherit; font-size: 0.82rem;

--- a/site_src/Assets/input.css
+++ b/site_src/Assets/input.css
@@ -912,6 +912,29 @@ code, pre, kbd, .font-mono {
 .tcg-room-opp { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .tcg-room-actions { display: flex; gap: 0.4rem; flex-wrap: wrap; }
 .tcg-empty { color: var(--fog-400); font-style: italic; text-align: center; font-size: 0.9rem; margin: 0.75rem 0; }
+/* ── Team-slot bar (create/join): five saved loadouts, one active ──────────── */
+.tcg-slotbar { display: flex; gap: 0.35rem; }
+.tcg-slotchip {
+  flex: 1; min-width: 0; padding: 0.4rem 0.3rem; cursor: pointer; font: inherit;
+  display: flex; flex-direction: column; align-items: center; gap: 0.15rem;
+  color: var(--fog-300); background: color-mix(in oklab, var(--ink-900) 50%, transparent);
+  border: 1px solid var(--ink-600); border-radius: 0.45rem;
+  transition: color 0.15s, border-color 0.15s, background 0.15s, box-shadow 0.15s;
+}
+.tcg-slotchip:hover { color: var(--fog-100); }
+.tcg-slotchip[disabled] { opacity: 0.6; cursor: wait; }
+.tcg-slotchip.active {
+  color: var(--accent-light); border-color: var(--accent);
+  background: color-mix(in oklab, var(--accent) 13%, transparent); box-shadow: 0 0 8px var(--glow-faint);
+}
+.tcg-slotchip .sc-name { font-size: 0.74rem; font-weight: 700; }
+/* Readiness lines: lineup (x/3) and deck (y/25). Green = battle-ready, red = not. */
+.tcg-slotchip .sc-count, .tcg-slotchip .sc-deck {
+  font-family: 'JetBrains Mono', monospace; font-size: 0.6rem; color: var(--fog-500);
+}
+.tcg-slotchip .sc-count.good, .tcg-slotchip .sc-deck.good { color: #4ade80; }
+.tcg-slotchip .sc-count.bad, .tcg-slotchip .sc-deck.bad { color: var(--danger); }
+.tcg-slotbar-err { font-family: 'JetBrains Mono', monospace; font-size: 0.7rem; color: var(--danger); }
 /* ── Browse page (in-progress battles + match history) ─────────────────────── */
 .tcg-browse-actions { display: flex; justify-content: center; gap: 0.6rem; flex-wrap: wrap; }
 /* These are two distinct actions, not a tab group: kill the resting glow (which read as
@@ -967,6 +990,11 @@ code, pre, kbd, .font-mono {
 .tcg-deck-msg { text-align: right; min-height: 1.1rem; font-family: 'JetBrains Mono', monospace; font-size: 0.8rem; color: var(--fog-300); }
 .tcg-deck-msg.err { color: var(--danger); }
 .tcg-deck-msg.ok { color: #4ade80; }
+/* Auto-sync indicator (deck edits save on change — no save button). */
+.tcg-deck-sync { font-family: 'JetBrains Mono', monospace; font-size: 0.72rem; color: var(--fog-400); min-width: 5.5rem; text-align: right; }
+.tcg-deck-sync.busy { color: var(--fog-300); }
+.tcg-deck-sync.ok { color: #4ade80; }
+.tcg-deck-sync.err { color: var(--danger); }
 /* Deck builder filter toolbar */
 .tcg-deck-toolbar { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem 0.7rem; padding: 0 0.1rem; }
 .tcg-chips { display: inline-flex; gap: 0.3rem; flex-wrap: wrap; }

--- a/site_src/Assets/input.css
+++ b/site_src/Assets/input.css
@@ -743,7 +743,15 @@ code, pre, kbd, .font-mono {
   background: linear-gradient(90deg, transparent, var(--accent), var(--accent-pale), transparent);
 }
 .tcg-wrap { max-width: 760px; margin: 1.5rem auto 0; display: flex; flex-direction: column; gap: 1.25rem; }
-.tcg-room-wrap { max-width: 1080px; margin: 1.25rem auto 0; display: flex; flex-direction: column; gap: 1rem; }
+/* Compact battle-room header: title + match id on one tight line to save vertical
+   space (so the board + skills fit with less scrolling). */
+.tcg-room-header {
+  max-width: 1340px; margin: 1rem auto 0; display: flex; align-items: baseline;
+  justify-content: center; gap: 0.7rem; flex-wrap: wrap;
+}
+.tcg-room-title { margin: 0; font-size: 1.5rem; }
+.tcg-room-match { font-size: 0.8rem; font-family: 'JetBrains Mono', monospace; }
+.tcg-room-wrap { max-width: 1340px; margin: 0.6rem auto 0; display: flex; flex-direction: column; gap: 1rem; }
 .tcg-deck-wrap { max-width: 1100px; margin: 1.25rem auto 0; display: flex; flex-direction: column; gap: 1rem; }
 .tcg-panel {
   background: color-mix(in oklab, var(--ink-800) 50%, transparent);
@@ -1065,8 +1073,8 @@ code, pre, kbd, .font-mono {
 .tcg-timer.urgent .tcg-timer-ring { background: conic-gradient(var(--danger) calc(var(--pct) * 1%), color-mix(in oklab, var(--ink-600) 80%, transparent) 0); }
 /* ── Arena: the focal battle area (opponent top, divider, your team bottom) ── */
 .tcg-arena {
-  position: relative; display: flex; flex-direction: column; gap: 0.5rem;
-  margin: 0.5rem 0; padding: 0.9rem 0.7rem; border-radius: 0.9rem;
+  position: relative; display: flex; flex-direction: column; gap: 0.35rem;
+  margin: 0.4rem 0; padding: 0.7rem 0.6rem; border-radius: 0.9rem;
   background:
     radial-gradient(120% 60% at 50% 0%, color-mix(in oklab, var(--danger) 9%, transparent), transparent 60%),
     radial-gradient(120% 60% at 50% 100%, color-mix(in oklab, var(--accent) 11%, transparent), transparent 60%),
@@ -1085,8 +1093,9 @@ code, pre, kbd, .font-mono {
   color: var(--fog-400); padding: 0.1rem 0.55rem; border: 1px solid var(--ink-600); border-radius: 999px;
   background: color-mix(in oklab, var(--ink-900) 60%, transparent);
 }
-/* Always three across — a team is three slots, never wrap to a second row. */
-.tcg-row { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 0.6rem; align-items: start; }
+/* Always three across — a team is three slots, never wrap to a second row.
+   Capped + centred so the board stays compact (skills reachable without scrolling). */
+.tcg-row { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 0.55rem; align-items: start; max-width: 540px; margin: 0 auto; width: 100%; }
 .tcg-side { display: flex; flex-direction: column; gap: 0.35rem; }
 .tcg-side-label {
   display: flex; align-items: center; gap: 0.45rem; font-family: 'JetBrains Mono', monospace;
@@ -1141,7 +1150,7 @@ code, pre, kbd, .font-mono {
 .tcg-char.lunge-down { animation: tcg-lunge-down 0.5s cubic-bezier(0.3, 0.8, 0.3, 1); z-index: 6; }
 .tcg-char.hit { animation: tcg-shake 0.42s cubic-bezier(0.36, 0.07, 0.19, 0.97); }
 
-.tcg-char-art { position: relative; aspect-ratio: 4 / 5; background: var(--ink-900); overflow: hidden; }
+.tcg-char-art { position: relative; aspect-ratio: 1 / 1.1; background: var(--ink-900); overflow: hidden; }
 .tcg-char-art .art { width: 100%; height: 100%; object-fit: cover; object-position: top center; display: block; }
 .tcg-active-tag {
   position: absolute; top: 6px; left: 6px; display: none; z-index: 4;
@@ -1265,8 +1274,8 @@ code, pre, kbd, .font-mono {
 @keyframes tcg-floatnum-static { 0% { opacity: 1; } 80% { opacity: 1; } 100% { opacity: 0; } }
 /* ── Controls dock (skills · hand · actions) below the arena ─────────────── */
 .tcg-dock {
-  display: flex; flex-direction: column; gap: 0.7rem; margin-top: 0.5rem;
-  padding: 0.7rem 0.8rem; border-radius: 0.75rem;
+  display: flex; flex-direction: column; gap: 0.5rem; margin-top: 0.4rem;
+  padding: 0.6rem 0.7rem; border-radius: 0.75rem;
   background: color-mix(in oklab, var(--ink-900) 40%, transparent);
   border: 1px solid color-mix(in oklab, var(--accent) 12%, var(--ink-600));
 }
@@ -1313,7 +1322,7 @@ code, pre, kbd, .font-mono {
 .tcg-skill .sk-reason { font-size: 0.6rem; color: var(--danger); font-style: italic; }
 .tcg-hand { display: flex; gap: 0.45rem; flex-wrap: wrap; justify-content: center; }
 .tcg-hand-card {
-  width: 84px; border-radius: 0.4rem; overflow: hidden; border: 1px solid var(--ink-600);
+  width: 66px; border-radius: 0.4rem; overflow: hidden; border: 1px solid var(--ink-600);
   background: var(--ink-900); cursor: pointer; position: relative; flex: 0 0 auto;
   transition: border-color 0.15s, box-shadow 0.15s, transform 0.1s;
 }
@@ -1333,6 +1342,7 @@ code, pre, kbd, .font-mono {
 .tcg-btn-end { box-shadow: 0 0 10px var(--glow-faint); }
 .tcg-btn-end:not([disabled]) { animation: tcg-ult-glow 2.4s ease-in-out infinite; }
 .tcg-log { max-height: 240px; overflow-y: auto; display: flex; flex-direction: column-reverse; gap: 0.08rem; font-family: 'JetBrains Mono', monospace; font-size: 0.72rem; color: var(--fog-300); }
+.tcg-side-empty { color: var(--fog-500); font-style: italic; font-size: 0.78rem; text-align: center; padding: 0.6rem 0; }
 .tcg-log-line { line-height: 1.4; }
 .tcg-log-turn {
   font-weight: 800; color: var(--accent-light); text-transform: uppercase; letter-spacing: 0.05em;
@@ -1349,14 +1359,92 @@ code, pre, kbd, .font-mono {
 /* Hoverable reference (effect/ability/item/skill name) — native title shows its description. */
 .tcg-log-ref { text-decoration: underline dotted; text-underline-offset: 2px; cursor: help; }
 .tcg-log-ref:hover { text-decoration-style: solid; }
-/* Wide screens: battle view on the left, battle log as a sticky right-hand column.
-   Below the breakpoint, .tcg-room-wrap's column layout keeps the log stacked underneath. */
+/* Wide screens: battle view on the left, a wide Log+Chat panel as a sticky right
+   column. Below the breakpoint the panel is hidden inline and opens as a modal
+   instead (driven by the floating launcher button) — see .tcg-logmodal. */
 @media (min-width: 920px) {
   #tcg-root { flex-direction: row; align-items: flex-start; }
   #tcg-root > #tcg-view { flex: 1 1 auto; min-width: 0; }
-  #tcg-root > .tcg-log-panel { flex: 0 0 clamp(280px, 27%, 360px); position: sticky; top: 0.5rem; }
-  #tcg-root > .tcg-log-panel .tcg-log { max-height: 72vh; }
+  #tcg-root > .tcg-side-panel {
+    flex: 0 0 clamp(360px, 34%, 480px); position: sticky; top: 0.5rem;
+    display: flex; flex-direction: column; max-height: calc(100vh - 1rem);
+  }
+  #tcg-root > .tcg-side-panel .tcg-feed { max-height: none; flex: 1 1 auto; }
 }
+
+/* ── Combined Log + Chat side panel (feed, composer, narrow modal + launcher) ── */
+.tcg-side-panel { padding: 0.75rem 0.85rem; display: flex; flex-direction: column; gap: 0.55rem; min-height: 0; }
+.tcg-side-head { display: flex; align-items: center; gap: 0.5rem; }
+.tcg-side-title {
+  flex: 1 1 auto; font-family: 'JetBrains Mono', monospace; font-size: 0.7rem; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.1em; color: var(--fog-400);
+}
+.tcg-tab-badge {
+  min-width: 1.05rem; height: 1.05rem; padding: 0 0.28rem; border-radius: 999px;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-family: 'JetBrains Mono', monospace; font-size: 0.58rem; font-weight: 800; line-height: 1;
+  color: #1a0410; background: var(--accent-light); box-shadow: 0 0 8px var(--glow-bright);
+}
+.tcg-side-close {
+  flex: 0 0 auto; width: 1.7rem; height: 1.7rem; display: none; align-items: center; justify-content: center;
+  background: transparent; border: 1px solid var(--ink-600); border-radius: 4px;
+  color: var(--fog-300); cursor: pointer; font: inherit; font-size: 0.85rem;
+}
+.tcg-side-close:hover { color: #fff; border-color: var(--accent); }
+.tcg-side-panel.in-modal .tcg-side-close { display: inline-flex; }
+
+/* The feed: action-log entries + chat bubbles interleaved, newest at the bottom. */
+.tcg-feed {
+  flex: 1 1 auto; overflow-y: auto; display: flex; flex-direction: column; gap: 0.18rem;
+  max-height: 300px; min-height: 0;
+  font-family: 'JetBrains Mono', monospace; font-size: 0.72rem; color: var(--fog-300);
+}
+/* Chat shows as a plain "name: message" line in the feed (not a bubble). */
+.tcg-chat-line { line-height: 1.4; margin: 0.06rem 0; word-break: break-word; overflow-wrap: anywhere; }
+.tcg-chat-author { font-weight: 800; color: var(--accent-light); }
+.tcg-chat-line.me .tcg-chat-author { color: #6ee7a0; }
+.tcg-chat-text { color: var(--fog-100); }
+.tcg-chat-composer { display: flex; gap: 0.4rem; }
+.tcg-chat-input {
+  flex: 1 1 auto; min-width: 0; padding: 0.45rem 0.65rem; font: inherit; font-size: 0.82rem;
+  background: var(--ink-900); color: var(--fog-100); border: 1px solid var(--ink-600); border-radius: 0.45rem;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.tcg-chat-input:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--glow-faint); }
+.tcg-chat-input::placeholder { color: var(--fog-500); }
+.tcg-chat-send {
+  flex: 0 0 auto; width: 2.4rem; border-radius: 0.45rem; cursor: pointer; font-size: 0.9rem;
+  background: color-mix(in oklab, var(--accent) 14%, transparent); border: 1px solid var(--accent);
+  color: var(--accent-light); transition: color 0.15s, box-shadow 0.15s;
+}
+.tcg-chat-send:hover { color: #fff; box-shadow: 0 0 12px var(--glow-bright); }
+
+/* Floating launcher (narrow screens only — JS toggles display). */
+.tcg-log-launch {
+  position: fixed; right: 1rem; bottom: 1rem; z-index: 8500; display: none;
+  align-items: center; gap: 0.4rem; padding: 0.6rem 0.95rem; border-radius: 999px; cursor: pointer;
+  font: inherit; font-family: 'JetBrains Mono', monospace; font-size: 0.78rem; font-weight: 700;
+  color: var(--accent-light); background: color-mix(in oklab, var(--ink-800) 92%, transparent);
+  border: 1px solid var(--accent); box-shadow: 0 6px 20px rgba(0,0,0,0.5), 0 0 14px var(--glow-faint);
+}
+.tcg-log-launch .ll-ico { font-size: 1rem; }
+.tcg-log-launch:hover { color: #fff; box-shadow: 0 6px 22px rgba(0,0,0,0.55), 0 0 18px var(--glow-bright); }
+@media (min-width: 920px) { .tcg-log-launch { display: none !important; } }
+
+/* Narrow-screen modal wrapping the side panel. */
+.tcg-logmodal {
+  position: fixed; inset: 0; z-index: 9000; display: none;
+  align-items: flex-end; justify-content: center;
+  background: rgba(0,0,0,0.6); backdrop-filter: blur(5px); -webkit-backdrop-filter: blur(5px);
+  padding: 0; overflow: hidden;
+}
+.tcg-logmodal.open { display: flex; }
+.tcg-logmodal-body { width: 100%; max-height: 82vh; display: flex; }
+.tcg-logmodal-body .tcg-side-panel {
+  width: 100%; border-radius: 0.9rem 0.9rem 0 0; max-height: 82vh;
+}
+.tcg-logmodal-body .tcg-feed { max-height: none; flex: 1 1 auto; }
+@media (min-width: 920px) { .tcg-logmodal { display: none !important; } }
 .tcg-section-title { display: flex; align-items: center; font-size: 0.66rem; text-transform: uppercase; letter-spacing: 0.12em; color: var(--fog-400); margin: 0 0 0.3rem; font-family: 'JetBrains Mono', monospace; }
 .tcg-invite { display: flex; flex-direction: column; gap: 0.5rem; align-items: center; }
 .tcg-invite-url { font-family: 'JetBrains Mono', monospace; font-size: 0.78rem; color: var(--fog-200); background: var(--ink-900); border: 1px solid var(--ink-600); border-radius: 0.4rem; padding: 0.4rem 0.6rem; max-width: 100%; overflow-x: auto; white-space: nowrap; }

--- a/site_src/Assets/input.css
+++ b/site_src/Assets/input.css
@@ -1404,9 +1404,8 @@ code, pre, kbd, .font-mono {
 .tcg-chat-author { font-weight: 800; color: var(--accent-light); }
 .tcg-chat-line.me .tcg-chat-author { color: #6ee7a0; }
 .tcg-chat-text { color: var(--fog-100); }
-/* Player marker before a chatter's name (spectators have none). */
-.tcg-chat-pico { margin-right: 0.22rem; color: var(--accent-light); font-size: 0.85em; }
-.tcg-chat-line.me .tcg-chat-pico { color: #6ee7a0; }
+/* Name icons (★ dev, ⚔ player) inherit the name's colour. */
+.tcg-chat-pico { margin-right: 0.18rem; color: inherit; font-size: 0.85em; }
 /* System notices (spectator joined/left). */
 .tcg-feed-system {
   margin: 0.1rem 0; text-align: center; font-style: italic; font-size: 0.68rem;

--- a/site_src/tcg/assets/tcg-battle-room.src.js
+++ b/site_src/tcg/assets/tcg-battle-room.src.js
@@ -880,9 +880,9 @@ function chatMsgEl(m) {
     return el('div', { class: 'tcg-feed-system' }, m.text);
   }
   const mine = chatIsMine(m);
-  // A plain "name: message" line. Players get a small icon before their name;
-  // spectators don't — that's how you tell who's actually in the match.
+  // Name icons (independent): ⭐ dev, ⚔ player.
   const author = el('span', { class: 'tcg-chat-author' });
+  if (m.isDev) author.appendChild(el('span', { class: 'tcg-chat-pico dev', title: 'Developer' }, '★'));
   if (m.isPlayer) author.appendChild(el('span', { class: 'tcg-chat-pico', title: 'Player' }, '⚔'));
   author.appendChild(document.createTextNode(m.username + ': '));
   return el('div', { class: 'tcg-chat-line' + (mine ? ' me' : '') }, [

--- a/site_src/tcg/assets/tcg-battle-room.src.js
+++ b/site_src/tcg/assets/tcg-battle-room.src.js
@@ -145,7 +145,7 @@ function ingest(room) {
     if (m.id <= lastFeedChatId) continue;
     feed.push({ kind: 'chat', m });
     lastFeedChatId = m.id;
-    if (!visible && !chatIsMine(m)) chatUnread += 1;
+    if (!visible && m.kind === 'chat' && !chatIsMine(m)) chatUnread += 1;
   }
   if (visible) chatUnread = 0;
   if (feed.length > 250) feed.splice(0, feed.length - 250);
@@ -153,9 +153,13 @@ function ingest(room) {
   if (!myTurn()) { armedSkill = null; armedItem = null; }
 }
 
+function isSpectator() { return !!(state && state.spectator); }
+// For spectators `yourSide` is just the layout side (p1 at the bottom); it does NOT
+// mean the viewer owns that side, so myTurn()/"you" checks must exclude spectators.
 function mySide() { return state ? state.yourSide : null; }
 function oppSide() { const s = mySide(); return s === 'p1' ? 'p2' : 'p1'; }
 function myTurn() {
+  if (isSpectator()) return false;
   const b = state && state.battle;
   return !!(b && state.status === 'active' && mySide() && b.currentPlayer === mySide());
 }
@@ -212,6 +216,10 @@ function hudCenter() {
   if (st) center.appendChild(st);
   const t = timerLine();
   if (t) center.appendChild(t);
+  const watching = state.spectatorCount || 0;
+  if (watching > 0) {
+    center.appendChild(el('span', { class: 'tcg-watchers', title: watching + ' watching' }, '👁 ' + watching));
+  }
   return center;
 }
 
@@ -510,7 +518,7 @@ function buildBoard() {
     const turn = el('span', { class: 'tcg-side-turn' }, '');
     const label = el('div', { class: 'tcg-side-label' }, [
       el('span', { class: 'tcg-side-dot' }),
-      el('span', null, side === mySide() ? 'Your team' : oppLabel()),
+      el('span', null, isSpectator() ? sideName(side) : (side === mySide() ? 'Your team' : oppLabel())),
       turn,
     ]);
     sideLabels[side] = { label, turn };
@@ -545,7 +553,7 @@ function updateBoard() {
     if (lab) {
       const acting = state.status === 'active' && b.currentPlayer === side;
       lab.label.classList.toggle('acting', acting);
-      lab.turn.textContent = acting ? (side === mySide() ? 'your turn' : 'their turn') : '';
+      lab.turn.textContent = acting ? (isSpectator() ? 'turn' : (side === mySide() ? 'your turn' : 'their turn')) : '';
     }
     const team = b.teams[side] || [];
     const nodes = boardCards[side] || [];
@@ -710,10 +718,24 @@ function actionBar() {
   return bar;
 }
 
+// Spectators have no actions — just a "watching" note + a way to leave.
+function spectatorBar() {
+  const bar = el('div', { class: 'tcg-actionbar tcg-spectate-bar' });
+  bar.appendChild(el('span', { class: 'tcg-spectate-note' }, [
+    el('span', { class: 'ab-ico' }, '👁'),
+    el('span', null, 'Spectating — you can chat but not play.'),
+  ]));
+  const leave = el('button', { type: 'button', class: 'tcg-btn danger' }, [el('span', { class: 'ab-ico' }, '✕'), el('span', null, 'Leave')]);
+  leave.addEventListener('click', () => { send({ type: 'leave' }); setTimeout(() => { window.location.href = '/games/tcg'; }, 200); });
+  bar.appendChild(leave);
+  return bar;
+}
+
 function statusLine() {
   const b = state.battle;
   if (state.status === 'lobby') return el('div', { class: 'tcg-status' }, state.mode === 'pvp' ? 'Waiting for an opponent to join…' : 'Setting up…');
   if (state.status === 'active') {
+    if (isSpectator()) return el('div', { class: 'tcg-status' }, sideName(b.currentPlayer) + '’s turn…');
     if (myTurn()) return el('div', { class: 'tcg-status you' }, 'Your turn');
     const opp = state.players[oppSide()];
     if (opp && !opp.connected) return el('div', { class: 'tcg-status warn' }, 'Opponent reconnecting…');
@@ -722,6 +744,7 @@ function statusLine() {
   if (state.status === 'ended') {
     const r = state.result || {};
     if (r.winner === 'draw' || r.winner == null) return el('div', { class: 'tcg-status draw' }, r.winner === 'draw' ? 'Draw!' : 'Battle ended');
+    if (isSpectator()) return el('div', { class: 'tcg-status win' }, sideName(r.winner) + ' wins');
     const won = r.winner === mySide();
     const tail = r.reason === 'timeout' ? ' (timeout)' : r.reason === 'disconnect' ? ' (disconnect)' : r.reason === 'forfeit' ? ' (forfeit)' : '';
     if (state.mode === 'solo') return el('div', { class: 'tcg-status win' }, formatBattleSide(r.winner) + ' wins' + tail);
@@ -818,12 +841,8 @@ let launcherBadge = null;
 let modalEl = null;      // backdrop (narrow)
 let modalBodyEl = null;
 
-// In solo one user drives both sides (mySide() flips per turn), so every message is
-// the viewer's own. In pvp, "mine" is the stable seated side.
 function chatIsMine(m) {
-  if (!state) return false;
-  if (state.mode === 'solo') return true;
-  return m.side === mySide();
+  return !!(m && m.senderId && CTX.selfId && m.senderId === CTX.selfId);
 }
 
 function sendChat() {
@@ -856,10 +875,18 @@ function buildSidePanel() {
 }
 
 function chatMsgEl(m) {
+  // System notices (spectator joined/left) render as a muted, italic feed line.
+  if (m.kind === 'system') {
+    return el('div', { class: 'tcg-feed-system' }, m.text);
+  }
   const mine = chatIsMine(m);
-  // A plain "name: message" line (not a bubble), styled like the rest of the feed.
+  // A plain "name: message" line. Players get a small icon before their name;
+  // spectators don't — that's how you tell who's actually in the match.
+  const author = el('span', { class: 'tcg-chat-author' });
+  if (m.isPlayer) author.appendChild(el('span', { class: 'tcg-chat-pico', title: 'Player' }, '⚔'));
+  author.appendChild(document.createTextNode(m.username + ': '));
   return el('div', { class: 'tcg-chat-line' + (mine ? ' me' : '') }, [
-    el('span', { class: 'tcg-chat-author' }, m.username + ': '),
+    author,
     el('span', { class: 'tcg-chat-text' }, m.text),
   ]);
 }
@@ -956,6 +983,13 @@ function oppLabel() {
   return opp && opp.username ? '@' + opp.username : 'Opponent';
 }
 
+// Display name for a side (spectator board labels): the seated player's username,
+// falling back to "Player 1"/"Player 2".
+function sideName(side) {
+  const p = state.players && state.players[side];
+  return p && p.username ? '@' + p.username : formatBattleSide(side);
+}
+
 function targetingBanner() {
   if (!myTurn()) return null;
   let ally = false;
@@ -1015,7 +1049,9 @@ function render() {
     viewEl.appendChild(boardEl);
     updateBoard();
 
-    if (state.status === 'active') {
+    if (isSpectator()) {
+      viewEl.appendChild(spectatorBar());
+    } else if (state.status === 'active') {
       const dock = el('div', { class: 'tcg-dock' });
       const sp = skillPanel(); if (sp) dock.appendChild(sp);
       dock.appendChild(handTray());

--- a/site_src/tcg/assets/tcg-battle-room.src.js
+++ b/site_src/tcg/assets/tcg-battle-room.src.js
@@ -15,6 +15,9 @@ import { formatBattleSide, formatSkillCategory } from './tcg-labels.lib.js';
   const MAX_EQUIP = 3;
   const TURN_TIMER_MS = 90000; // mirrors server TCG_TURN_TIMER_MS (for the timer ring)
   const reduceMotion = () => window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  // Wide layout breakpoint (mirrors the CSS @media min-width:920px). Above it the
+  // Log/Chat panel sits inline as a right column; below it, it opens as a modal.
+  const mq = window.matchMedia('(min-width: 920px)');
   // Floating damage-number tint per element (lowercased Element name, as it appears in the
   // log: "X took N <element> damage"). Unknown/absent element → default .dmg red via CSS.
   const ELEMENT_COLORS = {
@@ -42,8 +45,17 @@ let serverError = null;
 let countdownTimer = null;
 let armedSkill = null;              // { slot, index, targetKind }
 let armedItem = null;               // hand slotId
-const logLines = [];
 let lastLogSig = '';
+// Combined Log + Chat panel: one chronological feed of action-log entries and chat
+// messages, appended in arrival order. Entries: { kind:'log', e } | { kind:'chat', m }.
+const feed = [];
+// Seed with existing chat history from the initial snapshot (counts as already-seen).
+let lastFeedChatId = 0;
+if (CTX.initial && Array.isArray(CTX.initial.chat)) {
+  for (const m of CTX.initial.chat) { feed.push({ kind: 'chat', m }); lastFeedChatId = m.id; }
+}
+let chatUnread = 0;                // unread incoming chat count (narrow launcher badge)
+let logModalOpen = false;          // narrow-screen modal open?
 // Action animation hints derived from the most recent ingest.
 let newLogThisIngest = false;       // a brand-new action arrived this state update
 let pendingActorName = null;        // attacker name parsed from the action log
@@ -121,12 +133,22 @@ function ingest(room) {
     const sig = b.currentTurn + '|' + b.lastActionLog.map((e) => (e && e.text != null ? e.text : String(e))).join('␟');
     if (sig !== lastLogSig) {
       lastLogSig = sig;
-      for (const e of b.lastActionLog) logLines.push(e);
-      if (logLines.length > 200) logLines.splice(0, logLines.length - 200);
+      for (const e of b.lastActionLog) feed.push({ kind: 'log', e });
       newLogThisIngest = true;
       pendingActorName = parseActor(b.lastActionLog);
     }
   }
+  // Append any new chat messages to the same feed; badge unread while not visible.
+  const visible = mq.matches || logModalOpen;
+  const chat = Array.isArray(room.chat) ? room.chat : [];
+  for (const m of chat) {
+    if (m.id <= lastFeedChatId) continue;
+    feed.push({ kind: 'chat', m });
+    lastFeedChatId = m.id;
+    if (!visible && !chatIsMine(m)) chatUnread += 1;
+  }
+  if (visible) chatUnread = 0;
+  if (feed.length > 250) feed.splice(0, feed.length - 250);
   // Reset stale selections if it's not actionable.
   if (!myTurn()) { armedSkill = null; armedItem = null; }
 }
@@ -783,16 +805,146 @@ function logLineEl(e) {
   return div;
 }
 
-function logPanel() {
-  if (logLines.length === 0) return null;
-  const panel = el('div', { class: 'tcg-panel tcg-log-panel' });
-  panel.appendChild(el('p', { class: 'tcg-section-title' }, 'Battle Log'));
-  const logEl = el('div', { class: 'tcg-log' });
-  // column-reverse keeps newest pinned at the bottom; iterate newest→oldest so the
-  // DOM order reads chronologically top→bottom. Each line is styled by its kind.
-  for (let i = logLines.length - 1; i >= 0; i--) logEl.appendChild(logLineEl(logLines[i]));
-  panel.appendChild(logEl);
-  return panel;
+// ── Side panel: Battle Log + Chat ─────────────────────────────────────────
+// Built once and updated in place (like the board) so the chat input keeps focus
+// and typed text across the frequent state-driven re-renders. On wide screens it
+// docks as a right-hand column; on narrow screens it lives inside a modal opened
+// from a floating launcher button.
+const side = {
+  panel: null, feedBox: null, chatInput: null, modalClose: null,
+};
+let launcherEl = null;   // floating button (narrow)
+let launcherBadge = null;
+let modalEl = null;      // backdrop (narrow)
+let modalBodyEl = null;
+
+// In solo one user drives both sides (mySide() flips per turn), so every message is
+// the viewer's own. In pvp, "mine" is the stable seated side.
+function chatIsMine(m) {
+  if (!state) return false;
+  if (state.mode === 'solo') return true;
+  return m.side === mySide();
+}
+
+function sendChat() {
+  if (!side.chatInput) return;
+  const text = side.chatInput.value.replace(/\s+/g, ' ').trim();
+  if (!text) return;
+  if (send({ type: 'chat', text })) side.chatInput.value = '';
+  try { side.chatInput.focus(); } catch (e) { /* */ }
+}
+
+function buildSidePanel() {
+  const title = el('span', { class: 'tcg-side-title' }, 'Battle Log & Chat');
+  side.modalClose = el('button', { type: 'button', class: 'tcg-side-close', title: 'Close' }, '✕');
+  side.modalClose.addEventListener('click', closeLogModal);
+  const head = el('div', { class: 'tcg-side-head' }, [title, side.modalClose]);
+
+  // One combined chronological feed: action-log entries and chat messages interleaved.
+  side.feedBox = el('div', { class: 'tcg-feed' });
+
+  side.chatInput = el('input', {
+    type: 'text', class: 'tcg-chat-input', maxlength: '300',
+    placeholder: 'Message opponent…', autocomplete: 'off',
+  });
+  side.chatInput.addEventListener('keydown', (ev) => { if (ev.key === 'Enter') { ev.preventDefault(); sendChat(); } });
+  const sendBtn = el('button', { type: 'button', class: 'tcg-chat-send', title: 'Send' }, '➤');
+  sendBtn.addEventListener('click', sendChat);
+  const composer = el('div', { class: 'tcg-chat-composer' }, [side.chatInput, sendBtn]);
+
+  side.panel = el('div', { class: 'tcg-panel tcg-side-panel' }, [head, side.feedBox, composer]);
+}
+
+function chatMsgEl(m) {
+  const mine = chatIsMine(m);
+  // A plain "name: message" line (not a bubble), styled like the rest of the feed.
+  return el('div', { class: 'tcg-chat-line' + (mine ? ' me' : '') }, [
+    el('span', { class: 'tcg-chat-author' }, m.username + ': '),
+    el('span', { class: 'tcg-chat-text' }, m.text),
+  ]);
+}
+
+function renderFeedInto(box) {
+  // Preserve the "stick to bottom" behaviour unless the user has scrolled up to read.
+  const nearBottom = box.scrollHeight - box.scrollTop - box.clientHeight < 80;
+  clear(box);
+  if (feed.length === 0) { box.appendChild(el('div', { class: 'tcg-side-empty' }, 'No activity yet — say hi!')); return; }
+  for (const item of feed) {
+    box.appendChild(item.kind === 'chat' ? chatMsgEl(item.m) : logLineEl(item.e));
+  }
+  if (nearBottom) box.scrollTop = box.scrollHeight;
+}
+
+function setBadge(node, n) {
+  if (!node) return;
+  if (n > 0) { node.textContent = n > 9 ? '9+' : String(n); node.hidden = false; }
+  else { node.hidden = true; }
+}
+
+function updateSidePanel() {
+  if (!side.panel) buildSidePanel();
+  if (side.chatInput) side.chatInput.placeholder = (state && state.mode === 'solo') ? 'Type a message…' : 'Message opponent…';
+  renderFeedInto(side.feedBox);
+  setBadge(launcherBadge, logModalOpen ? 0 : chatUnread);
+}
+
+function buildLauncherAndModal() {
+  launcherBadge = el('span', { class: 'tcg-tab-badge', hidden: true }, '');
+  launcherEl = el('button', { type: 'button', class: 'tcg-log-launch', title: 'Battle log & chat' }, [
+    el('span', { class: 'll-ico' }, '💬'),
+    el('span', { class: 'll-label' }, 'Log'),
+    launcherBadge,
+  ]);
+  launcherEl.addEventListener('click', openLogModal);
+  document.body.appendChild(launcherEl);
+
+  modalBodyEl = el('div', { class: 'tcg-logmodal-body' });
+  modalEl = el('div', { class: 'tcg-logmodal' }, [modalBodyEl]);
+  modalEl.addEventListener('click', (e) => { if (e.target === modalEl) closeLogModal(); });
+  document.body.appendChild(modalEl);
+}
+
+function openLogModal() {
+  logModalOpen = true;
+  chatUnread = 0;
+  if (modalEl) modalEl.classList.add('open');
+  updateSidePanel();
+}
+
+function closeLogModal() {
+  if (!logModalOpen) return;
+  logModalOpen = false;
+  if (modalEl) modalEl.classList.remove('open');
+  updateSidePanel();
+}
+
+// Place the (single) side panel either inline as a right column (wide) or inside
+// the modal (narrow). Called every render and on breakpoint changes.
+function syncExtras() {
+  if (!side.panel) buildSidePanel();
+  if (!launcherEl) buildLauncherAndModal();
+  const root = document.getElementById('tcg-root');
+  if (!root) return;
+  const wide = mq.matches;
+  if (wide) {
+    if (logModalOpen) closeLogModal();
+    launcherEl.style.display = 'none';
+    side.modalClose.style.display = 'none';
+    side.panel.classList.remove('in-modal');
+    if (side.panel.parentNode !== root) root.appendChild(side.panel);
+  } else {
+    launcherEl.style.display = '';
+    side.modalClose.style.display = '';
+    side.panel.classList.add('in-modal');
+    if (side.panel.parentNode !== modalBodyEl) modalBodyEl.appendChild(side.panel);
+  }
+  updateSidePanel();
+}
+
+function hideExtras() {
+  if (launcherEl) launcherEl.style.display = 'none';
+  if (logModalOpen) closeLogModal();
+  if (side.panel && side.panel.parentNode) side.panel.parentNode.removeChild(side.panel);
 }
 
 function connectingEl() {
@@ -842,15 +994,15 @@ function renderError() {
 
 function render() {
   if (countdownTimer) { clearInterval(countdownTimer); countdownTimer = null; }
-  if (wsClosedByServer && serverError) { renderError(); return; }
-  if (!state) { clear(viewEl); viewEl.appendChild(connectingEl()); return; }
+  if (wsClosedByServer && serverError) { hideExtras(); renderError(); return; }
+  if (!state) { hideExtras(); clear(viewEl); viewEl.appendChild(connectingEl()); return; }
 
   clear(viewEl);
   viewEl.appendChild(hudBar());
 
   if (state.status === 'lobby') {
     if (state.mode === 'pvp') viewEl.appendChild(inviteBlock());
-    const extra = logPanel(); attachExtra(extra);
+    syncExtras();
     return;
   }
 
@@ -876,24 +1028,19 @@ function render() {
 
   if (serverError) viewEl.appendChild(el('div', { class: 'tcg-err' }, 'Server: ' + serverError));
 
-  attachExtra(logPanel());
-}
-
-// Keep the battle log in its own panel (right column on wide screens).
-let extraPanel = null;
-function attachExtra(node) {
-  const root = document.getElementById('tcg-root');
-  if (extraPanel && extraPanel.parentNode) extraPanel.parentNode.removeChild(extraPanel);
-  extraPanel = node;
-  if (root && node) root.appendChild(node);
+  syncExtras();
 }
 
 render();
 openWS();
 
+// Re-place the Log/Chat panel when crossing the wide/narrow breakpoint.
+mq.addEventListener('change', () => { if (state) syncExtras(); });
+
 document.addEventListener('keydown', (e) => {
   if (e.key === 'Escape') {
     if (globalThis.TcgDetail && globalThis.TcgDetail.close()) return;
+    if (logModalOpen) { closeLogModal(); return; }
     armedSkill = null; armedItem = null; render();
   }
 });

--- a/site_src/tcg/assets/tcg-battle-room.src.js
+++ b/site_src/tcg/assets/tcg-battle-room.src.js
@@ -843,6 +843,7 @@ let launcherEl = null;   // floating button (narrow)
 let launcherBadge = null;
 let modalEl = null;      // backdrop (narrow)
 let modalBodyEl = null;
+let lastFocusedBeforeModal = null; // restore focus to this when the drawer closes
 
 function chatIsMine(m) {
   return !!(m && m.senderId && CTX.selfId && m.senderId === CTX.selfId);
@@ -858,7 +859,7 @@ function sendChat() {
 
 function buildSidePanel() {
   const title = el('span', { class: 'tcg-side-title' }, 'Battle Log & Chat');
-  side.modalClose = el('button', { type: 'button', class: 'tcg-side-close', title: 'Close' }, '✕');
+  side.modalClose = el('button', { type: 'button', class: 'tcg-side-close', title: 'Close', 'aria-label': 'Close log and chat' }, '✕');
   side.modalClose.addEventListener('click', closeLogModal);
   const head = el('div', { class: 'tcg-side-head' }, [title, side.modalClose]);
 
@@ -867,10 +868,10 @@ function buildSidePanel() {
 
   side.chatInput = el('input', {
     type: 'text', class: 'tcg-chat-input', maxlength: '300',
-    placeholder: 'Message opponent…', autocomplete: 'off',
+    placeholder: 'Message opponent…', autocomplete: 'off', 'aria-label': 'Message',
   });
   side.chatInput.addEventListener('keydown', (ev) => { if (ev.key === 'Enter') { ev.preventDefault(); sendChat(); } });
-  const sendBtn = el('button', { type: 'button', class: 'tcg-chat-send', title: 'Send' }, '➤');
+  const sendBtn = el('button', { type: 'button', class: 'tcg-chat-send', title: 'Send', 'aria-label': 'Send message' }, '➤');
   sendBtn.addEventListener('click', sendChat);
   const composer = el('div', { class: 'tcg-chat-composer' }, [side.chatInput, sendBtn]);
 
@@ -931,7 +932,10 @@ function buildLauncherAndModal() {
   document.body.appendChild(launcherEl);
 
   modalBodyEl = el('div', { class: 'tcg-logmodal-body' });
-  modalEl = el('div', { class: 'tcg-logmodal' }, [modalBodyEl]);
+  modalEl = el('div', {
+    class: 'tcg-logmodal', role: 'dialog', 'aria-modal': 'true',
+    'aria-label': 'Battle log and chat', 'aria-hidden': 'true',
+  }, [modalBodyEl]);
   modalEl.addEventListener('click', (e) => { if (e.target === modalEl) closeLogModal(); });
   document.body.appendChild(modalEl);
 }
@@ -939,15 +943,21 @@ function buildLauncherAndModal() {
 function openLogModal() {
   logModalOpen = true;
   chatUnread = 0;
-  if (modalEl) modalEl.classList.add('open');
+  lastFocusedBeforeModal = document.activeElement;
+  if (modalEl) { modalEl.classList.add('open'); modalEl.setAttribute('aria-hidden', 'false'); }
   updateSidePanel();
+  // Move focus into the drawer so keyboard/screen-reader users land in the chat input.
+  try { (side.chatInput || side.modalClose).focus(); } catch (e) { /* */ }
 }
 
 function closeLogModal() {
   if (!logModalOpen) return;
   logModalOpen = false;
-  if (modalEl) modalEl.classList.remove('open');
+  if (modalEl) { modalEl.classList.remove('open'); modalEl.setAttribute('aria-hidden', 'true'); }
   updateSidePanel();
+  // Restore focus to whatever opened the drawer (the launcher).
+  try { if (lastFocusedBeforeModal && lastFocusedBeforeModal.focus) lastFocusedBeforeModal.focus(); } catch (e) { /* */ }
+  lastFocusedBeforeModal = null;
 }
 
 // Place the (single) side panel either inline as a right column (wide) or inside

--- a/site_src/tcg/assets/tcg-battle-room.src.js
+++ b/site_src/tcg/assets/tcg-battle-room.src.js
@@ -45,15 +45,22 @@ let serverError = null;
 let countdownTimer = null;
 let armedSkill = null;              // { slot, index, targetKind }
 let armedItem = null;               // hand slotId
-let lastLogSig = '';
-// Combined Log + Chat panel: one chronological feed of action-log entries and chat
-// messages, appended in arrival order. Entries: { kind:'log', e } | { kind:'chat', m }.
-const feed = [];
-// Seed with existing chat history from the initial snapshot (counts as already-seen).
-let lastFeedChatId = 0;
-if (CTX.initial && Array.isArray(CTX.initial.chat)) {
-  for (const m of CTX.initial.chat) { feed.push({ kind: 'chat', m }); lastFeedChatId = m.id; }
+// The combined Log + Chat feed is server-provided (state.feed): a chronological list of
+// { kind:'log', e } | { kind:'chat', m }. We render straight from it, so a rejoining client
+// shows the full prior history and never re-accumulates or replays it.
+function feedSig(b) {
+  if (!b || !b.lastActionLog || !b.lastActionLog.length) return '';
+  return b.currentTurn + '|' + b.lastActionLog.map((e) => (e && e.text != null ? e.text : String(e))).join('␟');
 }
+function maxChatId(fd) {
+  let m = 0;
+  for (const it of (fd || [])) if (it && it.kind === 'chat' && it.m && it.m.id > m) m = it.m.id;
+  return m;
+}
+// Seed from the initial snapshot so the first live update isn't mistaken for a brand-new
+// action (which would replay the last attack's animation on load/rejoin).
+let lastLogSig = feedSig(CTX.initial && CTX.initial.battle);
+let lastProcessedChatId = maxChatId(CTX.initial && CTX.initial.feed); // existing chat = already seen
 let chatUnread = 0;                // unread incoming chat count (narrow launcher badge)
 let logModalOpen = false;          // narrow-screen modal open?
 // Action animation hints derived from the most recent ingest.
@@ -129,26 +136,22 @@ function ingest(room) {
   const b = room.battle;
   newLogThisIngest = false;
   pendingActorName = null;
-  if (b && b.lastActionLog && b.lastActionLog.length) {
-    const sig = b.currentTurn + '|' + b.lastActionLog.map((e) => (e && e.text != null ? e.text : String(e))).join('␟');
-    if (sig !== lastLogSig) {
-      lastLogSig = sig;
-      for (const e of b.lastActionLog) feed.push({ kind: 'log', e });
-      newLogThisIngest = true;
-      pendingActorName = parseActor(b.lastActionLog);
-    }
+  // A genuinely new action (vs the last one we've seen) drives the attack animation.
+  const sig = feedSig(b);
+  if (sig && sig !== lastLogSig) {
+    lastLogSig = sig;
+    newLogThisIngest = true;
+    pendingActorName = parseActor(b.lastActionLog);
   }
-  // Append any new chat messages to the same feed; badge unread while not visible.
+  // Unread chat badge: count new incoming chat in the server feed while it's not visible.
   const visible = mq.matches || logModalOpen;
-  const chat = Array.isArray(room.chat) ? room.chat : [];
-  for (const m of chat) {
-    if (m.id <= lastFeedChatId) continue;
-    feed.push({ kind: 'chat', m });
-    lastFeedChatId = m.id;
-    if (!visible && m.kind === 'chat' && !chatIsMine(m)) chatUnread += 1;
+  for (const it of (Array.isArray(room.feed) ? room.feed : [])) {
+    if (!it || it.kind !== 'chat' || !it.m || it.m.kind !== 'chat') continue;
+    if (it.m.id <= lastProcessedChatId) continue;
+    lastProcessedChatId = it.m.id;
+    if (!visible && !chatIsMine(it.m)) chatUnread += 1;
   }
   if (visible) chatUnread = 0;
-  if (feed.length > 250) feed.splice(0, feed.length - 250);
   // Reset stale selections if it's not actionable.
   if (!myTurn()) { armedSkill = null; armedItem = null; }
 }
@@ -895,8 +898,10 @@ function renderFeedInto(box) {
   // Preserve the "stick to bottom" behaviour unless the user has scrolled up to read.
   const nearBottom = box.scrollHeight - box.scrollTop - box.clientHeight < 80;
   clear(box);
-  if (feed.length === 0) { box.appendChild(el('div', { class: 'tcg-side-empty' }, 'No activity yet — say hi!')); return; }
-  for (const item of feed) {
+  const fd = (state && Array.isArray(state.feed)) ? state.feed : [];
+  if (fd.length === 0) { box.appendChild(el('div', { class: 'tcg-side-empty' }, 'No activity yet — say hi!')); return; }
+  for (const item of fd) {
+    if (!item) continue;
     box.appendChild(item.kind === 'chat' ? chatMsgEl(item.m) : logLineEl(item.e));
   }
   if (nearBottom) box.scrollTop = box.scrollHeight;

--- a/site_src/tcg/assets/tcg-deck-builder.src.js
+++ b/site_src/tcg/assets/tcg-deck-builder.src.js
@@ -18,7 +18,7 @@
   const fourEl = document.getElementById('dk-four');
   const fillEl = document.getElementById('dk-fill');
   const legalEl = document.getElementById('dk-legal');
-  const saveBtn = document.getElementById('dk-save');
+  const syncEl = document.getElementById('dk-sync');
   const msgEl = document.getElementById('dk-msg');
   const emptyEl = document.getElementById('dk-empty');
   const cardTpl = document.getElementById('tcg-tpl-deck-card');
@@ -122,6 +122,7 @@
   function bump(id, delta) {
     counts[id] = Math.max(0, Math.min(CAPS.perCard, (counts[id] || 0) + delta));
     refresh();
+    scheduleSave();
     if (filt.inDeck) applyFilters();
     if (filt.sort === 'count') applySort();
   }
@@ -182,7 +183,7 @@
       const v = validate();
       legalEl.textContent = v.ok ? 'legal' : 'illegal';
       legalEl.className = 'tcg-badge ' + (v.ok ? 'legal' : 'illegal');
-      if (saveBtn) saveBtn.toggleAttribute('disabled', !v.ok);
+      // Illegal decks sync fine (shown red; battles reject them) — nothing is blocked.
       grid.querySelectorAll('.tcg-card').forEach((card) => {
         const id = card.dataset.id;
         const n = counts[id] || 0;
@@ -197,31 +198,78 @@
     });
   }
 
-  async function save() {
-    const v = validate();
-    if (!v.ok) { msg(v.reason, 'err'); return; }
-    saveBtn.setAttribute('disabled', 'disabled');
-    msg('Saving…', '');
-    try {
-      const composition = {};
-      for (const it of ITEMS) if (counts[it.id] > 0) composition[it.id] = counts[it.id];
-      const res = await fetch('/games/tcg/deck/save', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ csrf: CSRF, composition }),
-      });
-      const data = await res.json().catch(() => ({}));
-      if (!res.ok || !data || !data.ok) {
-        msg((data && data.error) ? data.error : 'Failed to save.', 'err');
-        refresh();
-        return;
-      }
-      msg('Deck saved.', 'ok');
-    } catch (e) {
-      msg('Network error.', 'err');
-      refresh();
+  // ── Auto-sync: every change saves after a short debounce (no save button) ──
+  const SAVE_DEBOUNCE_MS = 600;
+  let saveTimer = null;
+  let inFlight = false;
+  let pendingSave = false; // changed while a save was in flight → resend after
+  let dirty = false; // unsynced local changes (drives the pagehide flush)
+  let syncClearTimer = null;
+
+  function setSync(text, cls) {
+    if (!syncEl) return;
+    if (syncClearTimer) { clearTimeout(syncClearTimer); syncClearTimer = null; }
+    syncEl.textContent = text;
+    syncEl.className = 'tcg-deck-sync' + (cls ? ' ' + cls : '');
+    if (cls === 'ok') {
+      syncClearTimer = setTimeout(() => { syncEl.textContent = ''; }, 1500);
     }
   }
+
+  function snapshot() {
+    const composition = {};
+    for (const it of ITEMS) if (counts[it.id] > 0) composition[it.id] = counts[it.id];
+    return composition;
+  }
+
+  function scheduleSave() {
+    dirty = true;
+    setSync('saving…', 'busy');
+    if (saveTimer) clearTimeout(saveTimer);
+    saveTimer = setTimeout(doSave, SAVE_DEBOUNCE_MS);
+  }
+
+  async function doSave() {
+    if (saveTimer) { clearTimeout(saveTimer); saveTimer = null; }
+    if (inFlight) { pendingSave = true; return; }
+    inFlight = true;
+    do {
+      pendingSave = false;
+      try {
+        const res = await fetch('/games/tcg/deck/save', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ csrf: CSRF, composition: snapshot() }),
+          keepalive: true,
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok || !data || !data.ok) {
+          throw new Error((data && data.error) ? data.error : 'Failed to save.');
+        }
+        if (!pendingSave) { dirty = false; setSync('saved ✓', 'ok'); msg('', ''); }
+      } catch (e) {
+        // Keep dirty so the next change (or leaving the page) retries.
+        setSync('sync failed', 'err');
+        msg(e.message + ' Your latest change isn’t saved yet — it will retry on the next edit.', 'err');
+        break;
+      }
+    } while (pendingSave);
+    inFlight = false;
+  }
+
+  // Last-ditch flush if the user leaves mid-debounce (keepalive survives unload).
+  window.addEventListener('pagehide', () => {
+    if (!dirty) return;
+    if (saveTimer) { clearTimeout(saveTimer); saveTimer = null; }
+    try {
+      fetch('/games/tcg/deck/save', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ csrf: CSRF, composition: snapshot() }),
+        keepalive: true,
+      });
+    } catch (e) { /* page is going away */ }
+  });
 
   function msg(text, kind) {
     if (!msgEl) return;
@@ -250,7 +298,6 @@
   if (sortEl) {
     sortEl.addEventListener('change', () => { filt.sort = sortEl.value; applySort(); });
   }
-  if (saveBtn) saveBtn.addEventListener('click', save);
 
   buildRarityChips();
   buildCards();

--- a/site_src/tcg/assets/tcg-join.src.js
+++ b/site_src/tcg/assets/tcg-join.src.js
@@ -1,4 +1,5 @@
 import { setupTeamPicker } from './tcg-team-picker.lib.js';
+import { setupSlotBar } from './tcg-team-slots.lib.js';
 
 (() => {
   const dataEl = document.getElementById('tcg-join-data');
@@ -8,19 +9,41 @@ import { setupTeamPicker } from './tcg-team-picker.lib.js';
 
   const CSRF = ctx.csrf || '';
   const MATCH = ctx.matchId || '';
-  const DEFAULTS = ctx.defaults || [];
-  const DECK_LEGAL = !!ctx.deckLegal;
+  const TEAM_STATE = ctx.teamState || { active: 0, slots: [] };
+  let deckLegal = !!ctx.deckLegal;
   const joinBtn = document.getElementById('tcg-join');
   const errEl = document.getElementById('tcg-join-err');
   if (!joinBtn) return;
 
-  // `let` (not `const`): setupTeamPicker calls refreshJoin synchronously via
-  // onChange during construction, so `picker` must not be in the dead zone.
+  // `let` (not `const`): setupTeamPicker calls onTeamChange synchronously via
+  // onChange during construction, so these must not be in the dead zone.
   let picker = null;
-  picker = setupTeamPicker({ defaults: DEFAULTS, onChange: refreshJoin });
+  let slotBar = null;
+  const activeTeam = (TEAM_STATE.slots[TEAM_STATE.active] || { team: [] }).team;
+  picker = setupTeamPicker({ defaults: activeTeam, onChange: onTeamChange });
+  slotBar = setupSlotBar({
+    csrf: CSRF,
+    state: TEAM_STATE,
+    picker,
+    errEl: document.getElementById('tcg-slotbar-err'),
+    onDeckLegal: (legal) => {
+      deckLegal = !!legal;
+      const badge = document.querySelector('.tcg-badge');
+      if (badge) {
+        badge.className = 'tcg-badge ' + (deckLegal ? 'legal' : 'illegal');
+        badge.textContent = deckLegal ? 'legal deck' : 'illegal deck';
+      }
+      refreshJoin();
+    },
+  });
+
+  function onTeamChange() {
+    if (slotBar && picker) slotBar.scheduleSave(picker.getTeam());
+    refreshJoin();
+  }
 
   function refreshJoin() {
-    const ok = !!picker && picker.isComplete() && DECK_LEGAL;
+    const ok = !!picker && picker.isComplete() && deckLegal;
     joinBtn.toggleAttribute('disabled', !ok);
     if (errEl && ok) errEl.textContent = '';
   }
@@ -29,14 +52,14 @@ import { setupTeamPicker } from './tcg-team-picker.lib.js';
   joinBtn.addEventListener('click', async () => {
     if (joinBtn.hasAttribute('disabled')) return;
     errEl.textContent = '';
-    const team = picker ? picker.getTeam() : [];
-    if (team.length !== 3) { errEl.textContent = 'Pick three characters.'; return; }
     joinBtn.setAttribute('disabled', 'disabled');
     try {
+      // The battle plays from the active slot server-side — flush the last edit first.
+      if (slotBar) await slotBar.flush();
       const res = await fetch('/games/tcg/' + encodeURIComponent(MATCH) + '/join', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ csrf: CSRF, team }),
+        body: JSON.stringify({ csrf: CSRF }),
       });
       const data = await res.json().catch(() => ({}));
       if (!res.ok || !data || !data.ok) {

--- a/site_src/tcg/assets/tcg-landing.src.js
+++ b/site_src/tcg/assets/tcg-landing.src.js
@@ -1,4 +1,5 @@
 import { setupTeamPicker } from './tcg-team-picker.lib.js';
+import { setupSlotBar } from './tcg-team-slots.lib.js';
 
 (() => {
   const dataEl = document.getElementById('tcg-landing-data');
@@ -7,8 +8,8 @@ import { setupTeamPicker } from './tcg-team-picker.lib.js';
   try { ctx = JSON.parse(dataEl.textContent); } catch { return; }
 
   const CSRF = ctx.csrf || '';
-  const DEFAULTS = ctx.defaults || [];
-  const DECK_LEGAL = !!ctx.deckLegal;
+  const TEAM_STATE = ctx.teamState || { active: 0, slots: [] };
+  let deckLegal = !!ctx.deckLegal; // per-slot: updated when the active slot changes
   let mode = 'pvp';
 
   const modesEl = document.getElementById('tcg-modes');
@@ -16,18 +17,42 @@ import { setupTeamPicker } from './tcg-team-picker.lib.js';
   const errEl = document.getElementById('tcg-err');
   if (!createBtn) return;
 
-  // Declared with `let` (not `const`) so refreshCreate — which setupTeamPicker
-  // invokes synchronously via onChange during construction — can read `picker`
+  // Declared with `let` (not `const`) so onTeamChange — which setupTeamPicker
+  // invokes synchronously via onChange during construction — can read them
   // without hitting the temporal dead zone.
   let picker = null;
-  picker = setupTeamPicker({ defaults: DEFAULTS, onChange: refreshCreate });
+  let slotBar = null;
+  const activeTeam = (TEAM_STATE.slots[TEAM_STATE.active] || { team: [] }).team;
+  picker = setupTeamPicker({ defaults: activeTeam, onChange: onTeamChange });
+  slotBar = setupSlotBar({
+    csrf: CSRF,
+    state: TEAM_STATE,
+    picker,
+    errEl: document.getElementById('tcg-slotbar-err'),
+    onDeckLegal: setDeckLegal,
+  });
+
+  function onTeamChange() {
+    if (slotBar && picker) slotBar.scheduleSave(picker.getTeam());
+    refreshCreate();
+  }
 
   function refreshCreate() {
-    const ok = !!picker && picker.isComplete() && DECK_LEGAL;
+    const ok = !!picker && picker.isComplete() && deckLegal;
     createBtn.toggleAttribute('disabled', !ok);
     if (errEl && ok) errEl.textContent = '';
   }
   refreshCreate();
+
+  function setDeckLegal(legal) {
+    deckLegal = !!legal;
+    const badge = document.querySelector('.tcg-badge');
+    if (badge) {
+      badge.className = 'tcg-badge ' + (deckLegal ? 'legal' : 'illegal');
+      badge.textContent = deckLegal ? 'legal deck' : 'illegal deck';
+    }
+    refreshCreate();
+  }
 
   if (modesEl) {
     modesEl.querySelectorAll('.tcg-mode').forEach((b) => {
@@ -45,14 +70,15 @@ import { setupTeamPicker } from './tcg-team-picker.lib.js';
   createBtn.addEventListener('click', async () => {
     if (createBtn.hasAttribute('disabled')) return;
     errEl.textContent = '';
-    const team = picker ? picker.getTeam() : [];
-    if (team.length !== 3) { errEl.textContent = 'Pick three characters.'; return; }
     createBtn.setAttribute('disabled', 'disabled');
     try {
+      // The battle plays from the active slot server-side — make sure the last
+      // lineup edit has landed there first.
+      if (slotBar) await slotBar.flush();
       const res = await fetch('/games/tcg/create', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ csrf: CSRF, mode, team }),
+        body: JSON.stringify({ csrf: CSRF, mode }),
       });
       const data = await res.json().catch(() => ({}));
       if (!res.ok || !data || !data.ok) {

--- a/site_src/tcg/assets/tcg-team-picker.lib.js
+++ b/site_src/tcg/assets/tcg-team-picker.lib.js
@@ -49,7 +49,8 @@ function charArtUrl(slug) {
 
 /**
  * @param {{ defaults?: string[], onChange?: (team: string[]) => void }} opts
- * @returns {{ getTeam: () => string[], isComplete: () => boolean } | null}
+ * @returns {{ getTeam: () => string[], isComplete: () => boolean,
+ *            setTeam: (values: string[]) => void } | null}
  */
 export function setupTeamPicker(opts) {
   opts = opts || {};
@@ -92,6 +93,17 @@ export function setupTeamPicker(opts) {
   function removeAt(i) {
     if (i < 0 || i >= team.length) return;
     team.splice(i, 1);
+    renderSlots();
+    renderGridState();
+    notify();
+  }
+
+  /** Replace the whole selection (e.g. loading a saved team). Unknown values are dropped. */
+  function setTeam(values) {
+    team.length = 0;
+    for (const v of (Array.isArray(values) ? values : [])) {
+      if (team.length < TEAM_SIZE && byValue[v]) team.push(v);
+    }
     renderSlots();
     renderGridState();
     notify();
@@ -242,5 +254,5 @@ export function setupTeamPicker(opts) {
   renderGridState();
   notify();
 
-  return { getTeam, isComplete };
+  return { getTeam, isComplete, setTeam };
 }

--- a/site_src/tcg/assets/tcg-team-slots.lib.js
+++ b/site_src/tcg/assets/tcg-team-slots.lib.js
@@ -1,0 +1,166 @@
+/**
+ * Team-slot bar shared by the create + join pages: five saved loadout slots
+ * (lineup + deck), one active. Battles play from the active slot server-side.
+ *
+ * Switching slots is **optimistic**: the picker swaps to the locally-known lineup
+ * instantly and the select POST settles in the background (serialized, reverting the
+ * UI to the last server-confirmed slot on failure). Lineup saves are debounced and
+ * **slot-tagged**, so a fast switch mid-edit can never write into the wrong slot.
+ * Callers must `await flush()` before create/join so the server state is settled.
+ */
+
+const SAVE_DEBOUNCE_MS = 600;
+
+/**
+ * @param {{
+ *   csrf: string,
+ *   state: { active: number, slots: { team: string[] }[] },
+ *   picker: { setTeam: (values: string[]) => void },
+ *   errEl?: HTMLElement | null,
+ *   onDeckLegal?: (legal: boolean) => void,
+ * }} opts
+ * @returns {{ scheduleSave: (team: string[]) => void, flush: () => Promise<void> } | null}
+ */
+export function setupSlotBar(opts) {
+  const bar = document.getElementById('tcg-slotbar');
+  if (!bar || !opts || !opts.picker) return null;
+
+  const csrf = opts.csrf || '';
+  const deckSize = (opts.state && opts.state.deckSize) || 25;
+  const state = {
+    active: (opts.state && opts.state.active) || 0,
+    slots: (opts.state && Array.isArray(opts.state.slots) ? opts.state.slots : [])
+      .map((s) => ({
+        team: (s && Array.isArray(s.team)) ? s.team.slice() : [],
+        deckCount: (s && typeof s.deckCount === 'number') ? s.deckCount : deckSize,
+        deckLegal: !s || s.deckLegal !== false,
+      })),
+  };
+  while (state.slots.length < 5) state.slots.push({ team: [], deckCount: deckSize, deckLegal: true });
+
+  let serverActive = state.active; // last slot the server confirmed as active
+  let selectChain = Promise.resolve(); // serializes select settles in click order
+  let saveTimer = null;
+  let pending = null; // { slot, team } — debounced lineup save
+  let applying = false; // true while we push a slot's lineup into the picker
+
+  function err(msg) { if (opts.errEl) opts.errEl.textContent = msg || ''; }
+
+  async function post(path, payload) {
+    const res = await fetch(path, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(Object.assign({ csrf }, payload)),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok || !data || !data.ok) {
+      throw new Error((data && data.error) ? data.error : 'Request failed.');
+    }
+    return data;
+  }
+
+  function applyToPicker(team) {
+    applying = true;
+    try { opts.picker.setTeam(team); } finally { applying = false; }
+  }
+
+  async function flushLineup() {
+    if (saveTimer) { clearTimeout(saveTimer); saveTimer = null; }
+    if (!pending) return;
+    const p = pending;
+    pending = null;
+    try {
+      await post('/games/tcg/teams/lineup', p);
+    } catch (e) {
+      err(e.message);
+    }
+  }
+
+  function scheduleSave(team) {
+    if (applying) return; // a slot switch is loading its lineup — not a user edit
+    err('');
+    const slot = state.active;
+    state.slots[slot].team = team.slice();
+    render();
+    // Edits for a *different* slot than the pending save: send the old one off now.
+    if (pending && pending.slot !== slot) flushLineup();
+    pending = { slot, team: team.slice() };
+    if (saveTimer) clearTimeout(saveTimer);
+    saveTimer = setTimeout(flushLineup, SAVE_DEBOUNCE_MS);
+  }
+
+  async function settleSelect(i) {
+    if (serverActive === i) return;
+    try {
+      const data = await post('/games/tcg/teams/select', { slot: i });
+      serverActive = data.active;
+      state.slots[data.active].deckLegal = !!data.deckLegal;
+      // Adopt the server's copy of the lineup unless the user already edited it here.
+      if (Array.isArray(data.team) && (!pending || pending.slot !== data.active)) {
+        state.slots[data.active].team = data.team.slice();
+        if (state.active === data.active) { applyToPicker(data.team.slice()); }
+      }
+      if (opts.onDeckLegal && state.active === data.active) opts.onDeckLegal(!!data.deckLegal);
+      render();
+    } catch (e) {
+      // Only revert if this failed click is still the latest intent.
+      if (state.active === i) {
+        state.active = serverActive;
+        applyToPicker(state.slots[serverActive].team.slice());
+        render();
+      }
+      err(e.message || 'Slot switch failed.');
+    }
+  }
+
+  function select(i) {
+    if (i === state.active) return;
+    err('');
+    // Optimistic: local copy is authoritative (edits auto-save), swap instantly.
+    state.active = i;
+    applyToPicker(state.slots[i].team.slice());
+    render();
+    selectChain = selectChain.then(() => settleSelect(i)).catch(() => {});
+  }
+
+  function render() {
+    bar.replaceChildren();
+    state.slots.forEach((slot, i) => {
+      const chip = document.createElement('button');
+      chip.type = 'button';
+      chip.className = 'tcg-slotchip' + (i === state.active ? ' active' : '');
+      chip.setAttribute('aria-pressed', i === state.active ? 'true' : 'false');
+
+      const name = document.createElement('span');
+      name.className = 'sc-name';
+      name.textContent = 'Team ' + (i + 1);
+      chip.appendChild(name);
+
+      // Lineup readiness (x/3) and deck readiness (y/25) — red = not battle-ready.
+      const count = document.createElement('span');
+      count.className = 'sc-count' + (slot.team.length === 3 ? ' good' : ' bad');
+      count.textContent = slot.team.length + '/3';
+      chip.appendChild(count);
+
+      const deck = document.createElement('span');
+      deck.className = 'sc-deck' + (slot.deckLegal ? ' good' : ' bad');
+      deck.textContent = slot.deckCount + '/' + deckSize;
+      deck.title = slot.deckLegal ? 'Deck legal' : 'Deck illegal';
+      chip.appendChild(deck);
+
+      chip.addEventListener('click', () => select(i));
+      bar.appendChild(chip);
+    });
+  }
+  render();
+
+  return {
+    scheduleSave,
+    // Battles play from the server's active slot: settle any in-flight slot switch,
+    // then persist the last lineup edit.
+    flush: async () => {
+      try { await selectChain; } catch (e) { /* handled in settleSelect */ }
+      await flushLineup();
+    },
+  };
+}

--- a/site_src/tcg/html/tcg-battle-room.html
+++ b/site_src/tcg/html/tcg-battle-room.html
@@ -1,7 +1,7 @@
-<h1 class="text-center tcg-page-title">TCG Battle</h1>
-<p class="text-center text-fog-300 tcg-page-lead">
-  Match <code class="tcg-match-id">{{MATCH_ID}}</code>
-</p>
+<div class="tcg-room-header">
+  <h1 class="tcg-page-title tcg-room-title">TCG Battle</h1>
+  <span class="text-fog-300 tcg-room-match">Match <code class="tcg-match-id">{{MATCH_ID}}</code></span>
+</div>
 <div class="tcg-room-wrap" id="tcg-root">
   <div class="tcg-panel" id="tcg-view">
     <p class="tcg-connecting">Connecting…</p>

--- a/site_src/tcg/html/tcg-browse-history.html
+++ b/site_src/tcg/html/tcg-browse-history.html
@@ -1,0 +1,10 @@
+<li>
+  <a class="tcg-room tcg-hist" href="/games/tcg/match/{{ID}}">
+    <span class="tcg-room-mode">{{MODE}}</span>
+    <div class="tcg-room-meta">
+      <span class="tcg-hist-matchup">{{MATCHUP}}</span>
+      <span class="tcg-hist-result {{RESULT_CLASS}}">{{RESULT}}</span>
+    </div>
+    <span class="tcg-hist-time">{{TIME}}</span>
+  </a>
+</li>

--- a/site_src/tcg/html/tcg-browse-room.html
+++ b/site_src/tcg/html/tcg-browse-room.html
@@ -1,0 +1,11 @@
+<li class="tcg-room">
+  <span class="tcg-room-status {{STATUS_CLASS}}"><span class="tcg-room-led"></span>{{STATUS}}</span>
+  <div class="tcg-room-meta">
+    <span class="tcg-room-mode">{{MODE}}</span>
+    <span class="tcg-room-opp">{{MATCHUP}}</span>
+    {{WATCHERS}}
+  </div>
+  <div class="tcg-room-actions">
+    <a class="tcg-btn tcg-btn-ghost" href="/games/tcg/{{ID}}">[ {{LABEL}} ]</a>
+  </div>
+</li>

--- a/site_src/tcg/html/tcg-browse.html
+++ b/site_src/tcg/html/tcg-browse.html
@@ -1,0 +1,16 @@
+<h1 class="text-center tcg-page-title">TCG Battles</h1>
+<p class="text-center text-fog-300 tcg-page-lead">Watch a live battle or start your own.</p>
+<div class="tcg-wrap tcg-browse">
+  <div class="tcg-browse-actions">
+    <a class="tcg-btn tcg-btn-primary" href="/games/tcg/create">[ Create Battle ]</a>
+    <a class="tcg-btn tcg-btn-ghost" href="/games/tcg/deck">[ Deck Builder ]</a>
+  </div>
+  <div class="tcg-panel">
+    <p class="tcg-subtitle">In Progress</p>
+    {{IN_PROGRESS}}
+  </div>
+  <div class="tcg-panel">
+    <p class="tcg-subtitle">Recent Matches</p>
+    {{HISTORY}}
+  </div>
+</div>

--- a/site_src/tcg/html/tcg-create.html
+++ b/site_src/tcg/html/tcg-create.html
@@ -1,0 +1,21 @@
+<h1 class="text-center tcg-page-title">Create a Battle</h1>
+<p class="text-center text-fog-300 tcg-page-lead"><a class="tcg-link" href="/games/tcg">&larr; all battles</a></p>
+<div class="tcg-wrap">
+  <div class="tcg-panel">
+    <p class="tcg-subtitle">New Battle</p>
+    <div class="tcg-field">
+      <label>Mode</label>
+      <div class="tcg-modes" id="tcg-modes" role="group" aria-label="Battle mode">
+        <button type="button" class="tcg-mode active" data-mode="pvp" aria-pressed="true">
+          <span class="tcg-mode-title">PvP</span>
+          <span class="tcg-mode-sub">invite a friend</span>
+        </button>
+        <button type="button" class="tcg-mode" data-mode="solo" aria-pressed="false">
+          <span class="tcg-mode-title">Solo</span>
+          <span class="tcg-mode-sub">practice vs yourself</span>
+        </button>
+      </div>
+    </div>
+    {{TEAM_PICKER}}
+  </div>
+</div>

--- a/site_src/tcg/html/tcg-deck-builder.html
+++ b/site_src/tcg/html/tcg-deck-builder.html
@@ -1,6 +1,7 @@
 <h1 class="text-center tcg-page-title">TCG Deck Builder</h1>
 <p class="text-center text-fog-300 tcg-page-lead">
-  Build a legal {{DECK_SIZE}}-card deck. It's shared with <code class="tcg-code">/tcgbattle</code> on Discord.
+  Build a legal {{DECK_SIZE}}-card deck for your active team slot — changes save automatically.
+  It's shared with <code class="tcg-code">/tcgbattle</code> on Discord.
 </p>
 <div class="tcg-deck-wrap">
   <div class="tcg-panel tcg-deck-summary" id="tcg-deck-summary">
@@ -11,9 +12,9 @@
         <span>4★+ <b id="dk-four">0</b>/{{FOUR_MAX}}</span>
       </div>
       <div class="tcg-deck-actions">
+        <span id="dk-sync" class="tcg-deck-sync" aria-live="polite"></span>
         <span id="dk-legal" class="tcg-badge">—</span>
         <a href="/games/tcg" class="tcg-btn tcg-btn-ghost">[ back ]</a>
-        <button id="dk-save" type="button" class="tcg-btn tcg-btn-primary">[ save deck ]</button>
       </div>
     </div>
     <div class="tcg-deck-fill" aria-hidden="true"><div class="tcg-deck-fill-bar" id="dk-fill"></div></div>

--- a/site_src/tcg/html/tcg-team-picker.html
+++ b/site_src/tcg/html/tcg-team-picker.html
@@ -1,5 +1,13 @@
 <div class="tcg-field">
   <div class="tcg-team-head">
+    <label>Team Slot</label>
+    <span class="tcg-slotbar-err" id="tcg-slotbar-err" aria-live="polite"></span>
+  </div>
+  <div class="tcg-slotbar" id="tcg-slotbar" role="group" aria-label="Team slots"></div>
+  <p class="tcg-roster-hint">Each slot keeps its own lineup and deck. Edits save to the active slot automatically.</p>
+</div>
+<div class="tcg-field">
+  <div class="tcg-team-head">
     <label>Your Team</label>
     <span class="tcg-team-count" id="tcg-team-count">0 / 3</span>
   </div>

--- a/site_src/tcg/pages/landing.ts
+++ b/site_src/tcg/pages/landing.ts
@@ -14,11 +14,6 @@ import {
 } from '../html';
 import { formatRoomMode } from '../labels';
 
-export interface TcgRoster {
-  value: string;
-  name: string;
-}
-
 /** One open room for the browse list (still live until everyone leaves). */
 export interface TcgBrowseRoom {
   id: string;
@@ -54,14 +49,22 @@ export interface TcgBrowseOpts {
   loginReturnPath: string;
 }
 
+/** Client-facing brief of the five team slots (lineups + deck size/legality; deck contents stay server-side). */
+export interface TcgTeamStateBrief {
+  active: number;
+  deckSize: number;
+  slots: { team: string[]; deckCount: number; deckLegal: boolean }[];
+}
+
 export interface TcgCreateOpts {
   nonce: string;
   lv999?: boolean;
   user: NavUser | null;
   csrf: string | null;
-  roster: TcgRoster[];
   characterCatalog: CharacterCatalogEntry[];
   deckLegal: boolean;
+  /** The user's team slots; the picker edits the active one in place. */
+  teamState: TcgTeamStateBrief;
   loginReturnPath: string;
 }
 
@@ -182,7 +185,7 @@ export function TcgBrowsePage(opts: TcgBrowseOpts) {
 // ── Create page (separate from browse) ──────────────────────────────────────
 export function TcgCreatePage(opts: TcgCreateOpts) {
   const {
-    nonce, lv999, user, csrf, roster, characterCatalog, deckLegal, loginReturnPath,
+    nonce, lv999, user, csrf, characterCatalog, deckLegal, teamState, loginReturnPath,
   } = opts;
   if (!user) {
     return loginPage({
@@ -190,7 +193,6 @@ export function TcgCreatePage(opts: TcgCreateOpts) {
     });
   }
 
-  const firstThree = roster.slice(0, 3).map((r) => r.value);
   const teamPicker = renderTeamPicker({
     deckLegal,
     submitId: 'tcg-create',
@@ -202,7 +204,10 @@ export function TcgCreatePage(opts: TcgCreateOpts) {
     ${renderTcgHtml('tcg-create.html', { TEAM_PICKER: teamPicker })}
     ${tcgDetailModalShell()}
     ${tcgDetailAssets(nonce, characterCatalog)}
-    ${tcgScriptAssets('tcg-landing', nonce, { id: 'tcg-landing-data', payload: { csrf: csrf ?? '', defaults: firstThree, deckLegal } })}
+    ${tcgScriptAssets('tcg-landing', nonce, {
+    id: 'tcg-landing-data',
+    payload: { csrf: csrf ?? '', deckLegal, teamState },
+  })}
   `;
 
   return Layout({

--- a/site_src/tcg/pages/landing.ts
+++ b/site_src/tcg/pages/landing.ts
@@ -8,28 +8,53 @@ import {
   escapeAttr,
   escapeText,
   fillTcgHtml,
-  loadTcgHtml,
-  renderActiveRoomRow,
-  renderTeamPicker,
   renderTcgHtml,
+  renderTeamPicker,
   tcgScriptAssets,
 } from '../html';
-import { formatRoomMode, formatRoomStatus } from '../labels';
+import { formatRoomMode } from '../labels';
 
 export interface TcgRoster {
   value: string;
   name: string;
 }
 
-export interface TcgActiveRoomBrief {
+/** One open room for the browse list (still live until everyone leaves). */
+export interface TcgBrowseRoom {
   id: string;
   mode: 'pvp' | 'solo';
   status: 'lobby' | 'active' | 'ended';
-  opponentUsername: string | null;
-  youAreCreator: boolean;
+  p1: string | null;
+  p2: string | null;
+  spectators: number;
+  /** Viewer is a participant (creator/p1/p2) → label the button "open". */
+  you: boolean;
+  /** Open PvP lobby waiting for a second player → label "join". */
+  openLobby: boolean;
 }
 
-export interface TcgLandingOpts {
+/** One finished match for the history list. */
+export interface TcgHistoryEntry {
+  id: string;
+  mode: 'pvp' | 'solo';
+  p1: string;
+  p2: string;
+  winner: 'p1' | 'p2' | 'draw' | null;
+  endReason: string;
+  rounds: number;
+  endedAt: number;
+}
+
+export interface TcgBrowseOpts {
+  nonce: string;
+  lv999?: boolean;
+  user: NavUser | null;
+  rooms: TcgBrowseRoom[];
+  history: TcgHistoryEntry[];
+  loginReturnPath: string;
+}
+
+export interface TcgCreateOpts {
   nonce: string;
   lv999?: boolean;
   user: NavUser | null;
@@ -37,51 +62,131 @@ export interface TcgLandingOpts {
   roster: TcgRoster[];
   characterCatalog: CharacterCatalogEntry[];
   deckLegal: boolean;
-  activeRooms: TcgActiveRoomBrief[];
   loginReturnPath: string;
 }
 
-function renderActiveRoomsList(rooms: TcgActiveRoomBrief[]): string {
-  if (rooms.length === 0) return loadTcgHtml('tcg-active-rooms-empty.html');
+function loginPage(opts: { nonce: string; lv999?: boolean; user: NavUser | null; loginReturnPath: string }) {
+  return Layout({
+    title: 'Silverwolf — TCG Battle',
+    active: 'games',
+    body: renderTcgHtml('tcg-login.html', {
+      TITLE: 'TCG Battle',
+      WRAP_CLASS: 'tcg-wrap',
+      MESSAGE: 'TCG battles need a Discord account for matchmaking and your saved deck.',
+      LOGIN_URL: `/auth/discord/login?return=${encodeURIComponent(opts.loginReturnPath)}`,
+    }) as any,
+    nonce: opts.nonce,
+    lv999: opts.lv999,
+    user: opts.user,
+  });
+}
+
+// ── Browse page (default landing): in-progress battles + match history ───────
+function matchup(p1: string | null, p2: string | null, mode: 'pvp' | 'solo', waiting: boolean): string {
+  const a = p1 ? escapeText(p1) : '—';
+  if (mode === 'solo') return `${a} <span class="tcg-muted">(solo)</span>`;
+  if (waiting) return `${a} <span class="tcg-muted">— waiting for opponent</span>`;
+  return `${a} <span class="tcg-vs">vs</span> ${p2 ? escapeText(p2) : '—'}`;
+}
+
+const STATUS_LABEL: Record<TcgBrowseRoom['status'], string> = {
+  lobby: 'Lobby',
+  active: 'Live',
+  ended: 'Finished',
+};
+
+function renderBrowseRooms(rooms: TcgBrowseRoom[]): string {
+  if (rooms.length === 0) return '<p class="tcg-empty">No battles in progress. Create one!</p>';
   const rows = rooms.map((r) => {
-    const opponentHtml = r.opponentUsername
-      ? `vs @${escapeText(r.opponentUsername)}`
-      : (r.mode === 'pvp'
-        ? '<span class="tcg-muted">waiting for opponent</span>'
-        : '<span class="tcg-muted">solo</span>');
-    const copyButton = r.mode === 'pvp' && r.status === 'lobby'
-      ? fillTcgHtml('tcg-copy-link-btn.html', { ID: escapeAttr(r.id) })
+    const label = r.you ? 'open' : (r.openLobby ? 'join' : 'watch');
+    const watchers = r.spectators > 0
+      ? `<span class="tcg-room-watch" title="${r.spectators} watching">👁 ${r.spectators}</span>`
       : '';
-    return renderActiveRoomRow({
-      id: r.id,
-      status: formatRoomStatus(r.status),
-      statusClass: r.status,
-      mode: formatRoomMode(r.mode),
-      opponentHtml,
-      copyButton,
+    return fillTcgHtml('tcg-browse-room.html', {
+      ID: escapeAttr(r.id),
+      STATUS_CLASS: escapeAttr(r.status),
+      STATUS: STATUS_LABEL[r.status],
+      MODE: escapeText(formatRoomMode(r.mode)),
+      MATCHUP: matchup(r.p1, r.p2, r.mode, r.mode === 'pvp' && !r.p2),
+      WATCHERS: watchers,
+      LABEL: label,
     });
   }).join('');
   return `<ul class="tcg-rooms">${rows}</ul>`;
 }
 
-export function TcgBattleLandingPage(opts: TcgLandingOpts) {
-  const {
-    nonce, lv999, user, csrf, roster, characterCatalog, deckLegal, activeRooms, loginReturnPath,
-  } = opts;
+function relTime(ms: number, now: number): string {
+  const s = Math.max(0, Math.floor((now - ms) / 1000));
+  if (s < 60) return 'just now';
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 30) return `${d}d ago`;
+  const mo = Math.floor(d / 30);
+  if (mo < 12) return `${mo}mo ago`;
+  return `${Math.floor(mo / 12)}y ago`;
+}
 
+function resultText(e: TcgHistoryEntry): { text: string; cls: string } {
+  const tail = e.endReason === 'timeout' ? ' (timeout)'
+    : e.endReason === 'disconnect' ? ' (disconnect)'
+      : e.endReason === 'forfeit' ? ' (forfeit)' : '';
+  if (e.winner === 'draw' || e.winner == null) return { text: `Draw${tail}`, cls: 'draw' };
+  const name = e.winner === 'p1' ? e.p1 : e.p2;
+  return { text: `${escapeText(name)} won${tail}`, cls: 'win' };
+}
+
+function renderHistory(history: TcgHistoryEntry[], now: number): string {
+  if (history.length === 0) return '<p class="tcg-empty">No matches played yet.</p>';
+  const rows = history.map((e) => {
+    const res = resultText(e);
+    return fillTcgHtml('tcg-browse-history.html', {
+      ID: escapeAttr(e.id),
+      MODE: escapeText(formatRoomMode(e.mode)),
+      MATCHUP: `${escapeText(e.p1)} <span class="tcg-vs">vs</span> ${escapeText(e.p2)}`,
+      RESULT: `${res.text} <span class="tcg-muted">· ${e.rounds} rounds</span>`,
+      RESULT_CLASS: res.cls,
+      TIME: escapeText(relTime(e.endedAt, now)),
+    });
+  }).join('');
+  return `<ul class="tcg-rooms">${rows}</ul>`;
+}
+
+export function TcgBrowsePage(opts: TcgBrowseOpts) {
+  const {
+    nonce, lv999, user, rooms, history, loginReturnPath,
+  } = opts;
   if (!user) {
-    return Layout({
-      title: 'Silverwolf — TCG Battle',
-      active: 'games',
-      body: renderTcgHtml('tcg-login.html', {
-        TITLE: 'TCG Battle',
-        WRAP_CLASS: 'tcg-wrap',
-        MESSAGE: 'TCG battles need a Discord account for matchmaking and your saved deck.',
-        LOGIN_URL: `/auth/discord/login?return=${encodeURIComponent(loginReturnPath)}`,
-      }) as any,
-      nonce,
-      lv999,
-      user,
+    return loginPage({
+      nonce, lv999, user, loginReturnPath,
+    });
+  }
+
+  const body = renderTcgHtml('tcg-browse.html', {
+    IN_PROGRESS: renderBrowseRooms(rooms),
+    HISTORY: renderHistory(history, Date.now()),
+  });
+
+  return Layout({
+    title: 'Silverwolf — TCG Battles',
+    active: 'games',
+    body: body as any,
+    nonce,
+    lv999,
+    user,
+  });
+}
+
+// ── Create page (separate from browse) ──────────────────────────────────────
+export function TcgCreatePage(opts: TcgCreateOpts) {
+  const {
+    nonce, lv999, user, csrf, roster, characterCatalog, deckLegal, loginReturnPath,
+  } = opts;
+  if (!user) {
+    return loginPage({
+      nonce, lv999, user, loginReturnPath,
     });
   }
 
@@ -94,17 +199,14 @@ export function TcgBattleLandingPage(opts: TcgLandingOpts) {
   });
 
   const body = html`
-    ${renderTcgHtml('tcg-battle-landing.html', {
-    TEAM_PICKER: teamPicker,
-    ACTIVE_ROOMS: renderActiveRoomsList(activeRooms),
-  })}
+    ${renderTcgHtml('tcg-create.html', { TEAM_PICKER: teamPicker })}
     ${tcgDetailModalShell()}
     ${tcgDetailAssets(nonce, characterCatalog)}
     ${tcgScriptAssets('tcg-landing', nonce, { id: 'tcg-landing-data', payload: { csrf: csrf ?? '', defaults: firstThree, deckLegal } })}
   `;
 
   return Layout({
-    title: 'Silverwolf — TCG Battle',
+    title: 'Silverwolf — Create TCG Battle',
     active: 'games',
     body: body as any,
     nonce,

--- a/site_src/tcg/pages/match.ts
+++ b/site_src/tcg/pages/match.ts
@@ -1,0 +1,195 @@
+/* eslint-disable no-use-before-define, @typescript-eslint/no-use-before-define */
+import { raw } from 'hono/html';
+import { Layout } from '../../components/layout';
+import type { NavUser } from '../../components/navbar';
+import { escapeAttr, escapeText, renderTcgHtml } from '../html';
+import { formatRoomMode } from '../labels';
+import type { BattleSnapshot, SnapshotCharacter, SnapshotEffect } from '../../../tcg/battleSnapshot';
+import type { BattleLogEntry } from '../../../tcg/battle';
+import type { TcgChatMessage, TcgFeedItem } from '../rooms';
+
+export interface TcgMatchDetailOpts {
+  nonce: string;
+  lv999?: boolean;
+  user: NavUser | null;
+  id: string;
+  mode: 'pvp' | 'solo';
+  p1: string;
+  p2: string;
+  winner: 'p1' | 'p2' | 'draw' | null;
+  endReason: string;
+  rounds: number;
+  endedAt: number;
+  snapshot: BattleSnapshot | null;
+  feed: TcgFeedItem[];
+  notFound?: boolean;
+}
+
+const MAX_EQUIP = 3;
+const REASON_TAIL: Record<string, string> = {
+  timeout: ' (timeout)',
+  disconnect: ' (disconnect)',
+  forfeit: ' (forfeit)',
+};
+
+function effectsHtml(effects: SnapshotEffect[]): string {
+  const max = 6;
+  const shown = effects.slice(0, max).map((e) => {
+    const dur = e.duration < 999 ? ` ${e.duration}` : '';
+    const cls = e.positive ? 'buff' : 'debuff';
+    const title = escapeAttr(`${e.name}: ${e.description}`);
+    return `<span class="tcg-eff ${cls}" title="${title}">${escapeText(e.name + dur)}</span>`;
+  }).join('');
+  const more = effects.length > max ? `<span class="tcg-eff more">+${effects.length - max}</span>` : '';
+  return `${shown}${more}`;
+}
+
+function ultOrbHtml(ch: SnapshotCharacter): string {
+  const ult = ch.skills.find((s) => s.category === 'ultimate');
+  if (!ult || ult.energyCost <= 0) return '';
+  const cost = ult.energyCost;
+  const pct = Math.max(0, Math.min(100, (100 * ch.energy) / cost));
+  const full = ch.energy >= cost && !ch.isKnockedOut ? ' full' : '';
+  return `<div class="tcg-ult-orb foe${full}" title="${escapeAttr(ult.name)}">`
+    + `<span class="orb-fill" style="--pct:${pct}"></span>`
+    + '<span class="orb-glyph">⚡</span>'
+    + `<span class="orb-val">${Math.min(ch.energy, cost)}/${cost}</span></div>`;
+}
+
+function equipPipsHtml(ch: SnapshotCharacter): string {
+  const count = Math.min(ch.equipmentCount || 0, MAX_EQUIP);
+  let pips = '';
+  for (let i = 0; i < MAX_EQUIP; i += 1) {
+    const eq = ch.equipments[i];
+    let title = 'Empty slot';
+    if (i < count) title = eq ? escapeAttr(eq.name) : 'Equipped';
+    pips += `<span class="tcg-equip-pip${i < count ? ' on' : ''}" title="${title}"></span>`;
+  }
+  return `<div class="tcg-equip-pips${count === 0 ? ' empty' : ''}">${pips}</div>`;
+}
+
+function charCardHtml(ch: SnapshotCharacter): string {
+  const hpPct = Math.max(0, Math.min(100, (100 * ch.currentHp) / Math.max(1, ch.maxHp)));
+  const low = hpPct <= 30 ? ' low' : '';
+  const koCls = ch.isKnockedOut ? ' ko' : '';
+  return `<div class="tcg-char${koCls}">`
+    + '<div class="tcg-char-art">'
+    + `<img class="art" src="/static/tcg/char/${encodeURIComponent(ch.slug)}.png" alt="${escapeAttr(ch.name)}" loading="lazy" decoding="async">`
+    + '<div class="tcg-ko-badge">KO</div>'
+    + `${equipPipsHtml(ch)}${ultOrbHtml(ch)}</div>`
+    + '<div class="tcg-char-info">'
+    + `<div class="tcg-char-namerow"><span class="tcg-char-name">${escapeText(ch.name)}</span></div>`
+    + `<div class="tcg-hp-bar"><div class="tcg-hp-fill${low}" style="width:${hpPct}%"></div>`
+    + `<span class="tcg-hp-val">${Math.max(0, Math.round(ch.currentHp))} / ${ch.maxHp}</span></div>`
+    + `<div class="tcg-effects">${effectsHtml(ch.effects || [])}</div>`
+    + '</div></div>';
+}
+
+function sideHtml(side: 'p1' | 'p2', name: string, team: SnapshotCharacter[], isWinner: boolean): string {
+  const cards = team.map(charCardHtml).join('');
+  const crown = isWinner ? ' 👑' : '';
+  const acting = isWinner ? ' acting' : '';
+  return `<div class="tcg-side" data-side="${side}">`
+    + `<div class="tcg-side-label${acting}"><span class="tcg-side-dot"></span>`
+    + `<span>${escapeText(name)}${crown}</span></div>`
+    + `<div class="tcg-row">${cards}</div></div>`;
+}
+
+function boardHtml(o: TcgMatchDetailOpts): string {
+  const s = o.snapshot;
+  if (!s) return '<p class="tcg-empty">Final board state wasn’t saved for this match.</p>';
+  return `<div class="tcg-arena tcg-arena-static">${
+    sideHtml('p1', o.p1, s.teams.p1 || [], o.winner === 'p1')
+  }<div class="tcg-arena-divider"><span class="tcg-arena-vs">VS</span></div>${
+    sideHtml('p2', o.p2, s.teams.p2 || [], o.winner === 'p2')
+  }</div>`;
+}
+
+function logLineHtml(e: BattleLogEntry): string {
+  const kind = escapeAttr(e.kind || 'info');
+  const title = e.detail ? ` title="${escapeAttr(e.detail)}"` : '';
+  return `<div class="tcg-log-line tcg-log-${kind}"${title}>${escapeText(e.text)}</div>`;
+}
+
+function chatLineHtml(m: TcgChatMessage): string {
+  if (m.kind === 'system') return `<div class="tcg-feed-system">${escapeText(m.text)}</div>`;
+  const dev = m.isDev ? '<span class="tcg-chat-pico dev" title="Developer">★</span>' : '';
+  const player = m.isPlayer ? '<span class="tcg-chat-pico" title="Player">⚔</span>' : '';
+  return `<div class="tcg-chat-line"><span class="tcg-chat-author">${dev}${player}${escapeText(`${m.username}: `)}</span>`
+    + `<span class="tcg-chat-text">${escapeText(m.text)}</span></div>`;
+}
+
+// One combined feed (battle-log lines + chat interleaved) — identical to the live battle.
+function feedHtml(feed: TcgFeedItem[]): string {
+  if (!feed.length) return '<p class="tcg-empty">Nothing was recorded for this match.</p>';
+  const lines = feed.map((it) => (it.kind === 'chat' ? chatLineHtml(it.m) : logLineHtml(it.e))).join('');
+  return `<div class="tcg-feed tcg-feed-static">${lines}</div>`;
+}
+
+function resultLine(o: TcgMatchDetailOpts): string {
+  const tail = REASON_TAIL[o.endReason] || '';
+  if (o.winner === 'draw' || o.winner == null) {
+    return `<span class="tcg-hist-result draw">Draw${tail}</span>`;
+  }
+  const name = o.winner === 'p1' ? o.p1 : o.p2;
+  return `<span class="tcg-hist-result win">${escapeText(name)} won${escapeText(tail)}</span>`;
+}
+
+function shell(bodyInner: string, opts: TcgMatchDetailOpts) {
+  return Layout({
+    title: 'Silverwolf — TCG Match',
+    active: 'games',
+    body: raw(bodyInner) as any,
+    nonce: opts.nonce,
+    lv999: opts.lv999,
+    user: opts.user,
+  });
+}
+
+export function TcgMatchDetailPage(opts: TcgMatchDetailOpts) {
+  if (!opts.user) {
+    return Layout({
+      title: 'Silverwolf — TCG Match',
+      active: 'games',
+      body: renderTcgHtml('tcg-login.html', {
+        TITLE: 'TCG Match',
+        WRAP_CLASS: 'tcg-wrap',
+        MESSAGE: 'Log in to view match history.',
+        LOGIN_URL: `/auth/discord/login?return=${encodeURIComponent(`/games/tcg/match/${opts.id}`)}`,
+      }) as any,
+      nonce: opts.nonce,
+      lv999: opts.lv999,
+      user: opts.user,
+    });
+  }
+
+  const header = '<div class="tcg-room-header">'
+    + '<h1 class="tcg-page-title tcg-room-title">Match Result</h1>'
+    + '<a class="tcg-room-match tcg-link" href="/games/tcg">← all battles</a></div>';
+
+  if (opts.notFound) {
+    return shell(`${header}<div class="tcg-room-wrap"><div class="tcg-panel">`
+      + '<p class="tcg-empty">This match doesn’t exist.</p></div></div>', opts);
+  }
+
+  const meta = `${escapeText(formatRoomMode(opts.mode))} · ${opts.rounds} rounds`;
+  const matchup = `${escapeText(opts.p1)} <span class="tcg-vs">vs</span> ${escapeText(opts.p2)}`;
+
+  const body = `${header}
+    <div class="tcg-room-wrap">
+      <div class="tcg-panel">
+        <div class="tcg-match-summary">
+          <span class="tcg-match-matchup">${matchup}</span>
+          ${resultLine(opts)}
+          <span class="tcg-match-meta">${meta}</span>
+        </div>
+        ${boardHtml(opts)}
+      </div>
+      <div class="tcg-panel">
+        <p class="tcg-subtitle">Battle Log &amp; Chat</p>
+        ${feedHtml(opts.feed)}
+      </div>
+    </div>`;
+
+  return shell(body, opts);
+}

--- a/site_src/tcg/pages/room.ts
+++ b/site_src/tcg/pages/room.ts
@@ -3,7 +3,7 @@ import { html } from 'hono/html';
 import { Layout } from '../../components/layout';
 import type { NavUser } from '../../components/navbar';
 import type { TcgRoomSnapshot } from '../rooms';
-import type { TcgRoster } from './landing';
+import type { TcgTeamStateBrief } from './landing';
 import type { CharacterCatalogEntry } from './detail';
 import { tcgDetailAssets, tcgDetailModalShell } from './detail';
 import {
@@ -28,9 +28,10 @@ export interface TcgJoinPageOpts {
   user: NavUser | null;
   matchId: string;
   csrf: string | null;
-  roster: TcgRoster[];
   characterCatalog: CharacterCatalogEntry[];
   deckLegal: boolean;
+  /** The joiner's team slots; the picker edits the active one in place. */
+  teamState: TcgTeamStateBrief;
 }
 
 function noticePage(opts: {
@@ -55,9 +56,8 @@ function noticePage(opts: {
 /** Team-picker shown to a second player opening a PvP lobby link. */
 export function TcgBattleJoinPage(opts: TcgJoinPageOpts) {
   const {
-    nonce, lv999, user, matchId, csrf, roster, characterCatalog, deckLegal,
+    nonce, lv999, user, matchId, csrf, characterCatalog, deckLegal, teamState,
   } = opts;
-  const firstThree = roster.slice(0, 3).map((r) => r.value);
 
   const teamPicker = renderTeamPicker({
     deckLegal,
@@ -73,7 +73,7 @@ export function TcgBattleJoinPage(opts: TcgJoinPageOpts) {
     ${tcgScriptAssets('tcg-join', nonce, {
     id: 'tcg-join-data',
     payload: {
-      csrf: csrf ?? '', matchId, defaults: firstThree, deckLegal,
+      csrf: csrf ?? '', matchId, deckLegal, teamState,
     },
   })}
   `;

--- a/site_src/tcg/rooms.ts
+++ b/site_src/tcg/rooms.ts
@@ -24,6 +24,7 @@ import {
   endTurnAsCurrentPlayer,
 } from '../../tcg/battleCore';
 import { buildBattleSnapshot, type BattleSnapshot } from '../../tcg/battleSnapshot';
+import { isDevId } from '../../utils/accessControl';
 
 export type TcgMode = 'pvp' | 'solo';
 export type TcgRoomStatus = 'lobby' | 'active' | 'ended';
@@ -48,6 +49,8 @@ export interface TcgChatMessage {
   text: string;
   /** Sender is a seated player (UI shows a player icon); false for spectators/system. */
   isPlayer: boolean;
+  /** Sender is a bot dev (UI shows a star icon); independent of isPlayer. */
+  isDev: boolean;
   ts: number;
 }
 
@@ -429,7 +432,12 @@ class TcgRoomManager {
       .slice(0, TCG_CHAT_MAX_LEN);
     if (!text) return { ok: false, reason: 'empty' };
     this.appendChat(room, {
-      kind: 'chat', senderId: user.discordId, username: user.username, text, isPlayer,
+      kind: 'chat',
+      senderId: user.discordId,
+      username: user.username,
+      text,
+      isPlayer,
+      isDev: isDevId(user.discordId),
     });
     room.lastActivityAt = Date.now();
     return { ok: true };
@@ -447,7 +455,7 @@ class TcgRoomManager {
   /** Append a system notice (join/leave) to the chat stream. */
   private logSystem(room: TcgRoom, text: string) {
     this.appendChat(room, {
-      kind: 'system', senderId: '', username: '', text, isPlayer: false,
+      kind: 'system', senderId: '', username: '', text, isPlayer: false, isDev: false,
     });
   }
 

--- a/site_src/tcg/rooms.ts
+++ b/site_src/tcg/rooms.ts
@@ -166,6 +166,8 @@ export const TCG_CHAT_MAX_LEN = 300;
 export const TCG_CHAT_HISTORY = 60;
 // Cap concurrent spectators per room (guards memory / broadcast fan-out).
 export const TCG_MAX_SPECTATORS = 50;
+// Cap sockets a single spectator may hold (stops one user opening unlimited tabs/sockets).
+export const TCG_MAX_SOCKETS_PER_SPECTATOR = 4;
 
 export type TcgCreateResult =
   | { ok: true; room: TcgRoom }
@@ -257,6 +259,16 @@ class TcgRoomManager {
     if (room.status !== 'lobby') return { ok: false, reason: 'not_lobby' };
     if (room.p2) return { ok: false, reason: 'already_full' };
 
+    // If they were spectating this room, drop the spectator entry and close those
+    // sockets so they reconnect as p2 (otherwise they'd keep getting hand-less
+    // spectator snapshots and couldn't act).
+    const spec = room.spectators.get(user.discordId);
+    if (spec) {
+      room.spectators.delete(user.discordId);
+      for (const ws of spec.sockets) {
+        try { ws.close(1000, 'seated'); } catch { /* already closed */ }
+      }
+    }
     room.p2 = newSlot(user);
     room.p2Team = input.team;
     room.p2Deck = input.deck;
@@ -350,6 +362,9 @@ class TcgRoomManager {
       return { ok: false, reason: 'too_many_spectators' };
     }
     if (existing) {
+      if (existing.sockets.size >= TCG_MAX_SOCKETS_PER_SPECTATOR) {
+        return { ok: false, reason: 'too_many_sockets' };
+      }
       existing.sockets.add(ws);
     } else {
       room.spectators.set(user.discordId, {
@@ -485,7 +500,10 @@ class TcgRoomManager {
     const isPlayer = !!this.slotForUser(room, user.discordId);
     const isSpectator = room.spectators.has(user.discordId);
     if (!isPlayer && !isSpectator) return { ok: false, reason: 'not_a_player' };
+    // Bound the raw input *before* the Unicode regex so an oversized payload can't
+    // be normalized first; the final length is still enforced by the trailing slice.
     const text = String(textRaw)
+      .slice(0, TCG_CHAT_MAX_LEN * 8)
       .replace(/\p{Cc}/gu, ' ') // strip control chars (incl. newlines)
       .replace(/\s+/g, ' ')
       .trim()
@@ -632,18 +650,25 @@ class TcgRoomManager {
     this.clearTurnTimer(room);
     for (const t of room.disconnectTimers.values()) clearTimeout(t);
     room.disconnectTimers.clear();
-    this.recordMatchHistory(room);
-    this.rooms.delete(room.id);
+    // Only drop the in-memory room once the history write has durably succeeded; on
+    // failure keep it so the sweep backstop retries (avoids permanently losing a match).
+    this.recordMatchHistory(room)
+      .then(() => { this.rooms.delete(room.id); })
+      .catch((err: unknown) => logError('tcg closeRoom persist failed; keeping room for retry:', err));
   }
 
-  /** Persist the final, un-editable state to the match-history table (fire-and-forget). */
-  private recordMatchHistory(room: TcgRoom) {
+  /**
+   * Persist the final, un-editable state to the match-history table. Resolves once the
+   * write succeeds (or there's nothing to persist); rejects on DB failure so the caller
+   * can keep the room for retry rather than dropping it.
+   */
+  private recordMatchHistory(room: TcgRoom): Promise<void> {
     const db = this.silverwolf?.db;
     // Only persist rooms where a battle actually started (skip empty lobbies).
-    if (!db || !room.battle) return;
+    if (!db || !room.battle) return Promise.resolve();
     const p1Slot = room.p1;
     const p2Slot = room.mode === 'solo' ? room.p1 : room.p2;
-    if (!p1Slot || !p2Slot) return;
+    if (!p1Slot || !p2Slot) return Promise.resolve();
     const result = room.result ?? { winner: null as TcgWinner, reason: 'disconnect' as TcgEndReason };
     const slugs = (team: Character[] | undefined) => (team ?? []).map((c) => c.slug);
     // Permanent post-game state: the final board (hand-less) + the combined log/chat
@@ -657,7 +682,7 @@ class TcgRoomManager {
     } catch (err) {
       logError('tcg final-state serialize failed:', err);
     }
-    db.tcgMatch.recordMatch({
+    return db.tcgMatch.recordMatch({
       // One record per room, keyed by room id, so a closed room's old /:id link
       // resolves to /match/:id (the route redirects on miss).
       id: room.id,
@@ -674,7 +699,7 @@ class TcgRoomManager {
       createdAt: room.createdAt,
       endedAt: room.endedAt ?? Date.now(),
       finalState,
-    }).catch((err: unknown) => logError('tcg match record failed:', err));
+    });
   }
 
   private publicPlayer(slot: TcgPlayerSlot | undefined, side: BattleSide): TcgPublicPlayer | null {

--- a/site_src/tcg/rooms.ts
+++ b/site_src/tcg/rooms.ts
@@ -38,6 +38,14 @@ export interface TcgPlayerSlot {
   rematchAccepted: boolean;
 }
 
+export interface TcgChatMessage {
+  id: number;
+  side: BattleSide;
+  username: string;
+  text: string;
+  ts: number;
+}
+
 export interface TcgRoom {
   id: string;
   mode: TcgMode;
@@ -57,6 +65,8 @@ export interface TcgRoom {
   turnDeadline: number | null;
   turnTimer: ReturnType<typeof setTimeout> | null;
   disconnectTimers: Map<string, ReturnType<typeof setTimeout>>;
+  chat: TcgChatMessage[];
+  chatSeq: number;
   createdAt: number;
   endedAt: number | null;
   lastActivityAt: number;
@@ -82,6 +92,7 @@ export interface TcgRoomSnapshot {
   players: { p1: TcgPublicPlayer | null; p2: TcgPublicPlayer | null };
   creator: { discordId: string; username: string; avatarURL: string | null };
   battle: BattleSnapshot | null;
+  chat: TcgChatMessage[];
 }
 
 export interface TcgUserInfo {
@@ -110,6 +121,9 @@ const ENDED_TTL_MS = 5 * 60_000;
 export const TCG_ROOMS_PER_USER_CAP = 5;
 export const TCG_MAX_ACTIVE_ROOMS_GLOBAL = 2_000;
 const GC_SWEEP_MS = 60_000;
+// Chat: max characters per message, and how many recent messages a room retains.
+export const TCG_CHAT_MAX_LEN = 300;
+export const TCG_CHAT_HISTORY = 60;
 
 export type TcgCreateResult =
   | { ok: true; room: TcgRoom }
@@ -169,6 +183,8 @@ class TcgRoomManager {
       turnDeadline: null,
       turnTimer: null,
       disconnectTimers: new Map(),
+      chat: [],
+      chatSeq: 0,
       createdAt: now,
       endedAt: null,
       lastActivityAt: now,
@@ -344,6 +360,35 @@ class TcgRoomManager {
     return { ok: true };
   }
 
+  /**
+   * Append a chat message from a seated player. Any participant may chat regardless of
+   * whose turn it is (or whether the battle has ended). Text is sanitised + length-capped;
+   * the chat ring buffer keeps only the most recent {@link TCG_CHAT_HISTORY} messages.
+   * Returns `empty` when nothing remains after sanitising — callers should drop it silently.
+   */
+  postChat(room: TcgRoom, user: TcgUserInfo, textRaw: string):
+    { ok: true } | { ok: false; reason: string } {
+    const slot = this.slotForUser(room, user.discordId);
+    if (!slot) return { ok: false, reason: 'not_a_player' };
+    const text = String(textRaw)
+      .replace(/\p{Cc}/gu, ' ') // strip control chars (incl. newlines)
+      .replace(/\s+/g, ' ')
+      .trim()
+      .slice(0, TCG_CHAT_MAX_LEN);
+    if (!text) return { ok: false, reason: 'empty' };
+    // Stable side label (p1/p2) by seat — not the solo per-turn acting side.
+    const side: BattleSide = room.p2?.discordId === user.discordId ? 'p2' : 'p1';
+    room.chatSeq += 1;
+    room.chat.push({
+      id: room.chatSeq, side, username: slot.username, text, ts: Date.now(),
+    });
+    if (room.chat.length > TCG_CHAT_HISTORY) {
+      room.chat.splice(0, room.chat.length - TCG_CHAT_HISTORY);
+    }
+    room.lastActivityAt = Date.now();
+    return { ok: true };
+  }
+
   leaveRoom(room: TcgRoom, user: TcgUserInfo) {
     const slot = this.slotForUser(room, user.discordId);
     if (!slot) return;
@@ -450,6 +495,7 @@ class TcgRoomManager {
       // A null viewerSide means a non-player viewer — never build the snapshot, since
       // it embeds the viewer's private hand. Only seated players get the battle DTO.
       battle: room.battle && viewerSide ? buildBattleSnapshot(room.battle, viewerSide) : null,
+      chat: room.chat,
     };
   }
 

--- a/site_src/tcg/rooms.ts
+++ b/site_src/tcg/rooms.ts
@@ -16,7 +16,7 @@ import type { WSContext } from 'hono/ws';
 import type { Silverwolf } from '../../classes/silverwolf';
 import type { Character } from '../../tcg/character';
 import type { Item } from '../../tcg/item';
-import { Battle, BattleStatus } from '../../tcg/battle';
+import { Battle, BattleStatus, type BattleLogEntry } from '../../tcg/battle';
 import {
   type BattleSide,
   executeUseSkill,
@@ -25,6 +25,7 @@ import {
 } from '../../tcg/battleCore';
 import { buildBattleSnapshot, type BattleSnapshot } from '../../tcg/battleSnapshot';
 import { isDevId } from '../../utils/accessControl';
+import { logError } from '../../utils/log';
 
 export type TcgMode = 'pvp' | 'solo';
 export type TcgRoomStatus = 'lobby' | 'active' | 'ended';
@@ -37,6 +38,10 @@ export interface TcgPlayerSlot {
   avatarURL: string | null;
   sockets: Set<WSContext>;
   rematchAccepted: boolean;
+  /** Has ever connected (drives "joined" vs "reconnected" system messages). */
+  connectedOnce: boolean;
+  /** Set while an explicit Leave is in flight (so detach logs "left", not "disconnected"). */
+  leaving: boolean;
 }
 
 export interface TcgChatMessage {
@@ -61,6 +66,14 @@ export interface TcgSpectatorSlot {
   sockets: Set<WSContext>;
 }
 
+/**
+ * One entry in the combined feed (battle-log lines + chat interleaved in arrival order).
+ * Mirrors the shape the live client builds, so a recorded match renders identically.
+ */
+export type TcgFeedItem =
+  | { kind: 'log'; e: BattleLogEntry }
+  | { kind: 'chat'; m: TcgChatMessage };
+
 export interface TcgRoom {
   id: string;
   mode: TcgMode;
@@ -80,9 +93,13 @@ export interface TcgRoom {
   turnDeadline: number | null;
   turnTimer: ReturnType<typeof setTimeout> | null;
   disconnectTimers: Map<string, ReturnType<typeof setTimeout>>;
+  /** Fires after the room goes empty; closes + persists the room. */
+  closeTimer: ReturnType<typeof setTimeout> | null;
   spectators: Map<string, TcgSpectatorSlot>;
   chat: TcgChatMessage[];
   chatSeq: number;
+  /** Combined log+chat feed in arrival order, captured for the permanent match record. */
+  feed: TcgFeedItem[];
   createdAt: number;
   endedAt: number | null;
   lastActivityAt: number;
@@ -108,7 +125,8 @@ export interface TcgRoomSnapshot {
   players: { p1: TcgPublicPlayer | null; p2: TcgPublicPlayer | null };
   creator: { discordId: string; username: string; avatarURL: string | null };
   battle: BattleSnapshot | null;
-  chat: TcgChatMessage[];
+  /** Combined log+chat feed (recent slice) so a (re)joining client shows full history. */
+  feed: TcgFeedItem[];
   /** True when this snapshot is for a spectator (not seated; hand omitted, no actions). */
   spectator: boolean;
   /** Number of distinct spectators currently watching. */
@@ -135,9 +153,11 @@ export interface TcgJoinInput {
 // PvP turn timer (solo has no timer — you control both sides at your own pace).
 export const TCG_TURN_TIMER_MS = 90_000;
 export const TCG_DISCONNECT_GRACE_MS = 45_000;
+// A room closes (→ permanent history) this long after the last person leaves.
+const TCG_EMPTY_CLOSE_MS = 60_000;
+// Backstop: an empty room with no activity for this long is closed even if its
+// close timer was never scheduled (e.g. created but never joined).
 const ABANDONED_MS = 5 * 60_000;
-const LOBBY_TTL_MS = 10 * 60_000;
-const ENDED_TTL_MS = 5 * 60_000;
 export const TCG_ROOMS_PER_USER_CAP = 5;
 export const TCG_MAX_ACTIVE_ROOMS_GLOBAL = 2_000;
 const GC_SWEEP_MS = 60_000;
@@ -162,6 +182,8 @@ function newSlot(user: TcgUserInfo, ws?: WSContext): TcgPlayerSlot {
     avatarURL: user.avatarURL,
     sockets: ws ? new Set([ws]) : new Set(),
     rematchAccepted: false,
+    connectedOnce: false,
+    leaving: false,
   };
 }
 
@@ -205,9 +227,11 @@ class TcgRoomManager {
       turnDeadline: null,
       turnTimer: null,
       disconnectTimers: new Map(),
+      closeTimer: null,
       spectators: new Map(),
       chat: [],
       chatSeq: 0,
+      feed: [],
       createdAt: now,
       endedAt: null,
       lastActivityAt: now,
@@ -248,7 +272,17 @@ class TcgRoomManager {
     room.status = 'active';
     room.result = null;
     room.endedAt = null;
+    // Feed is cumulative across the room's life (incl. rematches), mirroring the live
+    // client; just append the new battle's opening turn header.
+    this.appendActionToFeed(room);
     this.setTurnTimer(room);
+  }
+
+  /** Append the most recent action's log lines to the combined feed (same as the live client). */
+  private appendActionToFeed(room: TcgRoom) {
+    if (!room.battle) return;
+    for (const e of room.battle.getLastActionLogEntries()) room.feed.push({ kind: 'log', e });
+    if (room.feed.length > 2000) room.feed.splice(0, room.feed.length - 2000);
   }
 
   getRoom(id: string): TcgRoom | null {
@@ -262,6 +296,14 @@ class TcgRoomManager {
           || r.p1?.discordId === discordId
           || r.p2?.discordId === discordId),
     );
+  }
+
+  /**
+   * All open rooms (any status) — every in-memory room is "live" until it closes and
+   * becomes history. Newest activity first.
+   */
+  listActive(): TcgRoom[] {
+    return [...this.rooms.values()].sort((a, b) => b.lastActivityAt - a.lastActivityAt);
   }
 
   /** Which battle side this user acts as. Solo → the currently-acting side. */
@@ -288,10 +330,17 @@ class TcgRoomManager {
    */
   attachSocket(room: TcgRoom, user: TcgUserInfo, ws: WSContext):
     { ok: true } | { ok: false; reason: string } {
+    this.cancelClose(room); // someone's here again
     const slot = this.slotForUser(room, user.discordId);
     if (slot) {
+      const firstEver = !slot.connectedOnce;
+      const wasAbsent = slot.sockets.size === 0;
       slot.sockets.add(ws);
+      slot.connectedOnce = true;
+      slot.leaving = false;
       this.cancelDisconnect(room, user.discordId);
+      if (firstEver) this.logSystem(room, `${slot.username} joined`);
+      else if (wasAbsent) this.logSystem(room, `${slot.username} reconnected`);
       room.lastActivityAt = Date.now();
       return { ok: true };
     }
@@ -309,7 +358,7 @@ class TcgRoomManager {
         avatarURL: user.avatarURL,
         sockets: new Set([ws]),
       });
-      this.logSystem(room, `${user.username} joined as a spectator`);
+      this.logSystem(room, `${user.username} started spectating`);
     }
     room.lastActivityAt = Date.now();
     return { ok: true };
@@ -320,10 +369,18 @@ class TcgRoomManager {
     const slot = this.slotForUser(room, discordId);
     if (slot) {
       slot.sockets.delete(ws);
-      if (slot.sockets.size === 0 && room.status === 'active' && room.mode === 'pvp') {
-        this.startDisconnectTimer(room, discordId);
+      if (slot.sockets.size === 0) {
+        if (slot.leaving) {
+          this.logSystem(room, `${slot.username} left`);
+          slot.leaving = false;
+        } else {
+          this.logSystem(room, `${slot.username} disconnected`);
+          // Mid-battle PvP drop: grace window, then the opponent wins by disconnect.
+          if (room.status === 'active' && room.mode === 'pvp') this.startDisconnectTimer(room, discordId);
+        }
       }
       room.lastActivityAt = Date.now();
+      this.maybeScheduleClose(room);
       return;
     }
     // Spectator: drop their socket; on the last one, remove them + log a "left" notice.
@@ -335,6 +392,7 @@ class TcgRoomManager {
       this.logSystem(room, `${spec.username} stopped spectating`);
     }
     room.lastActivityAt = Date.now();
+    this.maybeScheduleClose(room);
   }
 
   useSkill(room: TcgRoom, user: TcgUserInfo, charIndex: number, skillIndex: number, targetRaw: string | null):
@@ -375,12 +433,14 @@ class TcgRoomManager {
     return { ok: true, side };
   }
 
-  /** Post-action: settle victory, refresh PvP turn timer, bump activity. */
+  /** Post-action: capture the log into the feed, settle victory, refresh timer, bump activity. */
   private afterAction(room: TcgRoom) {
+    this.appendActionToFeed(room);
     room.lastActivityAt = Date.now();
     const battle = room.battle!;
     if (battle.status !== BattleStatus.Ongoing) {
-      this.endRoom(room, this.winnerFromStatus(battle.status), 'victory');
+      // Battle over — but the room stays open (rematch/chat) until everyone leaves.
+      this.endBattle(room, this.winnerFromStatus(battle.status), 'victory');
       return;
     }
     this.setTurnTimer(room);
@@ -443,13 +503,16 @@ class TcgRoomManager {
     return { ok: true };
   }
 
-  /** Push a chat/system entry onto the room's chat ring buffer. */
+  /** Push a chat/system entry onto the room's chat ring buffer + the combined feed. */
   private appendChat(room: TcgRoom, m: Omit<TcgChatMessage, 'id' | 'ts'>) {
     room.chatSeq += 1;
-    room.chat.push({ id: room.chatSeq, ts: Date.now(), ...m });
+    const msg: TcgChatMessage = { id: room.chatSeq, ts: Date.now(), ...m };
+    room.chat.push(msg);
     if (room.chat.length > TCG_CHAT_HISTORY) {
       room.chat.splice(0, room.chat.length - TCG_CHAT_HISTORY);
     }
+    room.feed.push({ kind: 'chat', m: msg });
+    if (room.feed.length > 2000) room.feed.splice(0, room.feed.length - 2000);
   }
 
   /** Append a system notice (join/leave) to the chat stream. */
@@ -459,20 +522,29 @@ class TcgRoomManager {
     });
   }
 
+  /**
+   * Explicit Leave. Forfeits an active PvP battle (the battle ends, opponent wins) but
+   * the room stays open for whoever remains; closing the player's sockets triggers
+   * `detachSocket`, which logs "left" and closes the room once it's empty.
+   */
   leaveRoom(room: TcgRoom, user: TcgUserInfo) {
     const slot = this.slotForUser(room, user.discordId);
-    if (!slot) return;
-    if (room.status === 'active' && room.mode === 'pvp') {
-      const side = this.sideForUser(room, user.discordId);
-      const winner: TcgWinner = side === 'p1' ? 'p2' : 'p1';
-      this.endRoom(room, winner, 'forfeit');
-    } else if (room.status !== 'ended') {
-      this.endRoom(room, null, 'disconnect');
+    if (slot) {
+      slot.leaving = true;
+      if (room.status === 'active' && room.mode === 'pvp') {
+        const side = this.sideForUser(room, user.discordId);
+        this.endBattle(room, side === 'p1' ? 'p2' : 'p1', 'forfeit');
+      }
+      for (const ws of [...slot.sockets]) {
+        try { ws.close(1000, 'left'); } catch { /* already closed */ }
+      }
+      return;
     }
-    const sockets = [...slot.sockets];
-    slot.sockets.clear();
-    for (const ws of sockets) {
-      try { ws.close(1000, 'left'); } catch { /* already closed */ }
+    const spec = room.spectators.get(user.discordId);
+    if (spec) {
+      for (const ws of [...spec.sockets]) {
+        try { ws.close(1000, 'left'); } catch { /* already closed */ }
+      }
     }
   }
 
@@ -484,7 +556,7 @@ class TcgRoomManager {
       if (room.status !== 'active' || !room.battle) return;
       const loser = room.battle.currentPlayer;
       const winner: TcgWinner = loser === 'p1' ? 'p2' : 'p1';
-      this.endRoom(room, winner, 'timeout');
+      this.endBattle(room, winner, 'timeout');
       this.broadcast(room);
     }, TCG_TURN_TIMER_MS);
   }
@@ -503,7 +575,7 @@ class TcgRoomManager {
       if (room.status !== 'active') return;
       const side = this.sideForUser(room, discordId);
       const winner: TcgWinner = side === 'p1' ? 'p2' : 'p1';
-      this.endRoom(room, winner, 'disconnect');
+      this.endBattle(room, winner, 'disconnect');
       this.broadcast(room);
     }, TCG_DISCONNECT_GRACE_MS);
     room.disconnectTimers.set(discordId, timer);
@@ -517,7 +589,8 @@ class TcgRoomManager {
     }
   }
 
-  private endRoom(room: TcgRoom, winner: TcgWinner, reason: TcgEndReason) {
+  /** End the *battle* (set result/status). The room stays open until everyone leaves. */
+  private endBattle(room: TcgRoom, winner: TcgWinner, reason: TcgEndReason) {
     if (room.status === 'ended') return;
     this.clearTurnTimer(room);
     for (const t of room.disconnectTimers.values()) clearTimeout(t);
@@ -526,6 +599,82 @@ class TcgRoomManager {
     room.status = 'ended';
     room.endedAt = Date.now();
     room.lastActivityAt = room.endedAt;
+  }
+
+  private isOccupied(room: TcgRoom): boolean {
+    if ((room.p1?.sockets.size ?? 0) > 0) return true;
+    if ((room.p2?.sockets.size ?? 0) > 0) return true;
+    for (const s of room.spectators.values()) if (s.sockets.size > 0) return true;
+    return false;
+  }
+
+  /** When the room empties, arm a timer to close + persist it (cancelled if anyone returns). */
+  private maybeScheduleClose(room: TcgRoom) {
+    if (this.isOccupied(room)) { this.cancelClose(room); return; }
+    if (room.closeTimer) return;
+    room.closeTimer = setTimeout(() => {
+      room.closeTimer = null;
+      if (this.isOccupied(room)) return;
+      this.closeRoom(room);
+    }, TCG_EMPTY_CLOSE_MS);
+  }
+
+  private cancelClose(room: TcgRoom) {
+    if (room.closeTimer) { clearTimeout(room.closeTimer); room.closeTimer = null; }
+  }
+
+  /** Everyone left: freeze the game to permanent history (if a battle happened) and drop the room. */
+  private closeRoom(room: TcgRoom) {
+    if (!this.rooms.has(room.id)) return;
+    // A battle abandoned mid-game (everyone gone) is settled now as a no-winner disconnect.
+    if (room.status === 'active' && room.battle) this.endBattle(room, null, 'disconnect');
+    this.cancelClose(room);
+    this.clearTurnTimer(room);
+    for (const t of room.disconnectTimers.values()) clearTimeout(t);
+    room.disconnectTimers.clear();
+    this.recordMatchHistory(room);
+    this.rooms.delete(room.id);
+  }
+
+  /** Persist the final, un-editable state to the match-history table (fire-and-forget). */
+  private recordMatchHistory(room: TcgRoom) {
+    const db = this.silverwolf?.db;
+    // Only persist rooms where a battle actually started (skip empty lobbies).
+    if (!db || !room.battle) return;
+    const p1Slot = room.p1;
+    const p2Slot = room.mode === 'solo' ? room.p1 : room.p2;
+    if (!p1Slot || !p2Slot) return;
+    const result = room.result ?? { winner: null as TcgWinner, reason: 'disconnect' as TcgEndReason };
+    const slugs = (team: Character[] | undefined) => (team ?? []).map((c) => c.slug);
+    // Permanent post-game state: the final board (hand-less) + the combined log/chat
+    // feed in arrival order, so the match page renders exactly like a live battle.
+    let finalState: string | null = null;
+    try {
+      finalState = JSON.stringify({
+        snapshot: buildBattleSnapshot(room.battle, 'p1', true),
+        feed: room.feed,
+      });
+    } catch (err) {
+      logError('tcg final-state serialize failed:', err);
+    }
+    db.tcgMatch.recordMatch({
+      // One record per room, keyed by room id, so a closed room's old /:id link
+      // resolves to /match/:id (the route redirects on miss).
+      id: room.id,
+      mode: room.mode,
+      p1DiscordId: p1Slot.discordId,
+      p1Username: p1Slot.username,
+      p1Team: slugs(room.p1Team),
+      p2DiscordId: p2Slot.discordId,
+      p2Username: p2Slot.username,
+      p2Team: slugs(room.p2Team ?? room.p1Team),
+      winner: result.winner,
+      endReason: result.reason,
+      rounds: room.battle.currentTurn,
+      createdAt: room.createdAt,
+      endedAt: room.endedAt ?? Date.now(),
+      finalState,
+    }).catch((err: unknown) => logError('tcg match record failed:', err));
   }
 
   private publicPlayer(slot: TcgPlayerSlot | undefined, side: BattleSide): TcgPublicPlayer | null {
@@ -571,7 +720,8 @@ class TcgRoomManager {
         avatarURL: room.creatorAvatarURL,
       },
       battle: room.battle ? buildBattleSnapshot(room.battle, layoutSide, spectator) : null,
-      chat: room.chat,
+      // Recent slice keeps the payload bounded; the full feed is persisted at close.
+      feed: room.feed.slice(-250),
       spectator,
       spectatorCount: room.spectators.size,
     };
@@ -603,18 +753,11 @@ class TcgRoomManager {
 
   private sweep() {
     const now = Date.now();
-    for (const [id, room] of this.rooms.entries()) {
-      if (room.status === 'lobby' && now - room.createdAt > LOBBY_TTL_MS) {
-        this.endRoom(room, null, 'disconnect');
-        this.rooms.delete(id);
-      } else if (room.status === 'ended' && room.endedAt && now - room.endedAt > ENDED_TTL_MS) {
-        this.rooms.delete(id);
-      } else if (room.status === 'active') {
-        const anyConnected = (room.p1?.sockets.size ?? 0) > 0 || (room.p2?.sockets.size ?? 0) > 0;
-        if (!anyConnected && now - room.lastActivityAt > ABANDONED_MS) {
-          this.endRoom(room, null, 'disconnect');
-          this.rooms.delete(id);
-        }
+    for (const [, room] of this.rooms.entries()) {
+      // Backstop: close any room that's been empty and idle too long (covers rooms
+      // whose close timer was never armed, e.g. created but never joined).
+      if (!this.isOccupied(room) && now - room.lastActivityAt > ABANDONED_MS) {
+        this.closeRoom(room);
       }
     }
   }

--- a/site_src/tcg/rooms.ts
+++ b/site_src/tcg/rooms.ts
@@ -40,10 +40,22 @@ export interface TcgPlayerSlot {
 
 export interface TcgChatMessage {
   id: number;
-  side: BattleSide;
+  /** 'chat' = a user message; 'system' = a join/leave/spectator notice. */
+  kind: 'chat' | 'system';
+  /** Discord id of the sender ('' for system messages). */
+  senderId: string;
   username: string;
   text: string;
+  /** Sender is a seated player (UI shows a player icon); false for spectators/system. */
+  isPlayer: boolean;
   ts: number;
+}
+
+export interface TcgSpectatorSlot {
+  discordId: string;
+  username: string;
+  avatarURL: string | null;
+  sockets: Set<WSContext>;
 }
 
 export interface TcgRoom {
@@ -65,6 +77,7 @@ export interface TcgRoom {
   turnDeadline: number | null;
   turnTimer: ReturnType<typeof setTimeout> | null;
   disconnectTimers: Map<string, ReturnType<typeof setTimeout>>;
+  spectators: Map<string, TcgSpectatorSlot>;
   chat: TcgChatMessage[];
   chatSeq: number;
   createdAt: number;
@@ -93,6 +106,10 @@ export interface TcgRoomSnapshot {
   creator: { discordId: string; username: string; avatarURL: string | null };
   battle: BattleSnapshot | null;
   chat: TcgChatMessage[];
+  /** True when this snapshot is for a spectator (not seated; hand omitted, no actions). */
+  spectator: boolean;
+  /** Number of distinct spectators currently watching. */
+  spectatorCount: number;
 }
 
 export interface TcgUserInfo {
@@ -124,6 +141,8 @@ const GC_SWEEP_MS = 60_000;
 // Chat: max characters per message, and how many recent messages a room retains.
 export const TCG_CHAT_MAX_LEN = 300;
 export const TCG_CHAT_HISTORY = 60;
+// Cap concurrent spectators per room (guards memory / broadcast fan-out).
+export const TCG_MAX_SPECTATORS = 50;
 
 export type TcgCreateResult =
   | { ok: true; room: TcgRoom }
@@ -183,6 +202,7 @@ class TcgRoomManager {
       turnDeadline: null,
       turnTimer: null,
       disconnectTimers: new Map(),
+      spectators: new Map(),
       chat: [],
       chatSeq: 0,
       createdAt: now,
@@ -258,16 +278,36 @@ class TcgRoomManager {
     return null;
   }
 
-  /** Seat (or re-seat) a user's socket. PvP: a non-creator with no p2 yet must join first. */
+  /**
+   * Attach a socket. Seated players (p1/p2, or the solo creator) reconnect into their
+   * slot; any other logged-in user attaches as a **spectator** (read-only, can chat).
+   * A spectator's first socket logs a "joined" system message.
+   */
   attachSocket(room: TcgRoom, user: TcgUserInfo, ws: WSContext):
     { ok: true } | { ok: false; reason: string } {
     const slot = this.slotForUser(room, user.discordId);
-    if (!slot) {
-      // Not seated. In PvP, the join HTTP step seats p2; spectating isn't supported.
-      return { ok: false, reason: 'not_a_player' };
+    if (slot) {
+      slot.sockets.add(ws);
+      this.cancelDisconnect(room, user.discordId);
+      room.lastActivityAt = Date.now();
+      return { ok: true };
     }
-    slot.sockets.add(ws);
-    this.cancelDisconnect(room, user.discordId);
+    // Spectator path.
+    const existing = room.spectators.get(user.discordId);
+    if (!existing && room.spectators.size >= TCG_MAX_SPECTATORS) {
+      return { ok: false, reason: 'too_many_spectators' };
+    }
+    if (existing) {
+      existing.sockets.add(ws);
+    } else {
+      room.spectators.set(user.discordId, {
+        discordId: user.discordId,
+        username: user.username,
+        avatarURL: user.avatarURL,
+        sockets: new Set([ws]),
+      });
+      this.logSystem(room, `${user.username} joined as a spectator`);
+    }
     room.lastActivityAt = Date.now();
     return { ok: true };
   }
@@ -275,10 +315,21 @@ class TcgRoomManager {
   detachSocket(room: TcgRoom, ws: WSContext, discordId: string) {
     if (!this.rooms.has(room.id)) return;
     const slot = this.slotForUser(room, discordId);
-    if (!slot) return;
-    slot.sockets.delete(ws);
-    if (slot.sockets.size === 0 && room.status === 'active' && room.mode === 'pvp') {
-      this.startDisconnectTimer(room, discordId);
+    if (slot) {
+      slot.sockets.delete(ws);
+      if (slot.sockets.size === 0 && room.status === 'active' && room.mode === 'pvp') {
+        this.startDisconnectTimer(room, discordId);
+      }
+      room.lastActivityAt = Date.now();
+      return;
+    }
+    // Spectator: drop their socket; on the last one, remove them + log a "left" notice.
+    const spec = room.spectators.get(discordId);
+    if (!spec) return;
+    spec.sockets.delete(ws);
+    if (spec.sockets.size === 0) {
+      room.spectators.delete(discordId);
+      this.logSystem(room, `${spec.username} stopped spectating`);
     }
     room.lastActivityAt = Date.now();
   }
@@ -368,25 +419,36 @@ class TcgRoomManager {
    */
   postChat(room: TcgRoom, user: TcgUserInfo, textRaw: string):
     { ok: true } | { ok: false; reason: string } {
-    const slot = this.slotForUser(room, user.discordId);
-    if (!slot) return { ok: false, reason: 'not_a_player' };
+    const isPlayer = !!this.slotForUser(room, user.discordId);
+    const isSpectator = room.spectators.has(user.discordId);
+    if (!isPlayer && !isSpectator) return { ok: false, reason: 'not_a_player' };
     const text = String(textRaw)
       .replace(/\p{Cc}/gu, ' ') // strip control chars (incl. newlines)
       .replace(/\s+/g, ' ')
       .trim()
       .slice(0, TCG_CHAT_MAX_LEN);
     if (!text) return { ok: false, reason: 'empty' };
-    // Stable side label (p1/p2) by seat — not the solo per-turn acting side.
-    const side: BattleSide = room.p2?.discordId === user.discordId ? 'p2' : 'p1';
-    room.chatSeq += 1;
-    room.chat.push({
-      id: room.chatSeq, side, username: slot.username, text, ts: Date.now(),
+    this.appendChat(room, {
+      kind: 'chat', senderId: user.discordId, username: user.username, text, isPlayer,
     });
+    room.lastActivityAt = Date.now();
+    return { ok: true };
+  }
+
+  /** Push a chat/system entry onto the room's chat ring buffer. */
+  private appendChat(room: TcgRoom, m: Omit<TcgChatMessage, 'id' | 'ts'>) {
+    room.chatSeq += 1;
+    room.chat.push({ id: room.chatSeq, ts: Date.now(), ...m });
     if (room.chat.length > TCG_CHAT_HISTORY) {
       room.chat.splice(0, room.chat.length - TCG_CHAT_HISTORY);
     }
-    room.lastActivityAt = Date.now();
-    return { ok: true };
+  }
+
+  /** Append a system notice (join/leave) to the chat stream. */
+  private logSystem(room: TcgRoom, text: string) {
+    this.appendChat(room, {
+      kind: 'system', senderId: '', username: '', text, isPlayer: false,
+    });
   }
 
   leaveRoom(room: TcgRoom, user: TcgUserInfo) {
@@ -470,18 +532,26 @@ class TcgRoomManager {
     };
   }
 
+  /**
+   * Build a snapshot for a viewer. `viewerSide` is the seated side for a player, or
+   * null for a spectator — spectators render p1 at the bottom and get **no hand**
+   * (the battle DTO is built with `spectator: true`).
+   */
   snapshotFor(room: TcgRoom, viewerSide: BattleSide | null): TcgRoomSnapshot {
+    const spectator = viewerSide == null;
     // In solo, both public players are the creator; the battle DTO uses the
     // currently-acting side so the right hand is shown.
     const p2Public = room.mode === 'solo'
       ? this.publicPlayer(room.p1, 'p2')
       : this.publicPlayer(room.p2, 'p2');
+    // Spectators have no side of their own; lay the board out from p1's perspective.
+    const layoutSide: BattleSide = viewerSide ?? 'p1';
     return {
       id: room.id,
       mode: room.mode,
       status: room.status,
       result: room.result,
-      yourSide: viewerSide,
+      yourSide: layoutSide,
       turnDeadline: room.turnDeadline,
       players: {
         p1: this.publicPlayer(room.p1, 'p1'),
@@ -492,10 +562,10 @@ class TcgRoomManager {
         username: room.creatorUsername,
         avatarURL: room.creatorAvatarURL,
       },
-      // A null viewerSide means a non-player viewer — never build the snapshot, since
-      // it embeds the viewer's private hand. Only seated players get the battle DTO.
-      battle: room.battle && viewerSide ? buildBattleSnapshot(room.battle, viewerSide) : null,
+      battle: room.battle ? buildBattleSnapshot(room.battle, layoutSide, spectator) : null,
       chat: room.chat,
+      spectator,
+      spectatorCount: room.spectators.size,
     };
   }
 
@@ -512,6 +582,15 @@ class TcgRoomManager {
     };
     sendTo(room.p1, 'p1');
     if (room.mode === 'pvp') sendTo(room.p2, 'p2');
+    // Spectators all share one hand-less snapshot.
+    if (room.spectators.size > 0) {
+      const specMsg = JSON.stringify({ type: 'state', room: this.snapshotFor(room, null) });
+      for (const spec of room.spectators.values()) {
+        for (const ws of spec.sockets) {
+          try { ws.send(specMsg); } catch { /* closing */ }
+        }
+      }
+    }
   }
 
   private sweep() {

--- a/site_src/tcg/routes.ts
+++ b/site_src/tcg/routes.ts
@@ -327,7 +327,7 @@ export function registerTcgBattleRoutes(
       );
     }
 
-    // Not a participant: offer to join an open PvP lobby; otherwise it's not viewable.
+    // Not a participant: offer to join an open PvP lobby…
     if (room.mode === 'pvp' && room.status === 'lobby' && !room.p2) {
       const composition = await loadDeckCompositionForUser(silverwolf.db, user.discordId);
       return c.html(
@@ -344,6 +344,8 @@ export function registerTcgBattleRoutes(
       );
     }
 
+    // …otherwise let them spectate (read-only; no hand, can chat). The snapshot is
+    // built with a null viewer side, which the manager renders as a spectator view.
     return c.html(
       TcgBattleRoomPage({
         nonce,
@@ -352,11 +354,9 @@ export function registerTcgBattleRoutes(
         matchId,
         selfDiscordId: user.discordId,
         csrf: user.csrfToken,
-        snapshot: null,
-        roomMissing: true,
+        snapshot: tcgRoomManager.snapshotFor(room, null),
         loginReturnPath,
       }).toString(),
-      404,
     );
   });
 

--- a/site_src/tcg/routes.ts
+++ b/site_src/tcg/routes.ts
@@ -6,11 +6,14 @@ import {
   type AppEnv, authedGameRequest, navUser, readGameBody,
 } from '../shared';
 import {
-  TcgBattleLandingPage,
-  type TcgActiveRoomBrief,
+  TcgBrowsePage,
+  TcgCreatePage,
+  type TcgBrowseRoom,
+  type TcgHistoryEntry,
   type TcgRoster,
 } from './pages/landing';
 import { TcgBattleRoomPage, TcgBattleJoinPage } from './pages/room';
+import { TcgMatchDetailPage } from './pages/match';
 import {
   TcgDeckBuilderPage,
   type DeckBuilderItem,
@@ -74,7 +77,7 @@ export function registerTcgBattleRoutes(
 ) {
   tcgRoomManager.init(silverwolf);
 
-  // ── Landing ───────────────────────────────────────────────────────────────
+  // ── Browse (default): all in-progress battles + recent match history ────────
   app.get(LANDING_PATH, async (c) => {
     const user = c.get('user');
     const nav = navUser(c);
@@ -83,47 +86,40 @@ export function registerTcgBattleRoutes(
 
     if (!user) {
       return c.html(
-        TcgBattleLandingPage({
-          nonce,
-          lv999,
-          user: nav,
-          csrf: null,
-          roster: ROSTER,
-          characterCatalog: CHARACTER_CATALOG,
-          deckLegal: false,
-          activeRooms: [],
-          loginReturnPath: LANDING_PATH,
+        TcgBrowsePage({
+          nonce, lv999, user: nav, rooms: [], history: [], loginReturnPath: LANDING_PATH,
         }).toString(),
       );
     }
 
-    const composition = await loadDeckCompositionForUser(silverwolf.db, user.discordId);
-    const deckLegal = isLegalDeck(composition);
-    const rooms = tcgRoomManager.listForUser(user.discordId);
-    const briefs: TcgActiveRoomBrief[] = rooms.map((r) => {
-      const youAreCreator = r.creatorDiscordId === user.discordId;
-      const other = youAreCreator ? r.p2 : r.p1;
-      const opp = (other && other.discordId !== user.discordId) ? other.username : null;
-      return {
-        id: r.id,
-        mode: r.mode,
-        status: r.status,
-        opponentUsername: opp,
-        youAreCreator,
-      };
-    });
+    const rooms: TcgBrowseRoom[] = tcgRoomManager.listActive().map((r) => ({
+      id: r.id,
+      mode: r.mode,
+      status: r.status,
+      p1: r.p1?.username ?? null,
+      p2: r.mode === 'solo' ? (r.p1?.username ?? null) : (r.p2?.username ?? null),
+      spectators: r.spectators.size,
+      you: r.creatorDiscordId === user.discordId
+        || r.p1?.discordId === user.discordId
+        || r.p2?.discordId === user.discordId,
+      openLobby: r.mode === 'pvp' && r.status === 'lobby' && !r.p2,
+    }));
+
+    const historyRows = await silverwolf.db.tcgMatch.getRecent(40);
+    const history: TcgHistoryEntry[] = historyRows.map((row: Record<string, any>) => ({
+      id: row.id,
+      mode: row.mode === 'solo' ? 'solo' : 'pvp',
+      p1: row.p1Username,
+      p2: row.p2Username,
+      winner: row.winner ?? null,
+      endReason: row.endReason,
+      rounds: row.rounds,
+      endedAt: row.endedAt,
+    }));
 
     return c.html(
-      TcgBattleLandingPage({
-        nonce,
-        lv999,
-        user: nav,
-        csrf: user.csrfToken,
-        roster: ROSTER,
-        characterCatalog: CHARACTER_CATALOG,
-        deckLegal,
-        activeRooms: briefs,
-        loginReturnPath: LANDING_PATH,
+      TcgBrowsePage({
+        nonce, lv999, user: nav, rooms, history, loginReturnPath: LANDING_PATH,
       }).toString(),
     );
   });
@@ -272,6 +268,108 @@ export function registerTcgBattleRoutes(
     return c.json({ ok: true });
   });
 
+  // ── Create page (registered before :id so "create" isn't captured) ──────────
+  app.get('/games/tcg/create', async (c) => {
+    const user = c.get('user');
+    const nav = navUser(c);
+    const nonce = c.get('nonce');
+    const lv999 = c.req.query('lv') === '999';
+    const loginReturnPath = '/games/tcg/create';
+
+    if (!user) {
+      return c.html(
+        TcgCreatePage({
+          nonce,
+          lv999,
+          user: nav,
+          csrf: null,
+          roster: ROSTER,
+          characterCatalog: CHARACTER_CATALOG,
+          deckLegal: false,
+          loginReturnPath,
+        }).toString(),
+      );
+    }
+
+    const composition = await loadDeckCompositionForUser(silverwolf.db, user.discordId);
+    return c.html(
+      TcgCreatePage({
+        nonce,
+        lv999,
+        user: nav,
+        csrf: user.csrfToken,
+        roster: ROSTER,
+        characterCatalog: CHARACTER_CATALOG,
+        deckLegal: isLegalDeck(composition),
+        loginReturnPath,
+      }).toString(),
+    );
+  });
+
+  // ── Match detail (permanent post-game state; before :id) ────────────────────
+  app.get('/games/tcg/match/:id', async (c) => {
+    const user = c.get('user');
+    const nav = navUser(c);
+    const nonce = c.get('nonce');
+    const lv999 = c.req.query('lv') === '999';
+    const matchId = c.req.param('id');
+
+    const base = {
+      nonce, lv999, user: nav, id: matchId,
+    } as const;
+
+    const blank = {
+      mode: 'pvp' as const,
+      p1: '',
+      p2: '',
+      winner: null,
+      endReason: '',
+      rounds: 0,
+      endedAt: 0,
+      snapshot: null,
+      feed: [],
+    };
+
+    if (!user) {
+      return c.html(TcgMatchDetailPage({ ...base, ...blank }).toString());
+    }
+
+    const row = await silverwolf.db.tcgMatch.getById(matchId);
+    if (!row) {
+      return c.html(TcgMatchDetailPage({ ...base, ...blank, notFound: true }).toString(), 404);
+    }
+
+    let snapshot = null;
+    let feed: any[] = [];
+    if (row.finalState) {
+      try {
+        const parsed = JSON.parse(row.finalState);
+        snapshot = parsed.snapshot ?? null;
+        if (Array.isArray(parsed.feed)) {
+          feed = parsed.feed;
+        } else {
+          // Fallback for any pre-feed rows: log lines, then chat.
+          const log = Array.isArray(parsed.log) ? parsed.log : [];
+          const chat = Array.isArray(parsed.chat) ? parsed.chat : [];
+          feed = [...log.map((e: any) => ({ kind: 'log', e })), ...chat.map((m: any) => ({ kind: 'chat', m }))];
+        }
+      } catch { /* corrupt blob → show summary only */ }
+    }
+
+    return c.html(TcgMatchDetailPage({
+      ...base,
+      mode: row.mode === 'solo' ? 'solo' : 'pvp',
+      p1: row.p1Username,
+      p2: row.p2Username,
+      winner: row.winner ?? null,
+      endReason: row.endReason,
+      rounds: row.rounds,
+      endedAt: row.endedAt,
+      snapshot,
+      feed,
+    }).toString());
+  });
+
   // ── Room page (play or join variant) ────────────────────────────────────────
   app.get('/games/tcg/:id', async (c) => {
     const matchId = c.req.param('id');
@@ -291,6 +389,9 @@ export function registerTcgBattleRoutes(
 
     const room = tcgRoomManager.getRoom(matchId);
     if (!room) {
+      // Closed rooms become permanent history under the same id — send old live links there.
+      const record = await silverwolf.db.tcgMatch.getById(matchId);
+      if (record) return c.redirect(`/games/tcg/match/${encodeURIComponent(matchId)}`);
       return c.html(
         TcgBattleRoomPage({
           nonce,

--- a/site_src/tcg/routes.ts
+++ b/site_src/tcg/routes.ts
@@ -10,7 +10,6 @@ import {
   TcgCreatePage,
   type TcgBrowseRoom,
   type TcgHistoryEntry,
-  type TcgRoster,
 } from './pages/landing';
 import { TcgBattleRoomPage, TcgBattleJoinPage } from './pages/room';
 import { TcgMatchDetailPage } from './pages/match';
@@ -24,7 +23,7 @@ import {
   type TcgMode,
 } from './rooms';
 import { createTcgWsEvents } from './ws';
-import { buildTeamOfThree, CHARACTER_ROSTER_DISCORD_CHOICES } from '../../tcg/characterRoster';
+import { buildTeamOfThree, characterFromRosterValue } from '../../tcg/characterRoster';
 import { CHARACTERS } from '../../tcg/characters';
 import { buildCharacterCatalog } from './pages/detail';
 import {
@@ -40,10 +39,16 @@ import {
 } from '../../tcg/items';
 import { DECK_SIZE } from '../../tcg/battle';
 import { loadDeckCompositionForUser, saveDeckCompositionForUser } from '../../tcg/deckStorage';
+import {
+  loadTeamState,
+  setActiveSlot,
+  updateSlotLineup,
+  TEAM_SLOT_COUNT,
+  type TcgTeamState,
+} from '../../tcg/teamSlotStorage';
 
 const LANDING_PATH = '/games/tcg';
 
-const ROSTER: TcgRoster[] = CHARACTER_ROSTER_DISCORD_CHOICES.map((c) => ({ value: c.value, name: c.name }));
 const CHARACTER_CATALOG = buildCharacterCatalog(CHARACTERS);
 
 const DECK_BUILDER_ITEMS: DeckBuilderItem[] = [...ALL_ITEMS]
@@ -63,11 +68,36 @@ const DECK_CAPS = {
   fourStarMax: DECK_MAX_FOUR_STAR_OR_ABOVE,
 };
 
-function parseTeam(raw: unknown): [string, string, string] | null {
-  if (!Array.isArray(raw) || raw.length !== 3) return null;
-  const vals = raw.map((v) => (typeof v === 'string' ? v : ''));
-  if (vals.some((v) => !v)) return null;
-  return [vals[0], vals[1], vals[2]];
+/** A partial lineup (0..3 known roster values) as sent by the slot auto-save. */
+function parseLineup(raw: unknown): string[] | null {
+  if (!Array.isArray(raw) || raw.length > 3) return null;
+  const vals: string[] = [];
+  for (const v of raw) {
+    if (typeof v !== 'string' || !characterFromRosterValue(v)) return null;
+    vals.push(v);
+  }
+  return vals;
+}
+
+/** Client-facing view of the slot state (lineups + deck size/legality; deck contents stay server-side). */
+function teamStateBrief(state: TcgTeamState) {
+  return {
+    active: state.active,
+    deckSize: DECK_SIZE,
+    slots: state.slots.map((s) => ({
+      team: s.team,
+      // null deck = the default deck: full and always legal.
+      deckCount: s.deck ? Object.values(s.deck).reduce((sum, n) => sum + n, 0) : DECK_SIZE,
+      deckLegal: s.deck ? isLegalDeck(s.deck) : true,
+    })),
+  };
+}
+
+/** The active slot's team, rebuilt server-side — every battle plays from a slot. */
+function activeSlotTeam(state: TcgTeamState) {
+  const vals = state.slots[state.active].team;
+  if (vals.length !== 3) return null;
+  return buildTeamOfThree(vals[0], vals[1], vals[2]);
 }
 
 export function registerTcgBattleRoutes(
@@ -134,10 +164,10 @@ export function registerTcgBattleRoutes(
     const mode: TcgMode | null = (modeRaw === 'pvp' || modeRaw === 'solo') ? modeRaw : null;
     if (!mode) return c.json({ ok: false, error: 'Pick a valid mode.' }, 400);
 
-    const teamVals = parseTeam(body!.team);
-    if (!teamVals) return c.json({ ok: false, error: 'Pick three characters.' }, 400);
-    const team = buildTeamOfThree(teamVals[0], teamVals[1], teamVals[2]);
-    if (!team) return c.json({ ok: false, error: 'Unknown character selected.' }, 400);
+    // Battles always play from the active team slot (the client edits it in place).
+    const state = await loadTeamState(silverwolf.db, auth.discordId);
+    const team = activeSlotTeam(state);
+    if (!team) return c.json({ ok: false, error: 'Your active team slot needs three characters.' }, 400);
 
     const composition = await loadDeckCompositionForUser(silverwolf.db, auth.discordId);
     if (!isLegalDeck(composition)) {
@@ -168,10 +198,9 @@ export function registerTcgBattleRoutes(
     if (auth instanceof Response) return auth;
 
     const matchId = c.req.param('id');
-    const teamVals = parseTeam(body!.team);
-    if (!teamVals) return c.json({ ok: false, error: 'Pick three characters.' }, 400);
-    const team = buildTeamOfThree(teamVals[0], teamVals[1], teamVals[2]);
-    if (!team) return c.json({ ok: false, error: 'Unknown character selected.' }, 400);
+    const state = await loadTeamState(silverwolf.db, auth.discordId);
+    const team = activeSlotTeam(state);
+    if (!team) return c.json({ ok: false, error: 'Your active team slot needs three characters.' }, 400);
 
     const composition = await loadDeckCompositionForUser(silverwolf.db, auth.discordId);
     if (!isLegalDeck(composition)) {
@@ -256,15 +285,55 @@ export function registerTcgBattleRoutes(
       if (n > 0) composition[id] = n;
     }
 
-    const validation = validateDeckComposition(composition);
-    if (!validation.ok) return c.json({ ok: false, error: validation.reason }, 400);
-
+    // Illegal compositions save fine — legality is display-only (red badge) and only
+    // enforced when a battle starts. Per-item whitelisting above still applies.
     try {
       await saveDeckCompositionForUser(silverwolf.db, auth.discordId, composition);
     } catch (err) {
       logError('tcg deck save failed:', err);
       return c.json({ ok: false, error: 'Failed to save deck.' }, 500);
     }
+    return c.json({ ok: true, deckLegal: validateDeckComposition(composition).ok });
+  });
+
+  // ── Team slots: five saved lineup+deck loadouts; battles use the active one ──
+  // Switch the active slot; responds with its lineup + deck legality so the picker
+  // and deck badge can update in place.
+  app.post('/games/tcg/teams/select', async (c) => {
+    const body = await readGameBody(c);
+    const auth = authedGameRequest(c, body);
+    if (auth instanceof Response) return auth;
+
+    const idx = typeof body!.slot === 'number' ? Math.trunc(body!.slot) : Number.NaN;
+    if (!Number.isInteger(idx) || idx < 0 || idx >= TEAM_SLOT_COUNT) {
+      return c.json({ ok: false, error: 'Invalid slot.' }, 400);
+    }
+    const state = await setActiveSlot(silverwolf.db, auth.discordId, idx);
+    // Judge legality from the slot's own deck (no second state load); a missing deck
+    // means the default deck, which is always legal.
+    const slotDeck = state.slots[state.active].deck;
+    return c.json({
+      ok: true,
+      active: state.active,
+      team: state.slots[state.active].team,
+      deckLegal: slotDeck ? isLegalDeck(slotDeck) : true,
+    });
+  });
+
+  // Auto-save a slot's lineup as the picker changes (partial teams allowed).
+  // Slot-explicit so a fast slot switch can't misattribute a debounced save.
+  app.post('/games/tcg/teams/lineup', async (c) => {
+    const body = await readGameBody(c);
+    const auth = authedGameRequest(c, body);
+    if (auth instanceof Response) return auth;
+
+    const idx = typeof body!.slot === 'number' ? Math.trunc(body!.slot) : Number.NaN;
+    if (!Number.isInteger(idx) || idx < 0 || idx >= TEAM_SLOT_COUNT) {
+      return c.json({ ok: false, error: 'Invalid slot.' }, 400);
+    }
+    const team = parseLineup(body!.team);
+    if (!team) return c.json({ ok: false, error: 'Invalid team.' }, 400);
+    await updateSlotLineup(silverwolf.db, auth.discordId, idx, team);
     return c.json({ ok: true });
   });
 
@@ -283,24 +352,27 @@ export function registerTcgBattleRoutes(
           lv999,
           user: nav,
           csrf: null,
-          roster: ROSTER,
           characterCatalog: CHARACTER_CATALOG,
           deckLegal: false,
+          teamState: { active: 0, deckSize: DECK_SIZE, slots: [] },
           loginReturnPath,
         }).toString(),
       );
     }
 
-    const composition = await loadDeckCompositionForUser(silverwolf.db, user.discordId);
+    const [composition, state] = await Promise.all([
+      loadDeckCompositionForUser(silverwolf.db, user.discordId),
+      loadTeamState(silverwolf.db, user.discordId),
+    ]);
     return c.html(
       TcgCreatePage({
         nonce,
         lv999,
         user: nav,
         csrf: user.csrfToken,
-        roster: ROSTER,
         characterCatalog: CHARACTER_CATALOG,
         deckLegal: isLegalDeck(composition),
+        teamState: teamStateBrief(state),
         loginReturnPath,
       }).toString(),
     );
@@ -430,7 +502,10 @@ export function registerTcgBattleRoutes(
 
     // Not a participant: offer to join an open PvP lobby…
     if (room.mode === 'pvp' && room.status === 'lobby' && !room.p2) {
-      const composition = await loadDeckCompositionForUser(silverwolf.db, user.discordId);
+      const [composition, state] = await Promise.all([
+        loadDeckCompositionForUser(silverwolf.db, user.discordId),
+        loadTeamState(silverwolf.db, user.discordId),
+      ]);
       return c.html(
         TcgBattleJoinPage({
           nonce,
@@ -438,9 +513,9 @@ export function registerTcgBattleRoutes(
           user: nav,
           matchId,
           csrf: user.csrfToken,
-          roster: ROSTER,
           characterCatalog: CHARACTER_CATALOG,
           deckLegal: isLegalDeck(composition),
+          teamState: teamStateBrief(state),
         }).toString(),
       );
     }

--- a/site_src/tcg/ws.ts
+++ b/site_src/tcg/ws.ts
@@ -124,6 +124,12 @@ export function createTcgWsEvents(roomId: string, user: AuthedUser): WSEvents {
           tcgRoomManager.leaveRoom(r, user);
           tcgRoomManager.broadcast(r);
           try { ws.close(1000, 'left'); } catch { /* */ }
+        } else if (type === 'chat') {
+          const text = typeof parsed.text === 'string' ? parsed.text : '';
+          const res = tcgRoomManager.postChat(r, user, text);
+          // An empty message after sanitising is dropped silently (no error banner).
+          if (!res.ok) { if (res.reason !== 'empty') send(ws, { type: 'error', code: res.reason }); return; }
+          tcgRoomManager.broadcast(r);
         } else if (type === 'ping') {
           send(ws, { type: 'pong' });
         } else {

--- a/tcg/battleSnapshot.ts
+++ b/tcg/battleSnapshot.ts
@@ -157,9 +157,11 @@ function snapshotTeam(battle: Battle, side: BattleSide): SnapshotCharacter[] {
 /**
  * Build a JSON-safe snapshot of the battle for one viewer. Only `viewerSide`'s hand
  * is included; both teams' public state (hp/energy/effects/skills) is always visible.
+ * Pass `spectator: true` for a non-player viewer — the hand is omitted entirely (a
+ * spectator must never see either side's cards), and `viewerSide` only sets layout.
  */
-export function buildBattleSnapshot(battle: Battle, viewerSide: BattleSide): BattleSnapshot {
-  const hand: SnapshotHandCard[] = Array.from(battle.handForSide(viewerSide).entries())
+export function buildBattleSnapshot(battle: Battle, viewerSide: BattleSide, spectator = false): BattleSnapshot {
+  const hand: SnapshotHandCard[] = spectator ? [] : Array.from(battle.handForSide(viewerSide).entries())
     .sort((a, b) => a[0] - b[0])
     .map(([slotId, item]) => ({
       slotId,

--- a/tcg/deckStorage.ts
+++ b/tcg/deckStorage.ts
@@ -4,21 +4,21 @@ import {
   defaultDeckComposition,
   expandDeckComposition,
   isLegalDeck,
-  ITEMS_BY_ID,
   ALL_ITEMS,
-  PER_CARD_MAX,
 } from './items';
 import { DECK_SIZE } from './battle';
 import type { Item } from './item';
+import { loadTeamState, updateActiveSlotDeck } from './teamSlotStorage';
 
 /**
- * Persistence layer for per-user TCG item decks. We store deck composition as JSON
- * (`{itemId: count}`) in `User.tcg_deck`. When the column is null/empty/invalid,
- * `loadDeckCompositionForUser` falls back to {@link defaultDeckComposition}.
+ * Per-user TCG deck access, routed to the **active team slot** (see
+ * `teamSlotStorage.ts`): a user's deck is whichever deck their active slot holds, so
+ * every existing deck surface (web deck builder, Discord `/tcgbattle deckset`,
+ * `buildDeckForUser`) edits/reads the active slot without knowing about slots.
+ * A slot with no deck (null) falls back to {@link defaultDeckComposition}.
  *
- * The storage format is deliberately a sparse map rather than a card list so that
- * nicer "edit deck" UIs (e.g. /tcgbattle deckset <item> <count>) can mutate one
- * entry at a time without rebuilding the whole deck.
+ * The composition format stays a sparse `{itemId: count}` map so "edit deck" UIs can
+ * mutate one entry at a time without rebuilding the whole deck.
  */
 
 interface DbLike {
@@ -29,51 +29,40 @@ interface DbLike {
 }
 
 /**
- * Read & validate a user's deck composition from the DB. Falls back to the default
- * composition if the column is missing, malformed, or doesn't form a legal deck.
+ * Read the active slot's deck composition **as saved** — possibly illegal (slots keep
+ * whatever the user last saved; legality is display-only until battle time). A slot
+ * with no deck (null) yields the default composition.
  */
 export async function loadDeckCompositionForUser(
   db: DbLike,
   userId: string,
 ): Promise<DeckComposition> {
   try {
-    const raw = await db.user.getUserAttr(userId, 'tcgDeck');
-    if (!raw || typeof raw !== 'string') {
-      return defaultDeckComposition();
-    }
-    const parsed = JSON.parse(raw) as unknown;
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      return defaultDeckComposition();
-    }
-    const composition: DeckComposition = {};
-    Object.entries(parsed as Record<string, unknown>).forEach(([id, count]) => {
-      if (typeof count === 'number' && Number.isFinite(count) && ITEMS_BY_ID[id]) {
-        composition[id] = Math.max(0, Math.min(PER_CARD_MAX, Math.floor(count)));
-      }
-    });
-    if (!isLegalDeck(composition)) {
-      return defaultDeckComposition();
-    }
-    return composition;
+    const state = await loadTeamState(db, userId);
+    return state.slots[state.active].deck ?? defaultDeckComposition();
   } catch (err) {
     logError('Failed to load TCG deck for user', err);
     return defaultDeckComposition();
   }
 }
 
-/** Persist a composition to the DB. Caller should validate first via {@link isLegalDeck}. */
+/** Persist a composition to the active slot. Illegal compositions save fine (shown red). */
 export async function saveDeckCompositionForUser(
   db: DbLike,
   userId: string,
   composition: DeckComposition,
 ): Promise<void> {
-  await db.user.setUserAttr(userId, 'tcgDeck', JSON.stringify(composition));
+  await updateActiveSlotDeck(db, userId, composition);
 }
 
-/** Build a 25-Item array for the given user, using their saved composition or the default. */
+/**
+ * Build a 25-Item array for the given user for a battle. An illegal saved deck falls
+ * back to the default here (Discord battles have no pre-battle legality gate; the web
+ * create/join routes reject illegal decks before ever getting this far).
+ */
 export async function buildDeckForUser(db: DbLike, userId: string): Promise<Item[]> {
   const composition = await loadDeckCompositionForUser(db, userId);
-  const cards = expandDeckComposition(composition);
+  const cards = expandDeckComposition(isLegalDeck(composition) ? composition : defaultDeckComposition());
   // Defensive: if validation passes the deck is exactly DECK_SIZE, but if anything
   // upstream changed we top it up with the default so battles never start short.
   if (cards.length < DECK_SIZE) {

--- a/tcg/teamSlotStorage.ts
+++ b/tcg/teamSlotStorage.ts
@@ -1,0 +1,139 @@
+import { logError } from '../utils/log';
+import {
+  type DeckComposition,
+  ITEMS_BY_ID,
+  PER_CARD_MAX,
+} from './items';
+
+/**
+ * Persistence for the five per-user **team slots**. Every battle plays from the
+ * currently-active slot; there is no separate "unsaved" team. A slot bundles a
+ * character lineup and an item-deck composition, stored together as JSON in
+ * `User.tcg_teams`:
+ *   { active: 0..4, slots: [{ team: rosterValue[0..3], deck: {itemId: count} | null }, ...] }
+ *
+ * `deck: null` means "use the default deck". Lineup edits and deck edits (web deck
+ * builder, Discord `/tcgbattle deckset` — via `deckStorage`, which routes to the
+ * active slot) write straight into the active slot; switching slots switches the
+ * whole loadout. On first load, a legacy `User.tcg_deck` is migrated into slot 1.
+ */
+
+export interface TcgTeamSlot {
+  /** 0..3 roster values (a battle needs exactly 3). */
+  team: string[];
+  /** Sparse {itemId: count}; null = default deck. */
+  deck: DeckComposition | null;
+}
+
+export interface TcgTeamState {
+  active: number;
+  /** Always exactly {@link TEAM_SLOT_COUNT} entries. */
+  slots: TcgTeamSlot[];
+}
+
+export const TEAM_SLOT_COUNT = 5;
+const TEAM_SIZE = 3;
+
+interface DbLike {
+  user: {
+    getUserAttr(userId: string, attribute: string): Promise<any>;
+    setUserAttr(userId: string, field: string, value: any): Promise<void>;
+  };
+}
+
+function sanitizeTeam(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  return v.filter((x): x is string => typeof x === 'string' && x.length > 0).slice(0, TEAM_SIZE);
+}
+
+/**
+ * Drop unknown items / clamp counts. Illegal (short/over-cap) compositions are kept
+ * as-is — legality is surfaced in the UI and enforced at battle time, not at save.
+ * Only a non-object collapses to null ("never set" → default deck); an explicitly
+ * saved empty deck stays `{}` so the user sees 0/25 rather than a silent default.
+ */
+function sanitizeDeck(v: unknown): DeckComposition | null {
+  if (!v || typeof v !== 'object' || Array.isArray(v)) return null;
+  const composition: DeckComposition = {};
+  Object.entries(v as Record<string, unknown>).forEach(([id, count]) => {
+    if (typeof count === 'number' && Number.isFinite(count) && count > 0 && ITEMS_BY_ID[id]) {
+      composition[id] = Math.max(0, Math.min(PER_CARD_MAX, Math.floor(count)));
+    }
+  });
+  return composition;
+}
+
+function emptySlot(): TcgTeamSlot {
+  return { team: [], deck: null };
+}
+
+function sanitizeSlot(v: unknown): TcgTeamSlot {
+  if (!v || typeof v !== 'object' || Array.isArray(v)) return emptySlot();
+  const o = v as Record<string, unknown>;
+  return { team: sanitizeTeam(o.team), deck: sanitizeDeck(o.deck) };
+}
+
+export async function loadTeamState(db: DbLike, userId: string): Promise<TcgTeamState> {
+  try {
+    const raw = await db.user.getUserAttr(userId, 'tcgTeams');
+    if (raw && typeof raw === 'string') {
+      const parsed = JSON.parse(raw) as any;
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed) && Array.isArray(parsed.slots)) {
+        const slots: TcgTeamSlot[] = [];
+        for (let i = 0; i < TEAM_SLOT_COUNT; i += 1) slots.push(sanitizeSlot(parsed.slots[i]));
+        const active = (Number.isInteger(parsed.active) && parsed.active >= 0 && parsed.active < TEAM_SLOT_COUNT)
+          ? parsed.active as number
+          : 0;
+        return { active, slots };
+      }
+    }
+  } catch (err) {
+    logError('Failed to load TCG team slots for user', err);
+  }
+  // First use (or corrupt data): fresh slots, seeding slot 1 with any legacy single deck.
+  const state: TcgTeamState = { active: 0, slots: Array.from({ length: TEAM_SLOT_COUNT }, emptySlot) };
+  try {
+    const legacy = await db.user.getUserAttr(userId, 'tcgDeck');
+    if (legacy && typeof legacy === 'string') {
+      state.slots[0].deck = sanitizeDeck(JSON.parse(legacy));
+    }
+  } catch { /* no legacy deck — leave defaults */ }
+  return state;
+}
+
+async function saveTeamState(db: DbLike, userId: string, state: TcgTeamState): Promise<void> {
+  await db.user.setUserAttr(userId, 'tcgTeams', JSON.stringify(state));
+}
+
+export async function setActiveSlot(db: DbLike, userId: string, index: number): Promise<TcgTeamState> {
+  const state = await loadTeamState(db, userId);
+  if (Number.isInteger(index) && index >= 0 && index < TEAM_SLOT_COUNT) state.active = index;
+  await saveTeamState(db, userId, state);
+  return state;
+}
+
+/**
+ * Overwrite one slot's lineup (0..3 values; roster validation is the caller's job).
+ * Slot-explicit — not "the active slot" — so a quick slot switch mid-edit can never
+ * misattribute a pending save.
+ */
+export async function updateSlotLineup(
+  db: DbLike,
+  userId: string,
+  index: number,
+  team: string[],
+): Promise<TcgTeamState> {
+  const state = await loadTeamState(db, userId);
+  if (Number.isInteger(index) && index >= 0 && index < TEAM_SLOT_COUNT) {
+    state.slots[index].team = sanitizeTeam(team);
+    await saveTeamState(db, userId, state);
+  }
+  return state;
+}
+
+/** Overwrite the active slot's deck (empty/invalid collapses to the default deck). */
+export async function updateActiveSlotDeck(db: DbLike, userId: string, deck: DeckComposition): Promise<void> {
+  const state = await loadTeamState(db, userId);
+  state.slots[state.active].deck = sanitizeDeck(deck);
+  await saveTeamState(db, userId, state);
+}

--- a/utils/accessControl.ts
+++ b/utils/accessControl.ts
@@ -38,6 +38,11 @@ function isDev(interaction: ChatInputCommandInteraction): boolean {
   return ALLOWED_USERS.includes(interaction.user.id);
 }
 
+/** Dev check by raw Discord user id (for the website, which has no interaction). */
+function isDevId(discordId: string): boolean {
+  return ALLOWED_USERS.includes(discordId);
+}
+
 function isAdmin(interaction: ChatInputCommandInteraction): boolean {
   // eslint-disable-next-line max-len
   return (interaction.member?.permissions as PermissionsBitField)?.has(PermissionsBitField.Flags.Administrator) || isDev(interaction);
@@ -54,6 +59,7 @@ function isAllowedServer(interaction: ChatInputCommandInteraction): boolean {
 
 export {
   isDev,
+  isDevId,
   isAdmin,
   isBasement,
   isAllowedServer,


### PR DESCRIPTION
- Pokemon showdown styled chat
  - Added an option to chat in the logs
  - Added an option to spectate other battles and yap
  - Room only shuts down after everyone left
- Browse ongoing battles & match history
  - Added a page to show all invites, ongoing, and finished battles
  - You can join any of them to yap
  - Finished battles are saved permanently in history after room shuts down
    - You can look at the final state & full chat and battle logs
    - No option to replay the entire battle cause that's hard to make and I'm lazy
- Saving teams
  - You can now save up to 5 teams on the website
    - Team lineup + Item deck
    - Auto synced 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated TCG browse and create pages (PvP/Solo selection).
  * Added spectator mode with a viewer-friendly battle view and chat access (no playing actions).
  * Added a post-match details page with results plus combined battle log/chat replay, with spectator-aware updates.
* **Bug Fixes**
  * Finished matches remain viewable; old room links redirect to match history.
* **Documentation**
  * Updated and expanded web TCG (PvP/solo) specifications, including spectator rules, WebSocket flow, room lifecycle, and history persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->