### PR TITLE
feat[ai]: roleplay characters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Bun process**. It serves fun/games both as slash commands and as web pages, plus
 **The website is public, so security and performance are first-class concerns — code defensively:
 validate every input, never trust client data, keep the CSP tight.**
 
-**Last updated: 2026-06-21**
+**Last updated: 2026-06-30**
 
 > **Maintenance rule.** Edit this file only on *substantive architectural* change — new
 > architecture, new auth, new data flows/services, schema or security-model changes, or when
@@ -89,11 +89,24 @@ plus a global `banned` flag as an emergency kill-switch. `DevCommand` enforces `
 running. **There is no website admin panel — all bot administration is via these Discord commands.**
 
 **Events** (wired in `classes/silverwolf.ts`): `messageCreate` → keyword triggers
-(`data/keywords.json`, each maps to a script in `utils/`) and a ~1% random seasonal Pokémon summon
-(`classes/handlers/*` — normal/Christmas/Halloween/April-Fools); `interactionCreate` → command
-dispatch + button handlers; message delete/edit tracked for history.
+(`data/keywords.json`, each maps to a script in `utils/`), a ~1% random seasonal Pokémon summon
+(`classes/handlers/*` — normal/Christmas/Halloween/April-Fools), and the roleplay mention router
+(`utils/rpRuntime.ts`); `interactionCreate` → command dispatch + button handlers + autocomplete
+dispatch; message delete/edit tracked for history.
 
-**Schedulers** (`Bun.cron`): birthday announcer (hourly), baby automation (daily + every 10 min).
+**Schedulers**: `Bun.cron` jobs — birthday announcer (hourly), baby automation (daily + every 10
+min); plus a 30s `setInterval` roleplay scheduler (`classes/rpScheduler.ts`).
+
+**Roleplay** (`utils/rp*.ts`, `commands/ai_rp_*.ts`, `db.rp` → `RpCharacter`/`RpSpawn`/`RpHistory`):
+user-defined characters (`/ai rp-create-char`) spawned per-channel (`/ai rp-spawn`, ≤5/channel) that
+reply through the shared AI webhook as themselves — name + a 128×128 avatar re-hosted in a per-server
+asset channel (ServerConfig key `rp_asset_channel`, set via `/ai rp-setasset`; signed CDN URLs are
+refreshed from the stored message id). Model `deepseek/deepseek-v3.2`, no tools, **per-character
+private history** with auto-compaction (oldest ~80% folded into a first-person memory) near the 128k
+window. Spawns are **soft-deleted** so history survives removal/re-spawn. `@name` / `@id` /
+`@name-id` mentions route in `messageCreate`; `all`-mode characters also chime in via the scheduler
+(≤1 reply/channel/tick; bot/webhook messages are never heard → no bot-to-bot loops). An in-memory
+active-channel set keeps non-RP traffic off the DB.
 
 **Database** (`bun:sqlite`, `persistence/database.db`). Layered: `tables/` (TableDefinition schema
 objects) → `models/` (DAOs) → `queries/` (SQL strings). **Access pattern:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,11 @@ private history** with auto-compaction (oldest ~80% folded into a first-person m
 window. Spawns are **soft-deleted** so history survives removal/re-spawn. `@name` / `@id` /
 `@name-id` mentions route in `messageCreate`; `all`-mode characters also chime in via the scheduler
 (≤1 reply/channel/tick; bot/webhook messages are never heard → no bot-to-bot loops). An in-memory
-active-channel set keeps non-RP traffic off the DB.
+active-channel set keeps non-RP traffic off the DB. Characters are defined via command fields **or** an
+uploaded `.json` (`utils/rpCharInput.ts` — size-capped, parsed in a try/catch, only the three known
+string fields read, never spread — the upload attack surface); `details` is token-capped (~4k),
+`starting_message` char-capped (6k, split on delivery). `{user}` in details/starting-message is
+substituted with the spawner's name in **self**-mode only (left literal in `all`-mode).
 
 **Database** (`bun:sqlite`, `persistence/database.db`). Layered: `tables/` (TableDefinition schema
 objects) → `models/` (DAOs) → `queries/` (SQL strings). **Access pattern:**

--- a/classes/rpScheduler.ts
+++ b/classes/rpScheduler.ts
@@ -1,0 +1,31 @@
+import { runProactiveRpTick } from '../utils/rpRuntime';
+import { log, logError } from '../utils/log';
+
+/** Drives proactive "all"-mode roleplay replies — one scan every 30s. */
+const RP_TICK_MS = 30_000;
+
+class RpScheduler {
+  private client: any;
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(client: any) {
+    this.client = client;
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      runProactiveRpTick(this.client).catch((err) => logError('Rp: proactive tick failed:', err));
+    }, RP_TICK_MS);
+    log(`Rp scheduler started (every ${RP_TICK_MS / 1000}s).`);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+}
+
+export default RpScheduler;

--- a/classes/silverwolf.ts
+++ b/classes/silverwolf.ts
@@ -7,7 +7,9 @@ import Database from '../database/Database';
 import BirthdayScheduler from './birthdayScheduler';
 import BabyScheduler from './babyScheduler';
 import FootballScheduler from './footballScheduler';
+import RpScheduler from './rpScheduler';
 import { log, logError } from '../utils/log';
+import { handleRpMessage, recomputeActiveRpChannels } from '../utils/rpRuntime';
 // Note: Bun automatically reads .env files
 import seasonConfig from '../data/config/skin/pokemon.json';
 import keywordsJson from '../data/keywords.json';
@@ -52,6 +54,7 @@ class Silverwolf extends Client {
   birthdayScheduler: BirthdayScheduler;
   babyScheduler: BabyScheduler;
   footballScheduler: FootballScheduler;
+  rpScheduler: RpScheduler;
   games: string[];
   chat: any;
   sexSessions: any[];
@@ -69,6 +72,7 @@ class Silverwolf extends Client {
     this.birthdayScheduler = new BirthdayScheduler(this);
     this.babyScheduler = new BabyScheduler(this);
     this.footballScheduler = new FootballScheduler(this);
+    this.rpScheduler = new RpScheduler(this);
     this.init();
     this.games = [];
     this.loadGames(); // Initialize the games list from the JSON file
@@ -92,6 +96,10 @@ class Silverwolf extends Client {
     log('Baby scheduler started.');
     this.footballScheduler.start();
     log('Football scheduler started.');
+
+    await recomputeActiveRpChannels(this.db);
+    this.rpScheduler.start();
+    log('Roleplay scheduler started.');
 
     log(`Silverwolf initialized.
 ----------------------------------------------
@@ -201,6 +209,10 @@ All wrongs reserved.
   }
 
   async processInteraction(interaction: any): Promise<void> {
+    if (interaction.isAutocomplete()) {
+      await this.handleAutocomplete(interaction);
+      return;
+    }
     if (interaction.isCommand()) {
       if (!interaction.guild) {
         await interaction.reply('commands can only be used in servers.');
@@ -231,6 +243,22 @@ All wrongs reserved.
     }
   }
 
+  async handleAutocomplete(interaction: any): Promise<void> {
+    try {
+      let command = this.commands.get(interaction.commandName);
+      const sub = interaction.options.getSubcommand(false);
+      if (sub) command = this.commands.get(`${interaction.commandName}.${sub}`);
+      if (command && typeof command.autocomplete === 'function') {
+        await command.autocomplete(interaction);
+      } else {
+        await interaction.respond([]);
+      }
+    } catch (error) {
+      logError('Error handling autocomplete:', error);
+      try { await interaction.respond([]); } catch { /* interaction already closed */ }
+    }
+  }
+
   async processMessage(message: any): Promise<void> {
     if (!message.guild) {
       log(`> Message received from ${message.author.username} (${message.author.id}) in DM: ${message.content}`);
@@ -243,6 +271,10 @@ All wrongs reserved.
     }
 
     log(`> Message received from ${message.author.username} (${message.author.id}) in ${message.channel.name} (${message.channel.id}) in ${message.guild.name} (${message.guild.id}): ${message.content}`);
+
+    // Roleplay: route to any characters spawned in this channel. Fire-and-forget;
+    // returns immediately (in-memory check) unless the channel actually has spawns.
+    handleRpMessage(this, message).catch((err) => logError('Rp: message handling failed:', err));
 
     const guildConfig = await loadResolvedServerConfig(this.db, message.guild.id);
 

--- a/commands/ai_rp_create.ts
+++ b/commands/ai_rp_create.ts
@@ -1,0 +1,96 @@
+import { Command } from './classes/Command';
+import {
+  validateCharName, MAX_CHARS_PER_USER, DETAILS_MAX_LENGTH, STARTING_MESSAGE_MAX_LENGTH,
+  formatCharHandle,
+} from '../utils/rpIdentity';
+import { processAvatar, hostAvatar } from '../utils/rpAvatar';
+import { characterEmbed } from '../utils/rpCommand';
+import { logError } from '../utils/log';
+
+/** Creates a roleplay character owned by the invoking user. */
+class AiRpCreate extends Command {
+  constructor(client: any) {
+    super(client, 'rp-create-char', 'Create a roleplay character', [
+      {
+        name: 'name', description: 'Short name (letters/numbers/underscore, no spaces)', type: 3, required: true,
+      },
+      {
+        name: 'details', description: 'Personality / background the character role-plays with', type: 3, required: true,
+      },
+      {
+        name: 'starting_message', description: 'The message the character opens with when spawned', type: 3, required: true,
+      },
+      {
+        name: 'pfp', description: 'Avatar image (auto-cropped to 128×128)', type: 11, required: false,
+      },
+    ], { isSubcommandOf: 'ai', blame: 'xei', ephemeral: true });
+  }
+
+  async run(interaction: any): Promise<void> {
+    const userId = interaction.user.id;
+    const name = interaction.options.getString('name');
+    const details = interaction.options.getString('details');
+    const startingMessage = interaction.options.getString('starting_message');
+    const attachment = interaction.options.getAttachment('pfp');
+
+    const nameError = validateCharName(name);
+    if (nameError) { await interaction.editReply(nameError); return; }
+    if (details.length > DETAILS_MAX_LENGTH) {
+      await interaction.editReply(`Details are too long (max ${DETAILS_MAX_LENGTH} characters).`); return;
+    }
+    if (startingMessage.length > STARTING_MESSAGE_MAX_LENGTH) {
+      await interaction.editReply(`Starting message is too long (max ${STARTING_MESSAGE_MAX_LENGTH} characters).`); return;
+    }
+
+    const count = await this.client.db.rp.countCharactersByCreator(userId);
+    if (count >= MAX_CHARS_PER_USER) {
+      await interaction.editReply(`You've hit the limit of ${MAX_CHARS_PER_USER} characters. Delete or reuse one first.`);
+      return;
+    }
+
+    // Validate the image before creating anything.
+    let processedBuffer: Buffer | null = null;
+    if (attachment) {
+      const processed = await processAvatar(attachment);
+      if (!processed.ok) { await interaction.editReply(processed.error); return; }
+      processedBuffer = processed.buffer;
+    }
+
+    try {
+      const character = await this.client.db.rp.createCharacter({
+        creatorId: userId, name, details, startingMessage,
+      });
+      if (!character) { await interaction.editReply('Failed to create the character. Please try again.'); return; }
+
+      let pfpWarning = '';
+      if (processedBuffer) {
+        const hosted = await hostAvatar(
+          this.client,
+          this.client.db,
+          interaction.guild.id,
+          character.charId,
+          processedBuffer,
+        );
+        if (hosted.ok) {
+          await this.client.db.rp.updateCharacterPfp(character.charId, {
+            url: hosted.url, messageId: hosted.messageId, channelId: hosted.channelId,
+          });
+        } else {
+          pfpWarning = `\n\n⚠️ The character was created, but the avatar wasn't set: ${hosted.error}`;
+        }
+      }
+
+      const fresh = await this.client.db.rp.getCharacter(character.charId);
+      const embed = await characterEmbed(this.client, this.client.db, fresh, `@${interaction.user.username}`);
+      await interaction.editReply({
+        content: `Created **${name}** \`${formatCharHandle(name, character.charId)}\`. Spawn it with \`/ai rp-spawn\`.${pfpWarning}`,
+        embeds: [embed],
+      });
+    } catch (err) {
+      logError('AiRpCreate error:', err);
+      await interaction.editReply('Failed to create the character. Please try again.');
+    }
+  }
+}
+
+export default AiRpCreate;

--- a/commands/ai_rp_create.ts
+++ b/commands/ai_rp_create.ts
@@ -1,45 +1,69 @@
 import { Command } from './classes/Command';
 import {
-  validateCharName, MAX_CHARS_PER_USER, DETAILS_MAX_LENGTH, STARTING_MESSAGE_MAX_LENGTH,
+  MAX_CHARS_PER_USER, DETAILS_OPTION_MAX_LENGTH, STARTING_MESSAGE_MAX_LENGTH, NAME_MAX_LENGTH,
   formatCharHandle,
 } from '../utils/rpIdentity';
 import { processAvatar, hostAvatar } from '../utils/rpAvatar';
-import { characterEmbed } from '../utils/rpCommand';
+import { buildCharacterView } from '../utils/rpCommand';
+import {
+  loadCharacterJson, validateName, validateDetails, validateStartingMessage, JSON_HELP,
+} from '../utils/rpCharInput';
 import { logError } from '../utils/log';
 
-/** Creates a roleplay character owned by the invoking user. */
+/** Creates a roleplay character — via individual fields, or a single uploaded .json. */
 class AiRpCreate extends Command {
   constructor(client: any) {
-    super(client, 'rp-create-char', 'Create a roleplay character', [
+    super(client, 'rp-create-char', 'Create a roleplay character (fill the fields, or upload a .json)', [
       {
-        name: 'name', description: 'Short name (letters/numbers/underscore, no spaces)', type: 3, required: true,
+        name: 'name', description: 'Short name (letters/numbers/underscore, no spaces)', type: 3, required: false, max_length: NAME_MAX_LENGTH,
       },
       {
-        name: 'details', description: 'Personality / background the character role-plays with', type: 3, required: true,
+        name: 'details', description: 'Personality / system prompt (use a .json for longer)', type: 3, required: false, max_length: DETAILS_OPTION_MAX_LENGTH,
       },
       {
-        name: 'starting_message', description: 'The message the character opens with when spawned', type: 3, required: true,
+        name: 'starting_message', description: 'Opening message (up to 6000 chars)', type: 3, required: false, max_length: STARTING_MESSAGE_MAX_LENGTH,
       },
       {
         name: 'pfp', description: 'Avatar image (auto-cropped to 128×128)', type: 11, required: false,
+      },
+      {
+        name: 'json', description: 'Upload a character .json instead of the fields (allows larger details)', type: 11, required: false,
       },
     ], { isSubcommandOf: 'ai', blame: 'xei', ephemeral: true });
   }
 
   async run(interaction: any): Promise<void> {
     const userId = interaction.user.id;
-    const name = interaction.options.getString('name');
-    const details = interaction.options.getString('details');
-    const startingMessage = interaction.options.getString('starting_message');
-    const attachment = interaction.options.getAttachment('pfp');
+    const nameOpt = interaction.options.getString('name');
+    const detailsOpt = interaction.options.getString('details');
+    const startingOpt = interaction.options.getString('starting_message');
+    const jsonAttachment = interaction.options.getAttachment('json');
+    const pfpAttachment = interaction.options.getAttachment('pfp');
 
-    const nameError = validateCharName(name);
-    if (nameError) { await interaction.editReply(nameError); return; }
-    if (details.length > DETAILS_MAX_LENGTH) {
-      await interaction.editReply(`Details are too long (max ${DETAILS_MAX_LENGTH} characters).`); return;
+    const hasTextOptions = !!(nameOpt || detailsOpt || startingOpt);
+    if (jsonAttachment && hasTextOptions) {
+      await interaction.editReply('Provide **either** the individual fields **or** a `.json` file — not both. (The `pfp` is separate and can go with either.)');
+      return;
     }
-    if (startingMessage.length > STARTING_MESSAGE_MAX_LENGTH) {
-      await interaction.editReply(`Starting message is too long (max ${STARTING_MESSAGE_MAX_LENGTH} characters).`); return;
+
+    // Resolve the definition from whichever method was used.
+    let fields: { name: string; details: string; startingMessage: string };
+    if (jsonAttachment) {
+      const loaded = await loadCharacterJson(jsonAttachment);
+      if (!loaded.ok) { await interaction.editReply(loaded.error); return; }
+      fields = loaded.fields;
+    } else {
+      const missing: string[] = [];
+      if (!nameOpt) missing.push('name');
+      if (!detailsOpt) missing.push('details');
+      if (!startingOpt) missing.push('starting_message');
+      if (missing.length > 0) {
+        await interaction.editReply(`Missing: **${missing.join(', ')}**. Fill those in, or upload a \`.json\`:\n${JSON_HELP}`);
+        return;
+      }
+      const err = validateName(nameOpt) || validateDetails(detailsOpt) || validateStartingMessage(startingOpt);
+      if (err) { await interaction.editReply(err); return; }
+      fields = { name: nameOpt, details: detailsOpt, startingMessage: startingOpt };
     }
 
     const count = await this.client.db.rp.countCharactersByCreator(userId);
@@ -50,15 +74,15 @@ class AiRpCreate extends Command {
 
     // Validate the image before creating anything.
     let processedBuffer: Buffer | null = null;
-    if (attachment) {
-      const processed = await processAvatar(attachment);
+    if (pfpAttachment) {
+      const processed = await processAvatar(pfpAttachment);
       if (!processed.ok) { await interaction.editReply(processed.error); return; }
       processedBuffer = processed.buffer;
     }
 
     try {
       const character = await this.client.db.rp.createCharacter({
-        creatorId: userId, name, details, startingMessage,
+        creatorId: userId, name: fields.name, details: fields.details, startingMessage: fields.startingMessage,
       });
       if (!character) { await interaction.editReply('Failed to create the character. Please try again.'); return; }
 
@@ -81,10 +105,10 @@ class AiRpCreate extends Command {
       }
 
       const fresh = await this.client.db.rp.getCharacter(character.charId);
-      const embed = await characterEmbed(this.client, this.client.db, fresh, `@${interaction.user.username}`);
+      const view = await buildCharacterView(this.client, this.client.db, fresh, `@${interaction.user.username}`);
       await interaction.editReply({
-        content: `Created **${name}** \`${formatCharHandle(name, character.charId)}\`. Spawn it with \`/ai rp-spawn\`.${pfpWarning}`,
-        embeds: [embed],
+        content: `Created **${fields.name}** \`${formatCharHandle(fields.name, character.charId)}\`. Spawn it with \`/ai rp-spawn\`.${pfpWarning}`,
+        ...view,
       });
     } catch (err) {
       logError('AiRpCreate error:', err);

--- a/commands/ai_rp_create.ts
+++ b/commands/ai_rp_create.ts
@@ -66,6 +66,8 @@ class AiRpCreate extends Command {
       fields = { name: nameOpt, details: detailsOpt, startingMessage: startingOpt };
     }
 
+    // Cheap advisory check so we can reject before processing an avatar; the real
+    // guard is enforced atomically inside createCharacter (below) to close the race.
     const count = await this.client.db.rp.countCharactersByCreator(userId);
     if (count >= MAX_CHARS_PER_USER) {
       await interaction.editReply(`You've hit the limit of ${MAX_CHARS_PER_USER} characters. Delete or reuse one first.`);
@@ -81,10 +83,14 @@ class AiRpCreate extends Command {
     }
 
     try {
-      const character = await this.client.db.rp.createCharacter({
+      const created = await this.client.db.rp.createCharacter({
         creatorId: userId, name: fields.name, details: fields.details, startingMessage: fields.startingMessage,
-      });
-      if (!character) { await interaction.editReply('Failed to create the character. Please try again.'); return; }
+      }, MAX_CHARS_PER_USER);
+      if (!created.ok) {
+        await interaction.editReply(`You've hit the limit of ${MAX_CHARS_PER_USER} characters. Delete or reuse one first.`);
+        return;
+      }
+      const { character } = created;
 
       let pfpWarning = '';
       if (processedBuffer) {

--- a/commands/ai_rp_details.ts
+++ b/commands/ai_rp_details.ts
@@ -1,0 +1,41 @@
+import { Command } from './classes/Command';
+import {
+  resolveCharOption, buildCharSearchChoices, resolveCreatorLabel, characterEmbed,
+} from '../utils/rpCommand';
+import { logError } from '../utils/log';
+
+/** Shows a character's full details (same view as create), including its avatar. */
+class AiRpDetails extends Command {
+  constructor(client: any) {
+    super(client, 'rp-details', 'View a roleplay character\'s details', [
+      {
+        name: 'char', description: 'Character (search by name or id)', type: 3, required: true, autocomplete: true,
+      },
+    ], { isSubcommandOf: 'ai', blame: 'xei', ephemeral: true });
+  }
+
+  async autocomplete(interaction: any): Promise<void> {
+    try {
+      const focused = interaction.options.getFocused();
+      const choices = await buildCharSearchChoices(this.client.db, this.client, focused);
+      await interaction.respond(choices);
+    } catch (err) {
+      logError('AiRpDetails autocomplete error:', err);
+      await interaction.respond([]).catch(() => {});
+    }
+  }
+
+  async run(interaction: any): Promise<void> {
+    const value = interaction.options.getString('char');
+    const character = await resolveCharOption(this.client.db, value);
+    if (!character) {
+      await interaction.editReply('No character matched that. Pick one from the suggestions.');
+      return;
+    }
+    const creatorLabel = await resolveCreatorLabel(this.client, character.creatorId);
+    const embed = await characterEmbed(this.client, this.client.db, character, creatorLabel);
+    await interaction.editReply({ embeds: [embed] });
+  }
+}
+
+export default AiRpDetails;

--- a/commands/ai_rp_details.ts
+++ b/commands/ai_rp_details.ts
@@ -1,10 +1,10 @@
 import { Command } from './classes/Command';
 import {
-  resolveCharOption, buildCharSearchChoices, resolveCreatorLabel, characterEmbed,
+  resolveCharOption, buildCharSearchChoices, resolveCreatorLabel, buildCharacterView,
 } from '../utils/rpCommand';
 import { logError } from '../utils/log';
 
-/** Shows a character's full details (same view as create), including its avatar. */
+/** Shows a character's full details (preview + attached .txt for long fields). */
 class AiRpDetails extends Command {
   constructor(client: any) {
     super(client, 'rp-details', 'View a roleplay character\'s details', [
@@ -33,8 +33,8 @@ class AiRpDetails extends Command {
       return;
     }
     const creatorLabel = await resolveCreatorLabel(this.client, character.creatorId);
-    const embed = await characterEmbed(this.client, this.client.db, character, creatorLabel);
-    await interaction.editReply({ embeds: [embed] });
+    const view = await buildCharacterView(this.client, this.client.db, character, creatorLabel);
+    await interaction.editReply(view);
   }
 }
 

--- a/commands/ai_rp_edit.ts
+++ b/commands/ai_rp_edit.ts
@@ -1,12 +1,15 @@
 import { Command } from './classes/Command';
 import {
-  validateCharName, DETAILS_MAX_LENGTH, STARTING_MESSAGE_MAX_LENGTH, formatCharHandle,
+  DETAILS_OPTION_MAX_LENGTH, STARTING_MESSAGE_MAX_LENGTH, NAME_MAX_LENGTH, formatCharHandle,
 } from '../utils/rpIdentity';
 import { processAvatar, hostAvatar } from '../utils/rpAvatar';
-import { resolveCharOption, buildCharSearchChoices, characterEmbed } from '../utils/rpCommand';
+import { resolveCharOption, buildCharSearchChoices, buildCharacterView } from '../utils/rpCommand';
+import {
+  loadCharacterJson, validateName, validateDetails, validateStartingMessage,
+} from '../utils/rpCharInput';
 import { logError } from '../utils/log';
 
-/** Edits a character you own. Only the creator can edit; others are rejected. */
+/** Edits a character you own (individual fields, or a full .json replacement). */
 class AiRpEdit extends Command {
   constructor(client: any) {
     super(client, 'rp-edit', 'Edit a roleplay character you created', [
@@ -14,16 +17,19 @@ class AiRpEdit extends Command {
         name: 'char', description: 'One of your characters (search by name or id)', type: 3, required: true, autocomplete: true,
       },
       {
-        name: 'name', description: 'New name', type: 3, required: false,
+        name: 'name', description: 'New name', type: 3, required: false, max_length: NAME_MAX_LENGTH,
       },
       {
-        name: 'details', description: 'New personality / background', type: 3, required: false,
+        name: 'details', description: 'New personality / system prompt', type: 3, required: false, max_length: DETAILS_OPTION_MAX_LENGTH,
       },
       {
-        name: 'starting_message', description: 'New opening message', type: 3, required: false,
+        name: 'starting_message', description: 'New opening message', type: 3, required: false, max_length: STARTING_MESSAGE_MAX_LENGTH,
       },
       {
         name: 'pfp', description: 'New avatar image (auto-cropped to 128×128)', type: 11, required: false,
+      },
+      {
+        name: 'json', description: 'Replace name+details+starting_message from a .json (larger details allowed)', type: 11, required: false,
       },
     ], { isSubcommandOf: 'ai', blame: 'xei', ephemeral: true });
   }
@@ -32,7 +38,7 @@ class AiRpEdit extends Command {
     try {
       const focused = interaction.options.getFocused();
       const all = await buildCharSearchChoices(this.client.db, this.client, focused);
-      // Only suggest the user's own characters (the id is the trailing token in the label).
+      // Only suggest the user's own characters.
       const owned = await this.client.db.rp.searchCharacters(focused);
       const ownIds = new Set(owned.filter((r: any) => r.creatorId === interaction.user.id).map((r: any) => r.charId));
       await interaction.respond(all.filter((c) => ownIds.has(c.value)));
@@ -54,25 +60,43 @@ class AiRpEdit extends Command {
       return;
     }
 
-    const newName = interaction.options.getString('name') ?? character.name;
-    const newDetails = interaction.options.getString('details') ?? character.details;
-    const newStarting = interaction.options.getString('starting_message') ?? character.startingMessage;
-    const attachment = interaction.options.getAttachment('pfp');
+    const nameOpt = interaction.options.getString('name');
+    const detailsOpt = interaction.options.getString('details');
+    const startingOpt = interaction.options.getString('starting_message');
+    const jsonAttachment = interaction.options.getAttachment('json');
+    const pfpAttachment = interaction.options.getAttachment('pfp');
 
-    if (interaction.options.getString('name')) {
-      const nameError = validateCharName(newName);
-      if (nameError) { await interaction.editReply(nameError); return; }
+    const hasTextOptions = !!(nameOpt || detailsOpt || startingOpt);
+    if (jsonAttachment && hasTextOptions) {
+      await interaction.editReply('Use **either** the fields **or** a `.json` — not both. (The `pfp` is separate.)');
+      return;
     }
-    if (newDetails.length > DETAILS_MAX_LENGTH) {
-      await interaction.editReply(`Details are too long (max ${DETAILS_MAX_LENGTH} characters).`); return;
+    if (!jsonAttachment && !hasTextOptions && !pfpAttachment) {
+      await interaction.editReply('Nothing to change — provide a new name / details / starting_message, a `.json`, or a `pfp`.');
+      return;
     }
-    if (newStarting.length > STARTING_MESSAGE_MAX_LENGTH) {
-      await interaction.editReply(`Starting message is too long (max ${STARTING_MESSAGE_MAX_LENGTH} characters).`); return;
+
+    let newName = character.name;
+    let newDetails = character.details;
+    let newStarting = character.startingMessage;
+    if (jsonAttachment) {
+      const loaded = await loadCharacterJson(jsonAttachment);
+      if (!loaded.ok) { await interaction.editReply(loaded.error); return; }
+      ({ name: newName, details: newDetails, startingMessage: newStarting } = loaded.fields);
+    } else {
+      if (nameOpt) newName = nameOpt;
+      if (detailsOpt) newDetails = detailsOpt;
+      if (startingOpt) newStarting = startingOpt;
+      let err: string | null = null;
+      if (nameOpt) err = validateName(newName);
+      if (!err && detailsOpt) err = validateDetails(newDetails);
+      if (!err && startingOpt) err = validateStartingMessage(newStarting);
+      if (err) { await interaction.editReply(err); return; }
     }
 
     let processedBuffer: Buffer | null = null;
-    if (attachment) {
-      const processed = await processAvatar(attachment);
+    if (pfpAttachment) {
+      const processed = await processAvatar(pfpAttachment);
       if (!processed.ok) { await interaction.editReply(processed.error); return; }
       processedBuffer = processed.buffer;
     }
@@ -101,10 +125,10 @@ class AiRpEdit extends Command {
       }
 
       const fresh = await this.client.db.rp.getCharacter(character.charId);
-      const embed = await characterEmbed(this.client, this.client.db, fresh, `@${interaction.user.username}`);
+      const view = await buildCharacterView(this.client, this.client.db, fresh, `@${interaction.user.username}`);
       await interaction.editReply({
         content: `Updated **${newName}** \`${formatCharHandle(newName, character.charId)}\`. Live spawns pick up the change on their next reply.${pfpWarning}`,
-        embeds: [embed],
+        ...view,
       });
     } catch (err) {
       logError('AiRpEdit error:', err);

--- a/commands/ai_rp_edit.ts
+++ b/commands/ai_rp_edit.ts
@@ -1,0 +1,116 @@
+import { Command } from './classes/Command';
+import {
+  validateCharName, DETAILS_MAX_LENGTH, STARTING_MESSAGE_MAX_LENGTH, formatCharHandle,
+} from '../utils/rpIdentity';
+import { processAvatar, hostAvatar } from '../utils/rpAvatar';
+import { resolveCharOption, buildCharSearchChoices, characterEmbed } from '../utils/rpCommand';
+import { logError } from '../utils/log';
+
+/** Edits a character you own. Only the creator can edit; others are rejected. */
+class AiRpEdit extends Command {
+  constructor(client: any) {
+    super(client, 'rp-edit', 'Edit a roleplay character you created', [
+      {
+        name: 'char', description: 'One of your characters (search by name or id)', type: 3, required: true, autocomplete: true,
+      },
+      {
+        name: 'name', description: 'New name', type: 3, required: false,
+      },
+      {
+        name: 'details', description: 'New personality / background', type: 3, required: false,
+      },
+      {
+        name: 'starting_message', description: 'New opening message', type: 3, required: false,
+      },
+      {
+        name: 'pfp', description: 'New avatar image (auto-cropped to 128×128)', type: 11, required: false,
+      },
+    ], { isSubcommandOf: 'ai', blame: 'xei', ephemeral: true });
+  }
+
+  async autocomplete(interaction: any): Promise<void> {
+    try {
+      const focused = interaction.options.getFocused();
+      const all = await buildCharSearchChoices(this.client.db, this.client, focused);
+      // Only suggest the user's own characters (the id is the trailing token in the label).
+      const owned = await this.client.db.rp.searchCharacters(focused);
+      const ownIds = new Set(owned.filter((r: any) => r.creatorId === interaction.user.id).map((r: any) => r.charId));
+      await interaction.respond(all.filter((c) => ownIds.has(c.value)));
+    } catch (err) {
+      logError('AiRpEdit autocomplete error:', err);
+      await interaction.respond([]).catch(() => {});
+    }
+  }
+
+  async run(interaction: any): Promise<void> {
+    const userId = interaction.user.id;
+    const character = await resolveCharOption(this.client.db, interaction.options.getString('char'));
+    if (!character) {
+      await interaction.editReply('No character matched that. Pick one from the suggestions.');
+      return;
+    }
+    if (character.creatorId !== userId) {
+      await interaction.editReply('You can only edit characters you created.');
+      return;
+    }
+
+    const newName = interaction.options.getString('name') ?? character.name;
+    const newDetails = interaction.options.getString('details') ?? character.details;
+    const newStarting = interaction.options.getString('starting_message') ?? character.startingMessage;
+    const attachment = interaction.options.getAttachment('pfp');
+
+    if (interaction.options.getString('name')) {
+      const nameError = validateCharName(newName);
+      if (nameError) { await interaction.editReply(nameError); return; }
+    }
+    if (newDetails.length > DETAILS_MAX_LENGTH) {
+      await interaction.editReply(`Details are too long (max ${DETAILS_MAX_LENGTH} characters).`); return;
+    }
+    if (newStarting.length > STARTING_MESSAGE_MAX_LENGTH) {
+      await interaction.editReply(`Starting message is too long (max ${STARTING_MESSAGE_MAX_LENGTH} characters).`); return;
+    }
+
+    let processedBuffer: Buffer | null = null;
+    if (attachment) {
+      const processed = await processAvatar(attachment);
+      if (!processed.ok) { await interaction.editReply(processed.error); return; }
+      processedBuffer = processed.buffer;
+    }
+
+    try {
+      await this.client.db.rp.updateCharacter(character.charId, userId, {
+        name: newName, details: newDetails, startingMessage: newStarting,
+      });
+
+      let pfpWarning = '';
+      if (processedBuffer) {
+        const hosted = await hostAvatar(
+          this.client,
+          this.client.db,
+          interaction.guild.id,
+          character.charId,
+          processedBuffer,
+        );
+        if (hosted.ok) {
+          await this.client.db.rp.updateCharacterPfp(character.charId, {
+            url: hosted.url, messageId: hosted.messageId, channelId: hosted.channelId,
+          });
+        } else {
+          pfpWarning = `\n\n⚠️ Details saved, but the avatar wasn't updated: ${hosted.error}`;
+        }
+      }
+
+      const fresh = await this.client.db.rp.getCharacter(character.charId);
+      const embed = await characterEmbed(this.client, this.client.db, fresh, `@${interaction.user.username}`);
+      await interaction.editReply({
+        content: `Updated **${newName}** \`${formatCharHandle(newName, character.charId)}\`. Live spawns pick up the change on their next reply.${pfpWarning}`,
+        embeds: [embed],
+      });
+    } catch (err) {
+      logError('AiRpEdit error:', err);
+      await interaction.editReply('Failed to edit the character. Please try again.');
+    }
+  }
+}
+
+export default AiRpEdit;

--- a/commands/ai_rp_edit.ts
+++ b/commands/ai_rp_edit.ts
@@ -3,7 +3,7 @@ import {
   DETAILS_OPTION_MAX_LENGTH, STARTING_MESSAGE_MAX_LENGTH, NAME_MAX_LENGTH, formatCharHandle,
 } from '../utils/rpIdentity';
 import { processAvatar, hostAvatar } from '../utils/rpAvatar';
-import { resolveCharOption, buildCharSearchChoices, buildCharacterView } from '../utils/rpCommand';
+import { resolveCharOption, buildCharacterView } from '../utils/rpCommand';
 import {
   loadCharacterJson, validateName, validateDetails, validateStartingMessage,
 } from '../utils/rpCharInput';
@@ -37,11 +37,14 @@ class AiRpEdit extends Command {
   async autocomplete(interaction: any): Promise<void> {
     try {
       const focused = interaction.options.getFocused();
-      const all = await buildCharSearchChoices(this.client.db, this.client, focused);
-      // Only suggest the user's own characters.
-      const owned = await this.client.db.rp.searchCharacters(focused);
-      const ownIds = new Set(owned.filter((r: any) => r.creatorId === interaction.user.id).map((r: any) => r.charId));
-      await interaction.respond(all.filter((c) => ownIds.has(c.value)));
+      // Scope the search to the caller's own characters up front, so their matches
+      // aren't dropped when other users' characters fill the global top-25.
+      const owned = await this.client.db.rp.searchOwnCharacters(interaction.user.id, focused);
+      const choices = owned.slice(0, 25).map((r: any) => ({
+        name: `${r.name} · ${r.charId}`.slice(0, 100),
+        value: r.charId,
+      }));
+      await interaction.respond(choices);
     } catch (err) {
       logError('AiRpEdit autocomplete error:', err);
       await interaction.respond([]).catch(() => {});

--- a/commands/ai_rp_remove.ts
+++ b/commands/ai_rp_remove.ts
@@ -1,0 +1,78 @@
+import { Command } from './classes/Command';
+import { isAdmin } from '../utils/accessControl';
+import { resolveCharOption } from '../utils/rpCommand';
+import { refreshRpChannel } from '../utils/rpRuntime';
+import { logError } from '../utils/log';
+
+/** Removes a character from this channel. Optionally wipes its memory of the channel. */
+class AiRpRemove extends Command {
+  constructor(client: any) {
+    super(client, 'rp-remove', 'Remove a roleplay character from this channel', [
+      {
+        name: 'char', description: 'Character spawned here (search by name or id)', type: 3, required: true, autocomplete: true,
+      },
+      {
+        name: 'clear_history',
+        description: 'Also wipe its memory of this channel (default: keep)',
+        type: 5,
+        required: false,
+      },
+    ], { isSubcommandOf: 'ai', blame: 'xei', ephemeral: true });
+  }
+
+  async autocomplete(interaction: any): Promise<void> {
+    try {
+      const term = (interaction.options.getFocused() || '').toLowerCase();
+      const spawns = await this.client.db.rp.getActiveSpawnsInChannel(interaction.channelId);
+      const choices = spawns
+        .filter((s: any) => !term || s.charNameLower.includes(term) || s.charId.includes(term))
+        .slice(0, 25)
+        .map((s: any) => ({ name: `${s.charName} · ${s.charId}`, value: s.charId }));
+      await interaction.respond(choices);
+    } catch (err) {
+      logError('AiRpRemove autocomplete error:', err);
+      await interaction.respond([]).catch(() => {});
+    }
+  }
+
+  async run(interaction: any): Promise<void> {
+    const character = await resolveCharOption(this.client.db, interaction.options.getString('char'));
+    if (!character) {
+      await interaction.editReply('No character matched that.');
+      return;
+    }
+
+    const spawn = await this.client.db.rp.getSpawn(interaction.channelId, character.charId);
+    if (!spawn || spawn.active !== 1) {
+      await interaction.editReply(`**${character.name}** isn't spawned in this channel.`);
+      return;
+    }
+
+    if (spawn.spawnerId !== interaction.user.id && !isAdmin(interaction)) {
+      await interaction.editReply('Only the person who spawned it (or an admin) can remove it.');
+      return;
+    }
+
+    const clearHistory = interaction.options.getBoolean('clear_history') ?? false;
+    try {
+      await this.client.db.rp.deactivateSpawn(spawn.spawnId);
+      if (clearHistory) {
+        await this.client.db.rp.deleteHistoryBySpawn(spawn.spawnId);
+        await this.client.db.rp.resetCompaction(spawn.spawnId);
+      }
+      await refreshRpChannel(this.client.db, interaction.channelId);
+
+      await interaction.editReply(
+        `Removed **${character.name}** from this channel.${
+          clearHistory
+            ? ' Its memory of this channel was wiped — a fresh spawn will start over.'
+            : ' Its conversation is kept and will resume if you spawn it here again.'}`,
+      );
+    } catch (err) {
+      logError('AiRpRemove error:', err);
+      await interaction.editReply('Failed to remove the character. Please try again.');
+    }
+  }
+}
+
+export default AiRpRemove;

--- a/commands/ai_rp_remove.ts
+++ b/commands/ai_rp_remove.ts
@@ -56,11 +56,9 @@ class AiRpRemove extends Command {
     const clearHistory = interaction.options.getBoolean('clear_history') ?? false;
     try {
       const spawnerLabel = await resolveCreatorLabel(this.client, spawn.spawnerId);
-      await this.client.db.rp.deactivateSpawn(spawn.spawnId);
-      if (clearHistory) {
-        await this.client.db.rp.deleteHistoryBySpawn(spawn.spawnId);
-        await this.client.db.rp.resetCompaction(spawn.spawnId);
-      }
+      // One atomic op: deactivate (+ optionally wipe history & compaction) together,
+      // so a mid-way failure can't leave the spawn half-cleared.
+      await this.client.db.rp.removeSpawn(spawn.spawnId, clearHistory);
       await refreshRpChannel(this.client.db, interaction.channelId);
 
       await interaction.editReply(

--- a/commands/ai_rp_remove.ts
+++ b/commands/ai_rp_remove.ts
@@ -1,6 +1,6 @@
 import { Command } from './classes/Command';
 import { isAdmin } from '../utils/accessControl';
-import { resolveCharOption } from '../utils/rpCommand';
+import { resolveCharOption, resolveCreatorLabel } from '../utils/rpCommand';
 import { refreshRpChannel } from '../utils/rpRuntime';
 import { logError } from '../utils/log';
 
@@ -55,6 +55,7 @@ class AiRpRemove extends Command {
 
     const clearHistory = interaction.options.getBoolean('clear_history') ?? false;
     try {
+      const spawnerLabel = await resolveCreatorLabel(this.client, spawn.spawnerId);
       await this.client.db.rp.deactivateSpawn(spawn.spawnId);
       if (clearHistory) {
         await this.client.db.rp.deleteHistoryBySpawn(spawn.spawnId);
@@ -63,7 +64,7 @@ class AiRpRemove extends Command {
       await refreshRpChannel(this.client.db, interaction.channelId);
 
       await interaction.editReply(
-        `Removed **${character.name}** from this channel.${
+        `Removed **${character.name}** (spawned by ${spawnerLabel}) from this channel.${
           clearHistory
             ? ' Its memory of this channel was wiped — a fresh spawn will start over.'
             : ' Its conversation is kept and will resume if you spawn it here again.'}`,

--- a/commands/ai_rp_setasset.ts
+++ b/commands/ai_rp_setasset.ts
@@ -1,0 +1,34 @@
+import { AdminCommand } from './classes/AdminCommand';
+import { ASSET_CHANNEL_KEY } from '../utils/rpAvatar';
+import { logError } from '../utils/log';
+
+/** Admin: choose the channel where roleplay character pfps are uploaded/hosted. */
+class AiRpSetAsset extends AdminCommand {
+  constructor(client: any) {
+    super(client, 'rp-setasset', 'Set the channel where roleplay character avatars are hosted', [
+      {
+        name: 'channel',
+        description: 'Channel to store character avatars in (bot needs send + embed perms there)',
+        type: 7,
+        required: true,
+        channel_types: [0],
+      },
+    ], { isSubcommandOf: 'ai', blame: 'xei', ephemeral: true });
+  }
+
+  async run(interaction: any): Promise<void> {
+    const channel = interaction.options.getChannel('channel');
+    try {
+      await this.client.db.serverConfig.setServerConfig(interaction.guild.id, ASSET_CHANNEL_KEY, channel.id);
+      await interaction.editReply(
+        `Roleplay asset channel set to <#${channel.id}>. New character avatars will be uploaded there — `
+        + 'don\'t delete those messages or the avatars will break.',
+      );
+    } catch (err) {
+      logError('AiRpSetAsset error:', err);
+      await interaction.editReply('Failed to set the asset channel. Please try again.');
+    }
+  }
+}
+
+export default AiRpSetAsset;

--- a/commands/ai_rp_spawn.ts
+++ b/commands/ai_rp_spawn.ts
@@ -1,0 +1,121 @@
+import { Command } from './classes/Command';
+import { MAX_SPAWNS_PER_CHANNEL } from '../utils/rpIdentity';
+import { resolveCharOption, buildCharSearchChoices } from '../utils/rpCommand';
+import { markRpChannelActive } from '../utils/rpRuntime';
+import { sendAsCharacter } from '../utils/rpDelivery';
+import { logError } from '../utils/log';
+
+/** Spawns a character into the current channel (or reconfigures an existing spawn). */
+class AiRpSpawn extends Command {
+  constructor(client: any) {
+    super(client, 'rp-spawn', 'Spawn a roleplay character into this channel', [
+      {
+        name: 'char', description: 'Character to spawn (search by name or id)', type: 3, required: true, autocomplete: true,
+      },
+      {
+        name: 'interactability',
+        description: 'Who it responds to',
+        type: 3,
+        required: true,
+        choices: [
+          { name: 'self — only you can interact', value: 'self' },
+          { name: 'all — anyone; it also chimes in on its own', value: 'all' },
+        ],
+      },
+      {
+        name: 'compaction',
+        description: 'Auto-summarize old messages to extend memory (default: enabled)',
+        type: 3,
+        required: false,
+        choices: [
+          { name: 'enabled', value: 'enabled' },
+          { name: 'disabled', value: 'disabled' },
+        ],
+      },
+    ], { isSubcommandOf: 'ai', blame: 'xei', ephemeral: true });
+  }
+
+  async autocomplete(interaction: any): Promise<void> {
+    try {
+      const choices = await buildCharSearchChoices(this.client.db, this.client, interaction.options.getFocused());
+      await interaction.respond(choices);
+    } catch (err) {
+      logError('AiRpSpawn autocomplete error:', err);
+      await interaction.respond([]).catch(() => {});
+    }
+  }
+
+  async run(interaction: any): Promise<void> {
+    const channel = interaction.channel;
+    if (!channel || typeof channel.fetchWebhooks !== 'function') {
+      await interaction.editReply('Characters can only be spawned in normal text channels.');
+      return;
+    }
+
+    const character = await resolveCharOption(this.client.db, interaction.options.getString('char'));
+    if (!character) {
+      await interaction.editReply('No character matched that. Pick one from the suggestions.');
+      return;
+    }
+
+    const interactability = interaction.options.getString('interactability') as 'self' | 'all';
+    const compactionEnabled = (interaction.options.getString('compaction') ?? 'enabled') === 'enabled';
+
+    try {
+      const result = await this.client.db.rp.trySpawn({
+        channelId: channel.id,
+        guildId: interaction.guild.id,
+        charId: character.charId,
+        spawnerId: interaction.user.id,
+        interactability,
+        compactionEnabled,
+      });
+
+      if (!result.ok) {
+        await interaction.editReply(
+          `This channel already has the maximum of ${MAX_SPAWNS_PER_CHANNEL} characters. `
+          + 'Remove one with `/ai rp-remove` first.',
+        );
+        return;
+      }
+
+      markRpChannelActive(channel.id);
+      const compactionLabel = compactionEnabled ? 'enabled' : 'disabled';
+
+      if (result.reconfigured) {
+        await interaction.editReply(
+          `Updated **${character.name}**'s settings here — interactability **${interactability}**, compaction **${compactionLabel}**.`,
+        );
+        return;
+      }
+
+      const historyCount = await this.client.db.rp.countHistory(result.spawnId);
+      await interaction.editReply(
+        `Spawned **${character.name}** here — interactability **${interactability}**, compaction **${compactionLabel}**.${
+          historyCount > 0 ? ' Resumed its existing conversation.' : ''}`,
+      );
+
+      // Brand-new conversation → post the opening message as the character.
+      if (historyCount === 0 && character.startingMessage) {
+        await sendAsCharacter({
+          client: this.client,
+          db: this.client.db,
+          channel,
+          character: {
+            charId: character.charId,
+            name: character.name,
+            pfpUrl: character.pfpUrl,
+            pfpMessageId: character.pfpMessageId,
+            pfpChannelId: character.pfpChannelId,
+          },
+          text: character.startingMessage,
+        });
+      }
+    } catch (err) {
+      logError('AiRpSpawn error:', err);
+      await interaction.editReply('Failed to spawn the character. Please try again.');
+    }
+  }
+}
+
+export default AiRpSpawn;

--- a/commands/ai_rp_spawn.ts
+++ b/commands/ai_rp_spawn.ts
@@ -90,19 +90,16 @@ class AiRpSpawn extends Command {
       }
 
       const historyCount = await this.client.db.rp.countHistory(result.spawnId);
-      await interaction.editReply(
-        `Spawned **${character.name}** here — interactability **${interactability}**, compaction **${compactionLabel}**.${
-          historyCount > 0 ? ' Resumed its existing conversation.' : ''}`,
-      );
 
       // Brand-new conversation → post the opening message as the character.
+      let openerWarning = '';
       if (historyCount === 0 && character.startingMessage) {
         // Self-mode resolves {user} to the spawner; all-mode leaves it literal.
         const spawnerName = interaction.member?.displayName || interaction.user.username;
         const startingText = interactability === 'self'
           ? applyUserVar(character.startingMessage, spawnerName)
           : character.startingMessage;
-        await sendAsCharacter({
+        const delivered = await sendAsCharacter({
           client: this.client,
           db: this.client.db,
           channel,
@@ -115,7 +112,16 @@ class AiRpSpawn extends Command {
           },
           text: startingText,
         });
+        if (!delivered) {
+          openerWarning = '\n\n⚠️ The spawn is active, but I couldn\'t post its opening message here — '
+            + 'check that I have the **Manage Webhooks** permission in this channel.';
+        }
       }
+
+      await interaction.editReply(
+        `Spawned **${character.name}** here — interactability **${interactability}**, compaction **${compactionLabel}**.${
+          historyCount > 0 ? ' Resumed its existing conversation.' : ''}${openerWarning}`,
+      );
     } catch (err) {
       logError('AiRpSpawn error:', err);
       await interaction.editReply('Failed to spawn the character. Please try again.');

--- a/commands/ai_rp_spawn.ts
+++ b/commands/ai_rp_spawn.ts
@@ -1,5 +1,5 @@
 import { Command } from './classes/Command';
-import { MAX_SPAWNS_PER_CHANNEL } from '../utils/rpIdentity';
+import { MAX_SPAWNS_PER_CHANNEL, applyUserVar } from '../utils/rpIdentity';
 import { resolveCharOption, buildCharSearchChoices } from '../utils/rpCommand';
 import { markRpChannelActive } from '../utils/rpRuntime';
 import { sendAsCharacter } from '../utils/rpDelivery';
@@ -97,6 +97,11 @@ class AiRpSpawn extends Command {
 
       // Brand-new conversation → post the opening message as the character.
       if (historyCount === 0 && character.startingMessage) {
+        // Self-mode resolves {user} to the spawner; all-mode leaves it literal.
+        const spawnerName = interaction.member?.displayName || interaction.user.username;
+        const startingText = interactability === 'self'
+          ? applyUserVar(character.startingMessage, spawnerName)
+          : character.startingMessage;
         await sendAsCharacter({
           client: this.client,
           db: this.client.db,
@@ -108,7 +113,7 @@ class AiRpSpawn extends Command {
             pfpMessageId: character.pfpMessageId,
             pfpChannelId: character.pfpChannelId,
           },
-          text: character.startingMessage,
+          text: startingText,
         });
       }
     } catch (err) {

--- a/commands/commandgroups/ai.ts
+++ b/commands/commandgroups/ai.ts
@@ -2,6 +2,9 @@ import { CommandGroup } from '../classes/commandGroup';
 
 export default class Ai extends CommandGroup {
   constructor(client: any) {
-    super(client, 'ai', 'Manage your AI chat sessions', ['view', 'chatnew', 'chatswitch', 'chatdelete', 'retitle']);
+    super(client, 'ai', 'Manage your AI chat sessions', [
+      'view', 'chatnew', 'chatswitch', 'chatdelete', 'retitle',
+      'rp-create-char', 'rp-details', 'rp-edit', 'rp-spawn', 'rp-remove', 'rp-setasset',
+    ]);
   }
 }

--- a/database/Database.ts
+++ b/database/Database.ts
@@ -5,6 +5,7 @@ import * as tables from './tables';
 import serverConfigQueries from './queries/serverConfigQueries';
 import imageGenQueries from './queries/imageGenQueries';
 import battleshipsMatchQueries from './queries/battleshipsMatchQueries';
+import rpQueries from './queries/rpQueries';
 import * as modelClasses from './models';
 import type { TableDefinition, QueryResult } from './types';
 import type UserModel from './models/UserModel';
@@ -22,6 +23,7 @@ import type ServerConfigModel from './models/ServerConfigModel';
 import type BirthdayReminderModel from './models/BirthdayReminderModel';
 import type FootballMatchAnnouncementModel from './models/FootballMatchAnnouncementModel';
 import type PoopModel from './models/PoopModel';
+import type RpModel from './models/RpModel';
 import type WebSessionModel from './models/WebSessionModel';
 
 class Database {
@@ -174,6 +176,13 @@ class Database {
     // Back the per-user recent battleships-match lookup (GET_RECENT_FOR_USER).
     this.db.run(battleshipsMatchQueries.CREATE_INDEX_X_RECENT);
     this.db.run(battleshipsMatchQueries.CREATE_INDEX_O_RECENT);
+
+    // Roleplay: mention routing, the proactive "all"-mode scan, and search.
+    this.db.run(rpQueries.CREATE_INDEX_SPAWN_CHANNEL);
+    this.db.run(rpQueries.CREATE_INDEX_SPAWN_ALL);
+    this.db.run(rpQueries.CREATE_INDEX_HISTORY_SPAWN);
+    this.db.run(rpQueries.CREATE_INDEX_CHAR_NAME);
+    this.db.run(rpQueries.CREATE_INDEX_CHAR_CREATOR);
 
     // Migrate legacy ServerRoles into ServerConfig when opening an older database.
     this.migrateLegacyServerRolesIfNeeded();
@@ -332,6 +341,7 @@ class Database {
   get marriage(): MarriageModel { return this.models.MarriageModel; }
   get pokemon(): PokemonModel { return this.models.PokemonModel; }
   get poop(): PoopModel { return this.models.PoopModel; }
+  get rp(): RpModel { return this.models.RpModel; }
   get serverConfig(): ServerConfigModel { return this.models.ServerConfigModel; }
   get user(): UserModel { return this.models.UserModel; }
   get webSession(): WebSessionModel { return this.models.WebSessionModel; }

--- a/database/models/RpModel.ts
+++ b/database/models/RpModel.ts
@@ -11,6 +11,10 @@ export interface SpawnResult {
   spawnId?: number;
 }
 
+export type CreateCharacterResult =
+  | { ok: true; character: Record<string, any> }
+  | { ok: false; reason: 'limit' };
+
 /** DAO for roleplay characters, their per-channel spawns, and private history. */
 class RpModel {
   private db: Database;
@@ -32,6 +36,12 @@ class RpModel {
     throw new Error('Could not allocate a unique character id');
   }
 
+  /**
+   * Creates a character. When `maxPerCreator` is given, the per-creator quota is
+   * enforced **inside the same transaction** as the insert, so two concurrent
+   * creates can't both slip past the limit. Throws (rather than silently returning a
+   * phantom "not found") if the insert doesn't actually persist.
+   */
   async createCharacter(params: {
     creatorId: string;
     name: string;
@@ -40,22 +50,36 @@ class RpModel {
     pfpUrl?: string | null;
     pfpMessageId?: string | null;
     pfpChannelId?: string | null;
-  }): Promise<Record<string, any> | null> {
+  }, maxPerCreator?: number): Promise<CreateCharacterResult> {
     await this.db.user.getUser(params.creatorId);
     const charId = await this.generateUniqueCharId();
-    await this.db.executeQuery(rpQueries.INSERT_CHARACTER, [
-      charId,
-      params.creatorId,
-      params.name,
-      params.name.toLowerCase(),
-      params.details,
-      params.startingMessage,
-      params.pfpUrl ?? null,
-      params.pfpMessageId ?? null,
-      params.pfpChannelId ?? null,
-    ]);
+    const outcome: { limited: boolean } = await this.db.executeTransaction((rawDb: any) => {
+      if (typeof maxPerCreator === 'number') {
+        const countRow = rawDb.query(rpQueries.COUNT_CHARACTERS_BY_CREATOR).get(params.creatorId) as any;
+        if ((countRow?.count ?? 0) >= maxPerCreator) return { limited: true };
+      }
+      const res = rawDb.query(rpQueries.INSERT_CHARACTER).run(
+        charId,
+        params.creatorId,
+        params.name,
+        params.name.toLowerCase(),
+        params.details,
+        params.startingMessage,
+        params.pfpUrl ?? null,
+        params.pfpMessageId ?? null,
+        params.pfpChannelId ?? null,
+      );
+      if ((res?.changes ?? 0) !== 1) {
+        throw new Error(`Failed to create RP character ${params.name} (${charId})`);
+      }
+      return { limited: false };
+    });
+
+    if (outcome.limited) return { ok: false, reason: 'limit' };
+    const created = await this.getCharacter(charId);
+    if (!created) throw new Error(`RP character ${charId} was inserted but could not be reloaded`);
     log(`Rp: created character ${params.name} (${charId}) by ${params.creatorId}`);
-    return this.getCharacter(charId);
+    return { ok: true, character: created };
   }
 
   async getCharacter(charId: string): Promise<Record<string, any> | null> {
@@ -102,6 +126,15 @@ class RpModel {
   async searchCharacters(term: string): Promise<Record<string, any>[]> {
     const cleaned = term.toLowerCase().replace(/[%_]/g, '');
     return this.db.executeSelectAllQuery(rpQueries.SEARCH_CHARACTERS, [`%${cleaned}%`, `${cleaned}%`]);
+  }
+
+  /** Search scoped to one creator, so the owner's matches aren't crowded out of the top-25. */
+  async searchOwnCharacters(creatorId: string, term: string): Promise<Record<string, any>[]> {
+    const cleaned = term.toLowerCase().replace(/[%_]/g, '');
+    return this.db.executeSelectAllQuery(
+      rpQueries.SEARCH_OWN_CHARACTERS,
+      [creatorId, `%${cleaned}%`, `${cleaned}%`],
+    );
   }
 
   // ── Spawns ──────────────────────────────────────────────────────────────
@@ -190,6 +223,21 @@ class RpModel {
 
   async deactivateSpawn(spawnId: number): Promise<void> {
     await this.db.executeQuery(rpQueries.DEACTIVATE_SPAWN, [spawnId]);
+  }
+
+  /**
+   * Removes a spawn (soft-delete), optionally wiping its history + compaction state,
+   * as one atomic transaction so a mid-way failure can't leave it half-cleared.
+   */
+  async removeSpawn(spawnId: number, clearHistory: boolean): Promise<void> {
+    await this.db.executeTransaction((rawDb: any) => {
+      rawDb.query(rpQueries.DEACTIVATE_SPAWN).run(spawnId);
+      if (clearHistory) {
+        rawDb.query(rpQueries.DELETE_HISTORY_BY_SPAWN).run(spawnId);
+        rawDb.query(rpQueries.RESET_COMPACTION).run(spawnId);
+      }
+      return undefined;
+    });
   }
 
   async touchSpawnActivity(spawnId: number): Promise<void> {

--- a/database/models/RpModel.ts
+++ b/database/models/RpModel.ts
@@ -1,0 +1,239 @@
+import rpQueries from '../queries/rpQueries';
+import { generateCharId, MAX_SPAWNS_PER_CHANNEL } from '../../utils/rpIdentity';
+import { log } from '../../utils/log';
+import type Database from '../Database';
+
+export interface SpawnResult {
+  ok: boolean;
+  reason?: 'limit';
+  /** True when the spawn was already active (a pure live reconfigure). */
+  reconfigured?: boolean;
+  spawnId?: number;
+}
+
+/** DAO for roleplay characters, their per-channel spawns, and private history. */
+class RpModel {
+  private db: Database;
+
+  constructor(db: Database) {
+    this.db = db;
+  }
+
+  // ── Characters ──────────────────────────────────────────────────────────
+
+  /** Generates a 6-char id not already in use (a handful of tries is plenty at 36^6). */
+  private async generateUniqueCharId(): Promise<string> {
+    for (let i = 0; i < 12; i += 1) {
+      const candidate = generateCharId();
+      // eslint-disable-next-line no-await-in-loop
+      const existing = await this.getCharacter(candidate);
+      if (!existing) return candidate;
+    }
+    throw new Error('Could not allocate a unique character id');
+  }
+
+  async createCharacter(params: {
+    creatorId: string;
+    name: string;
+    details: string;
+    startingMessage: string;
+    pfpUrl?: string | null;
+    pfpMessageId?: string | null;
+    pfpChannelId?: string | null;
+  }): Promise<Record<string, any> | null> {
+    await this.db.user.getUser(params.creatorId);
+    const charId = await this.generateUniqueCharId();
+    await this.db.executeQuery(rpQueries.INSERT_CHARACTER, [
+      charId,
+      params.creatorId,
+      params.name,
+      params.name.toLowerCase(),
+      params.details,
+      params.startingMessage,
+      params.pfpUrl ?? null,
+      params.pfpMessageId ?? null,
+      params.pfpChannelId ?? null,
+    ]);
+    log(`Rp: created character ${params.name} (${charId}) by ${params.creatorId}`);
+    return this.getCharacter(charId);
+  }
+
+  async getCharacter(charId: string): Promise<Record<string, any> | null> {
+    return this.db.executeSelectQuery(rpQueries.GET_CHARACTER_BY_ID, [charId]);
+  }
+
+  async countCharactersByCreator(creatorId: string): Promise<number> {
+    const row = await this.db.executeSelectQuery(rpQueries.COUNT_CHARACTERS_BY_CREATOR, [creatorId]);
+    return row?.count ?? 0;
+  }
+
+  /** Updates definition fields; returns false if the requester isn't the owner. */
+  async updateCharacter(charId: string, creatorId: string, params: {
+    name: string;
+    details: string;
+    startingMessage: string;
+  }): Promise<boolean> {
+    const res = await this.db.executeQuery(rpQueries.UPDATE_CHARACTER, [
+      params.name,
+      params.name.toLowerCase(),
+      params.details,
+      params.startingMessage,
+      charId,
+      creatorId,
+    ]);
+    return (res.changes ?? 0) > 0;
+  }
+
+  async updateCharacterPfp(charId: string, pfp: {
+    url: string | null;
+    messageId: string | null;
+    channelId: string | null;
+  }): Promise<void> {
+    await this.db.executeQuery(rpQueries.UPDATE_CHARACTER_PFP, [
+      pfp.url, pfp.messageId, pfp.channelId, charId,
+    ]);
+  }
+
+  /** Marks the cached CDN url as broken so delivery falls back to a default avatar. */
+  async clearCharacterPfpUrl(charId: string): Promise<void> {
+    await this.db.executeQuery(rpQueries.CLEAR_CHARACTER_PFP_URL, [charId]);
+  }
+
+  async searchCharacters(term: string): Promise<Record<string, any>[]> {
+    const cleaned = term.toLowerCase().replace(/[%_]/g, '');
+    return this.db.executeSelectAllQuery(rpQueries.SEARCH_CHARACTERS, [`%${cleaned}%`, `${cleaned}%`]);
+  }
+
+  // ── Spawns ──────────────────────────────────────────────────────────────
+
+  async getSpawn(channelId: string, charId: string): Promise<Record<string, any> | null> {
+    return this.db.executeSelectQuery(rpQueries.GET_SPAWN, [channelId, charId]);
+  }
+
+  async getSpawnById(spawnId: number): Promise<Record<string, any> | null> {
+    return this.db.executeSelectQuery(rpQueries.GET_SPAWN_BY_ID, [spawnId]);
+  }
+
+  async getActiveSpawnsInChannel(channelId: string): Promise<Record<string, any>[]> {
+    return this.db.executeSelectAllQuery(rpQueries.GET_ACTIVE_SPAWNS_IN_CHANNEL, [channelId]);
+  }
+
+  async getActiveAllSpawns(): Promise<Record<string, any>[]> {
+    return this.db.executeSelectAllQuery(rpQueries.GET_ACTIVE_ALL_SPAWNS, []);
+  }
+
+  /** Distinct channel ids with at least one active spawn (for the router fast-path). */
+  async getDistinctActiveChannels(): Promise<string[]> {
+    const rows = await this.db.executeSelectAllQuery(rpQueries.GET_DISTINCT_ACTIVE_CHANNELS, []);
+    return rows.map((r) => r.channelId);
+  }
+
+  /** Role of the newest history turn, or null when there is none. */
+  async getLastHistoryRole(spawnId: number): Promise<'user' | 'model' | null> {
+    const row = await this.db.executeSelectQuery(rpQueries.GET_LAST_HISTORY_ROLE, [spawnId]);
+    return (row?.role as 'user' | 'model') ?? null;
+  }
+
+  /**
+   * Spawns (or reactivates/reconfigures) a character in a channel, enforcing the
+   * per-channel cap transactionally. Reactivating a removed spawn or a brand-new
+   * one counts against the cap; a pure reconfigure of an already-active spawn does not.
+   */
+  async trySpawn(params: {
+    channelId: string;
+    guildId: string;
+    charId: string;
+    spawnerId: string;
+    interactability: 'self' | 'all';
+    compactionEnabled: boolean;
+  }): Promise<SpawnResult> {
+    const compactionInt = params.compactionEnabled ? 1 : 0;
+    const result: SpawnResult = await this.db.executeTransaction((rawDb: any) => {
+      const existing = rawDb.query(rpQueries.GET_SPAWN).get(params.channelId, params.charId) as any;
+      const isActive = !!existing && existing.active === 1;
+
+      if (!isActive) {
+        const countRow = rawDb.query(rpQueries.COUNT_ACTIVE_SPAWNS_IN_CHANNEL).get(params.channelId) as any;
+        if ((countRow?.count ?? 0) >= MAX_SPAWNS_PER_CHANNEL) {
+          return { ok: false, reason: 'limit' } as SpawnResult;
+        }
+      }
+
+      if (existing) {
+        rawDb.query(rpQueries.REACTIVATE_SPAWN).run(
+          params.spawnerId,
+          params.interactability,
+          compactionInt,
+          existing.spawn_id,
+        );
+        return { ok: true, reconfigured: isActive, spawnId: existing.spawn_id } as SpawnResult;
+      }
+
+      rawDb.query(rpQueries.INSERT_SPAWN).run(
+        params.channelId,
+        params.guildId,
+        params.charId,
+        params.spawnerId,
+        params.interactability,
+        compactionInt,
+      );
+      const newId = (rawDb.query('SELECT last_insert_rowid() AS id').get() as any).id;
+      return { ok: true, reconfigured: false, spawnId: newId } as SpawnResult;
+    });
+    return result;
+  }
+
+  async countActiveSpawnsInChannel(channelId: string): Promise<number> {
+    const row = await this.db.executeSelectQuery(rpQueries.COUNT_ACTIVE_SPAWNS_IN_CHANNEL, [channelId]);
+    return row?.count ?? 0;
+  }
+
+  async deactivateSpawn(spawnId: number): Promise<void> {
+    await this.db.executeQuery(rpQueries.DEACTIVATE_SPAWN, [spawnId]);
+  }
+
+  async touchSpawnActivity(spawnId: number): Promise<void> {
+    await this.db.executeQuery(rpQueries.TOUCH_SPAWN_ACTIVITY, [spawnId]);
+  }
+
+  async setCompactionState(spawnId: number, memory: string, uptoId: number): Promise<void> {
+    await this.db.executeQuery(rpQueries.SET_COMPACTION_STATE, [memory, uptoId, spawnId]);
+  }
+
+  async setCompactionFailed(spawnId: number, failed: boolean): Promise<void> {
+    await this.db.executeQuery(rpQueries.SET_COMPACTION_FAILED, [failed ? 1 : 0, spawnId]);
+  }
+
+  async resetCompaction(spawnId: number): Promise<void> {
+    await this.db.executeQuery(rpQueries.RESET_COMPACTION, [spawnId]);
+  }
+
+  // ── History ─────────────────────────────────────────────────────────────
+
+  async addHistory(
+    spawnId: number,
+    role: 'user' | 'model',
+    message: string,
+    speaker?: { id: string | null; name: string | null },
+  ): Promise<void> {
+    await this.db.executeQuery(rpQueries.ADD_HISTORY, [
+      spawnId, role, speaker?.id ?? null, speaker?.name ?? null, message,
+    ]);
+  }
+
+  /** Un-compacted tail (rows newer than `afterId`), oldest first. */
+  async getHistoryAfter(spawnId: number, afterId: number): Promise<Record<string, any>[]> {
+    return this.db.executeSelectAllQuery(rpQueries.GET_HISTORY_AFTER, [spawnId, afterId]);
+  }
+
+  async countHistory(spawnId: number): Promise<number> {
+    const row = await this.db.executeSelectQuery(rpQueries.COUNT_HISTORY, [spawnId]);
+    return row?.count ?? 0;
+  }
+
+  async deleteHistoryBySpawn(spawnId: number): Promise<void> {
+    await this.db.executeQuery(rpQueries.DELETE_HISTORY_BY_SPAWN, [spawnId]);
+  }
+}
+
+export default RpModel;

--- a/database/models/index.ts
+++ b/database/models/index.ts
@@ -11,6 +11,7 @@ import ImageGenModel from './ImageGenModel';
 import MarriageModel from './MarriageModel';
 import PokemonModel from './PokemonModel';
 import PoopModel from './PoopModel';
+import RpModel from './RpModel';
 import ServerConfigModel from './ServerConfigModel';
 import UserModel from './UserModel';
 import WebSessionModel from './WebSessionModel';
@@ -29,6 +30,7 @@ export {
   MarriageModel,
   PokemonModel,
   PoopModel,
+  RpModel,
   ServerConfigModel,
   UserModel,
   WebSessionModel,

--- a/database/queries/rpQueries.ts
+++ b/database/queries/rpQueries.ts
@@ -1,0 +1,103 @@
+const rpQueries = {
+  // ── Characters ────────────────────────────────────────────────────────────
+  INSERT_CHARACTER: `
+    INSERT INTO RpCharacter
+      (char_id, creator_id, name, name_lower, details, starting_message, pfp_url, pfp_message_id, pfp_channel_id)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `,
+  GET_CHARACTER_BY_ID: 'SELECT * FROM RpCharacter WHERE char_id = ?',
+  COUNT_CHARACTERS_BY_CREATOR: 'SELECT COUNT(*) AS count FROM RpCharacter WHERE creator_id = ?',
+  // Ownership is enforced in the WHERE clause: a non-owner update changes 0 rows.
+  UPDATE_CHARACTER: `
+    UPDATE RpCharacter
+    SET name = ?, name_lower = ?, details = ?, starting_message = ?, updated_at = CURRENT_TIMESTAMP
+    WHERE char_id = ? AND creator_id = ?
+  `,
+  UPDATE_CHARACTER_PFP: `
+    UPDATE RpCharacter
+    SET pfp_url = ?, pfp_message_id = ?, pfp_channel_id = ?, updated_at = CURRENT_TIMESTAMP
+    WHERE char_id = ?
+  `,
+  CLEAR_CHARACTER_PFP_URL: 'UPDATE RpCharacter SET pfp_url = NULL WHERE char_id = ?',
+  // Substring search over name, plus id prefix. Caller passes ('%term%', 'term%').
+  SEARCH_CHARACTERS: `
+    SELECT char_id, creator_id, name, name_lower
+    FROM RpCharacter
+    WHERE name_lower LIKE ? OR char_id LIKE ?
+    ORDER BY name_lower ASC
+    LIMIT 25
+  `,
+
+  // ── Spawns ────────────────────────────────────────────────────────────────
+  GET_SPAWN: 'SELECT * FROM RpSpawn WHERE channel_id = ? AND char_id = ?',
+  GET_SPAWN_BY_ID: 'SELECT * FROM RpSpawn WHERE spawn_id = ?',
+  INSERT_SPAWN: `
+    INSERT INTO RpSpawn (channel_id, guild_id, char_id, spawner_id, interactability, compaction_enabled)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `,
+  // Re-spawn / reconfigure: reactivate and overwrite the live params (never the
+  // character definition). Compaction state and history are left untouched.
+  REACTIVATE_SPAWN: `
+    UPDATE RpSpawn
+    SET active = 1, spawner_id = ?, interactability = ?, compaction_enabled = ?,
+        last_activity_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+    WHERE spawn_id = ?
+  `,
+  DEACTIVATE_SPAWN: 'UPDATE RpSpawn SET active = 0, updated_at = CURRENT_TIMESTAMP WHERE spawn_id = ?',
+  COUNT_ACTIVE_SPAWNS_IN_CHANNEL: 'SELECT COUNT(*) AS count FROM RpSpawn WHERE channel_id = ? AND active = 1',
+  // Active spawns in a channel + their character definition, for the mention router.
+  GET_ACTIVE_SPAWNS_IN_CHANNEL: `
+    SELECT s.*, c.name AS char_name, c.name_lower AS char_name_lower, c.details AS char_details,
+           c.starting_message AS char_starting_message, c.creator_id AS char_creator_id,
+           c.pfp_url AS char_pfp_url, c.pfp_message_id AS char_pfp_message_id,
+           c.pfp_channel_id AS char_pfp_channel_id
+    FROM RpSpawn s
+    JOIN RpCharacter c ON c.char_id = s.char_id
+    WHERE s.channel_id = ? AND s.active = 1
+  `,
+  // Every active "all"-mode spawn across all channels, for the proactive scheduler.
+  GET_ACTIVE_ALL_SPAWNS: `
+    SELECT s.*, c.name AS char_name, c.details AS char_details,
+           c.starting_message AS char_starting_message,
+           c.pfp_url AS char_pfp_url, c.pfp_message_id AS char_pfp_message_id,
+           c.pfp_channel_id AS char_pfp_channel_id
+    FROM RpSpawn s
+    JOIN RpCharacter c ON c.char_id = s.char_id
+    WHERE s.active = 1 AND s.interactability = 'all' AND s.compaction_failed = 0
+  `,
+  TOUCH_SPAWN_ACTIVITY: 'UPDATE RpSpawn SET last_activity_at = CURRENT_TIMESTAMP WHERE spawn_id = ?',
+  // Channels with at least one active spawn — used to build the in-memory fast-path set.
+  GET_DISTINCT_ACTIVE_CHANNELS: 'SELECT DISTINCT channel_id FROM RpSpawn WHERE active = 1',
+  SET_COMPACTION_STATE: `
+    UPDATE RpSpawn
+    SET compacted_memory = ?, compacted_upto_id = ?, compaction_failed = 0, updated_at = CURRENT_TIMESTAMP
+    WHERE spawn_id = ?
+  `,
+  SET_COMPACTION_FAILED: 'UPDATE RpSpawn SET compaction_failed = ? WHERE spawn_id = ?',
+  RESET_COMPACTION: `
+    UPDATE RpSpawn
+    SET compacted_memory = NULL, compacted_upto_id = NULL, compaction_failed = 0, updated_at = CURRENT_TIMESTAMP
+    WHERE spawn_id = ?
+  `,
+
+  // ── History ───────────────────────────────────────────────────────────────
+  ADD_HISTORY: `
+    INSERT INTO RpHistory (spawn_id, role, speaker_id, speaker_name, message)
+    VALUES (?, ?, ?, ?, ?)
+  `,
+  // The un-compacted tail (rows newer than compacted_upto_id), oldest first.
+  GET_HISTORY_AFTER: 'SELECT * FROM RpHistory WHERE spawn_id = ? AND id > ? ORDER BY id ASC',
+  // Role of the newest turn — 'user' means the character has something to respond to.
+  GET_LAST_HISTORY_ROLE: 'SELECT role FROM RpHistory WHERE spawn_id = ? ORDER BY id DESC LIMIT 1',
+  COUNT_HISTORY: 'SELECT COUNT(*) AS count FROM RpHistory WHERE spawn_id = ?',
+  DELETE_HISTORY_BY_SPAWN: 'DELETE FROM RpHistory WHERE spawn_id = ?',
+
+  // ── Indexes (run on init) ─────────────────────────────────────────────────
+  CREATE_INDEX_SPAWN_CHANNEL: 'CREATE INDEX IF NOT EXISTS idx_rpspawn_channel_active ON RpSpawn (channel_id, active)',
+  CREATE_INDEX_SPAWN_ALL: 'CREATE INDEX IF NOT EXISTS idx_rpspawn_active_interact ON RpSpawn (active, interactability)',
+  CREATE_INDEX_HISTORY_SPAWN: 'CREATE INDEX IF NOT EXISTS idx_rphistory_spawn_id ON RpHistory (spawn_id, id)',
+  CREATE_INDEX_CHAR_NAME: 'CREATE INDEX IF NOT EXISTS idx_rpcharacter_name_lower ON RpCharacter (name_lower)',
+  CREATE_INDEX_CHAR_CREATOR: 'CREATE INDEX IF NOT EXISTS idx_rpcharacter_creator ON RpCharacter (creator_id)',
+};
+
+export default rpQueries;

--- a/database/queries/rpQueries.ts
+++ b/database/queries/rpQueries.ts
@@ -27,6 +27,15 @@ const rpQueries = {
     ORDER BY name_lower ASC
     LIMIT 25
   `,
+  // Same search, scoped to one creator — so the owner's matches aren't crowded out of
+  // the top-25 by other users' characters. Caller passes (creatorId, '%term%', 'term%').
+  SEARCH_OWN_CHARACTERS: `
+    SELECT char_id, creator_id, name, name_lower
+    FROM RpCharacter
+    WHERE creator_id = ? AND (name_lower LIKE ? OR char_id LIKE ?)
+    ORDER BY name_lower ASC
+    LIMIT 25
+  `,
 
   // ── Spawns ────────────────────────────────────────────────────────────────
   GET_SPAWN: 'SELECT * FROM RpSpawn WHERE channel_id = ? AND char_id = ?',
@@ -37,9 +46,13 @@ const rpQueries = {
   `,
   // Re-spawn / reconfigure: reactivate and overwrite the live params (never the
   // character definition). Compaction state and history are left untouched.
+  // A deliberate re-spawn also clears a stale compaction_failed flag, so an all-mode
+  // character that previously hit a compaction failure can re-enter the proactive
+  // scheduler (GET_ACTIVE_ALL_SPAWNS filters out compaction_failed = 1).
   REACTIVATE_SPAWN: `
     UPDATE RpSpawn
     SET active = 1, spawner_id = ?, interactability = ?, compaction_enabled = ?,
+        compaction_failed = 0,
         last_activity_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
     WHERE spawn_id = ?
   `,

--- a/database/tables/index.ts
+++ b/database/tables/index.ts
@@ -13,6 +13,9 @@ import marriageTable from './marriageTable';
 import pokemonTable from './pokemonTable';
 import poopEntryTable from './poopEntryTable';
 import poopProfileTable from './poopProfileTable';
+import rpCharacterTable from './rpCharacterTable';
+import rpSpawnTable from './rpSpawnTable';
+import rpHistoryTable from './rpHistoryTable';
 import serverConfigTable from './serverConfigTable';
 import userTable from './userTable';
 import webSessionTable from './webSessionTable';
@@ -33,6 +36,9 @@ export {
   pokemonTable,
   poopEntryTable,
   poopProfileTable,
+  rpCharacterTable,
+  rpSpawnTable,
+  rpHistoryTable,
   serverConfigTable,
   userTable,
   webSessionTable,
@@ -52,6 +58,9 @@ export type { ImageGenLogRow } from './imageGenLogTable';
 export type { MarriageRow } from './marriageTable';
 export type { PokemonRow } from './pokemonTable';
 export type { PoopEntryRow } from './poopEntryTable';
+export type { RpCharacterRow } from './rpCharacterTable';
+export type { RpSpawnRow } from './rpSpawnTable';
+export type { RpHistoryRow } from './rpHistoryTable';
 export type { ServerConfigRow } from './serverConfigTable';
 export type { UserRow, UserStatsRow } from './userTable';
 export type { WebSessionRow } from './webSessionTable';

--- a/database/tables/rpCharacterTable.ts
+++ b/database/tables/rpCharacterTable.ts
@@ -1,0 +1,46 @@
+import type { TableDefinition } from '../types';
+
+/**
+ * A roleplay character *definition* (global, owned by its creator). Spawned into
+ * channels via RpSpawn. `char_id` is a 6-char lowercase alphanumeric handle that
+ * disambiguates same-named characters (see utils/rpIdentity.ts). The pfp is
+ * re-hosted in a server asset channel; we keep the message id so a fresh signed
+ * CDN url can be re-derived when the cached one expires.
+ */
+export interface RpCharacterRow {
+  char_id: string;
+  creator_id: string;
+  name: string;
+  name_lower: string;
+  details: string;
+  starting_message: string;
+  pfp_url: string | null;
+  pfp_message_id: string | null;
+  pfp_channel_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+const rpCharacterTable: TableDefinition = {
+  name: 'RpCharacter',
+  columns: [
+    { name: 'char_id', type: 'TEXT PRIMARY KEY' },
+    { name: 'creator_id', type: 'VARCHAR NOT NULL' },
+    { name: 'name', type: 'VARCHAR NOT NULL' },
+    { name: 'name_lower', type: 'VARCHAR NOT NULL' },
+    { name: 'details', type: 'TEXT NOT NULL' },
+    { name: 'starting_message', type: 'TEXT NOT NULL DEFAULT \'\'' },
+    { name: 'pfp_url', type: 'TEXT DEFAULT NULL' },
+    { name: 'pfp_message_id', type: 'TEXT DEFAULT NULL' },
+    { name: 'pfp_channel_id', type: 'TEXT DEFAULT NULL' },
+    { name: 'created_at', type: 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP' },
+    { name: 'updated_at', type: 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP' },
+  ],
+  primaryKey: ['char_id'],
+  specialConstraints: [],
+  constraints: [
+    'FOREIGN KEY (creator_id) REFERENCES User(id)',
+  ],
+};
+
+export default rpCharacterTable;

--- a/database/tables/rpHistoryTable.ts
+++ b/database/tables/rpHistoryTable.ts
@@ -1,0 +1,38 @@
+import type { TableDefinition } from '../types';
+
+/**
+ * One turn in a spawned character's private conversation. Keyed by spawn_id (stable
+ * across remove/re-spawn since spawns are soft-deleted). User turns carry speaker
+ * attribution so the model can address people by name in a multi-user channel;
+ * model turns leave them null. Raw rows are never erased on compaction — they're
+ * just skipped during replay once folded into RpSpawn.compacted_memory.
+ */
+export interface RpHistoryRow {
+  id: number;
+  spawn_id: number;
+  role: 'user' | 'model';
+  speaker_id: string | null;
+  speaker_name: string | null;
+  message: string;
+  timestamp: string;
+}
+
+const rpHistoryTable: TableDefinition = {
+  name: 'RpHistory',
+  columns: [
+    { name: 'id', type: 'INTEGER PRIMARY KEY AUTOINCREMENT' },
+    { name: 'spawn_id', type: 'INTEGER NOT NULL' },
+    { name: 'role', type: "TEXT CHECK(role IN ('user', 'model')) NOT NULL" },
+    { name: 'speaker_id', type: 'VARCHAR DEFAULT NULL' },
+    { name: 'speaker_name', type: 'VARCHAR DEFAULT NULL' },
+    { name: 'message', type: 'TEXT NOT NULL' },
+    { name: 'timestamp', type: 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP' },
+  ],
+  primaryKey: ['id'],
+  specialConstraints: [],
+  constraints: [
+    'FOREIGN KEY (spawn_id) REFERENCES RpSpawn(spawn_id)',
+  ],
+};
+
+export default rpHistoryTable;

--- a/database/tables/rpSpawnTable.ts
+++ b/database/tables/rpSpawnTable.ts
@@ -1,0 +1,58 @@
+import type { TableDefinition } from '../types';
+
+/**
+ * A character spawned into a specific channel. UNIQUE(channel_id, char_id) makes
+ * "no duplicates in a channel" a DB invariant; re-spawning reactivates and
+ * reconfigures the existing row (so history survives a remove). `active = 0` is a
+ * soft-remove — the row and its compaction state stay so re-spawn can resume.
+ *
+ * Compaction state lives here: `compacted_memory` is the model-authored summary of
+ * everything up to `compacted_upto_id` (an RpHistory.id); replay = starting message
+ * + compacted_memory + history rows newer than that id. `compaction_failed` halts
+ * the character until it is mentioned again (then we retry / fall back to truncation).
+ */
+export interface RpSpawnRow {
+  spawn_id: number;
+  channel_id: string;
+  guild_id: string;
+  char_id: string;
+  spawner_id: string;
+  interactability: 'self' | 'all';
+  compaction_enabled: number;
+  compacted_memory: string | null;
+  compacted_upto_id: number | null;
+  compaction_failed: number;
+  active: number;
+  last_activity_at: string;
+  created_at: string;
+  updated_at: string;
+}
+
+const rpSpawnTable: TableDefinition = {
+  name: 'RpSpawn',
+  columns: [
+    { name: 'spawn_id', type: 'INTEGER PRIMARY KEY AUTOINCREMENT' },
+    { name: 'channel_id', type: 'VARCHAR NOT NULL' },
+    { name: 'guild_id', type: 'VARCHAR NOT NULL' },
+    { name: 'char_id', type: 'TEXT NOT NULL' },
+    { name: 'spawner_id', type: 'VARCHAR NOT NULL' },
+    { name: 'interactability', type: "TEXT NOT NULL DEFAULT 'self'" },
+    { name: 'compaction_enabled', type: 'INTEGER NOT NULL DEFAULT 1' },
+    { name: 'compacted_memory', type: 'TEXT DEFAULT NULL' },
+    { name: 'compacted_upto_id', type: 'INTEGER DEFAULT NULL' },
+    { name: 'compaction_failed', type: 'INTEGER NOT NULL DEFAULT 0' },
+    { name: 'active', type: 'INTEGER NOT NULL DEFAULT 1' },
+    { name: 'last_activity_at', type: 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP' },
+    { name: 'created_at', type: 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP' },
+    { name: 'updated_at', type: 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP' },
+  ],
+  primaryKey: ['spawn_id'],
+  specialConstraints: [
+    'UNIQUE (channel_id, char_id)',
+  ],
+  constraints: [
+    'FOREIGN KEY (char_id) REFERENCES RpCharacter(char_id)',
+  ],
+};
+
+export default rpSpawnTable;

--- a/tests/database/RpModel.test.ts
+++ b/tests/database/RpModel.test.ts
@@ -29,10 +29,11 @@ describe('RpModel', () => {
   });
 
   async function makeChar(creatorId: string, name: string): Promise<string> {
-    const c = await rp.createCharacter({
+    const res = await rp.createCharacter({
       creatorId, name, details: `${name} details`, startingMessage: `hi from ${name}`,
     });
-    return c!.charId;
+    if (!res.ok) throw new Error('unexpected quota rejection while seeding a test character');
+    return res.character.charId;
   }
 
   it('creates characters with unique ids and allows same name for different creators', async () => {
@@ -44,6 +45,39 @@ describe('RpModel', () => {
     const fetched = await rp.getCharacter(a);
     expect(fetched!.name).toBe('aventurine');
     expect(fetched!.nameLower).toBe('aventurine');
+  });
+
+  it('enforces the per-creator cap atomically and reports a limit result', async () => {
+    for (let i = 0; i < 3; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      const res = await rp.createCharacter({
+        creatorId: 'capped', name: `cap${i}`, details: 'd', startingMessage: 's',
+      }, 3);
+      expect(res.ok).toBe(true);
+    }
+    const over = await rp.createCharacter({
+      creatorId: 'capped', name: 'capX', details: 'd', startingMessage: 's',
+    }, 3);
+    expect(over.ok).toBe(false);
+    if (!over.ok) expect(over.reason).toBe('limit');
+    expect(await rp.countCharactersByCreator('capped')).toBe(3);
+  });
+
+  it('removeSpawn deactivates and (optionally) clears history + compaction in one op', async () => {
+    const id = await makeChar('user-1', 'atomic');
+    const spawn = await rp.trySpawn({
+      channelId: CHANNEL, guildId: GUILD, charId: id, spawnerId: 'user-1', interactability: 'all', compactionEnabled: true,
+    });
+    const spawnId = spawn.spawnId!;
+    await rp.addHistory(spawnId, 'user', 'hi', { id: 'user-2', name: 'Finch' });
+    await rp.setCompactionState(spawnId, 'a memory', 1);
+
+    await rp.removeSpawn(spawnId, true);
+    expect(await rp.countActiveSpawnsInChannel(CHANNEL)).toBe(0);
+    expect(await rp.countHistory(spawnId)).toBe(0);
+    const row = await rp.getSpawnById(spawnId);
+    expect(row!.compactedMemory).toBeNull();
+    expect(row!.compactionFailed).toBe(0);
   });
 
   it('only the owner can update a character', async () => {

--- a/tests/database/RpModel.test.ts
+++ b/tests/database/RpModel.test.ts
@@ -1,0 +1,146 @@
+import {
+  describe, it, expect, beforeAll, afterAll, beforeEach,
+} from 'bun:test';
+import Database from '../../database/Database';
+import type RpModel from '../../database/models/RpModel';
+
+describe('RpModel', () => {
+  let db: Database;
+  let rp: RpModel;
+  const CHANNEL = 'chan-1';
+  const GUILD = 'guild-1';
+
+  beforeAll(async () => {
+    db = new Database(`./tests/temp/testRp-${Date.now()}.db`);
+    await db.ready;
+    rp = db.rp;
+  });
+
+  afterAll(() => {
+    db.db.close();
+  });
+
+  beforeEach(async () => {
+    // Child → parent order to respect foreign keys.
+    await db.executeQuery('DELETE FROM RpHistory');
+    await db.executeQuery('DELETE FROM RpSpawn');
+    await db.executeQuery('DELETE FROM RpCharacter');
+    await db.executeQuery('DELETE FROM User');
+  });
+
+  async function makeChar(creatorId: string, name: string): Promise<string> {
+    const c = await rp.createCharacter({
+      creatorId, name, details: `${name} details`, startingMessage: `hi from ${name}`,
+    });
+    return c!.charId;
+  }
+
+  it('creates characters with unique ids and allows same name for different creators', async () => {
+    const a = await makeChar('user-1', 'aventurine');
+    const b = await makeChar('user-2', 'aventurine');
+    expect(a).not.toBe(b);
+    expect(await rp.countCharactersByCreator('user-1')).toBe(1);
+
+    const fetched = await rp.getCharacter(a);
+    expect(fetched!.name).toBe('aventurine');
+    expect(fetched!.nameLower).toBe('aventurine');
+  });
+
+  it('only the owner can update a character', async () => {
+    const id = await makeChar('owner', 'sunny');
+    const denied = await rp.updateCharacter(id, 'not-owner', {
+      name: 'evil', details: 'x', startingMessage: 'y',
+    });
+    expect(denied).toBe(false);
+    const ok = await rp.updateCharacter(id, 'owner', {
+      name: 'sunny2', details: 'd', startingMessage: 's',
+    });
+    expect(ok).toBe(true);
+    expect((await rp.getCharacter(id))!.name).toBe('sunny2');
+  });
+
+  it('spawns, reconfigures in place, and enforces the 5-per-channel cap', async () => {
+    const ids = [];
+    for (let i = 0; i < 6; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      ids.push(await makeChar('user-1', `char${i}`));
+    }
+
+    // First five spawn fine.
+    for (let i = 0; i < 5; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      const res = await rp.trySpawn({
+        channelId: CHANNEL, guildId: GUILD, charId: ids[i], spawnerId: 'user-1', interactability: 'self', compactionEnabled: true,
+      });
+      expect(res.ok).toBe(true);
+      expect(res.reconfigured).toBe(false);
+    }
+    expect(await rp.countActiveSpawnsInChannel(CHANNEL)).toBe(5);
+
+    // Sixth distinct character is rejected.
+    const sixth = await rp.trySpawn({
+      channelId: CHANNEL, guildId: GUILD, charId: ids[5], spawnerId: 'user-1', interactability: 'self', compactionEnabled: true,
+    });
+    expect(sixth.ok).toBe(false);
+    expect(sixth.reason).toBe('limit');
+
+    // Re-spawning an already-active character is a reconfigure (doesn't count against the cap).
+    const reconf = await rp.trySpawn({
+      channelId: CHANNEL, guildId: GUILD, charId: ids[0], spawnerId: 'user-1', interactability: 'all', compactionEnabled: false,
+    });
+    expect(reconf.ok).toBe(true);
+    expect(reconf.reconfigured).toBe(true);
+    const spawn = await rp.getSpawn(CHANNEL, ids[0]);
+    expect(spawn!.interactability).toBe('all');
+    expect(spawn!.compactionEnabled).toBe(0);
+    expect(await rp.countActiveSpawnsInChannel(CHANNEL)).toBe(5);
+  });
+
+  it('keeps history across remove + re-spawn (same spawn id), and clears it on demand', async () => {
+    const id = await makeChar('user-1', 'memory');
+    const first = await rp.trySpawn({
+      channelId: CHANNEL, guildId: GUILD, charId: id, spawnerId: 'user-1', interactability: 'all', compactionEnabled: true,
+    });
+    const spawnId = first.spawnId!;
+
+    await rp.addHistory(spawnId, 'user', 'hello', { id: 'user-2', name: 'Finch' });
+    await rp.addHistory(spawnId, 'model', 'hi there');
+    expect(await rp.getLastHistoryRole(spawnId)).toBe('model');
+
+    // Remove (soft) then re-spawn → same spawn id, history intact.
+    await rp.deactivateSpawn(spawnId);
+    expect(await rp.countActiveSpawnsInChannel(CHANNEL)).toBe(0);
+    const again = await rp.trySpawn({
+      channelId: CHANNEL, guildId: GUILD, charId: id, spawnerId: 'user-1', interactability: 'all', compactionEnabled: true,
+    });
+    expect(again.spawnId).toBe(spawnId);
+    expect(again.reconfigured).toBe(false); // was inactive → treated as a fresh spawn
+    const tail = await rp.getHistoryAfter(spawnId, 0);
+    expect(tail).toHaveLength(2);
+    expect(tail[0].speakerName).toBe('Finch');
+
+    // clear_history wipes it.
+    await rp.deleteHistoryBySpawn(spawnId);
+    expect(await rp.countHistory(spawnId)).toBe(0);
+    expect(await rp.getLastHistoryRole(spawnId)).toBeNull();
+  });
+
+  it('tracks distinct active channels for the router fast-path', async () => {
+    const id = await makeChar('user-1', 'router');
+    const res = await rp.trySpawn({
+      channelId: CHANNEL, guildId: GUILD, charId: id, spawnerId: 'user-1', interactability: 'self', compactionEnabled: true,
+    });
+    expect(await rp.getDistinctActiveChannels()).toContain(CHANNEL);
+    await rp.deactivateSpawn(res.spawnId!);
+    expect(await rp.getDistinctActiveChannels()).not.toContain(CHANNEL);
+  });
+
+  it('searches by name substring and id prefix', async () => {
+    await makeChar('user-1', 'aventurine');
+    await makeChar('user-1', 'robinbird');
+    const byName = await rp.searchCharacters('venturi');
+    expect(byName.some((r) => r.nameLower === 'aventurine')).toBe(true);
+    const byNamePartial = await rp.searchCharacters('robin');
+    expect(byNamePartial.some((r) => r.nameLower === 'robinbird')).toBe(true);
+  });
+});

--- a/tests/utils/rpCharInput.test.ts
+++ b/tests/utils/rpCharInput.test.ts
@@ -9,7 +9,10 @@ import {
 
 const realFetch = globalThis.fetch;
 function stubFetch(body: string, ok = true): void {
-  globalThis.fetch = (async () => ({ ok, text: async () => body })) as any;
+  globalThis.fetch = (async () => ({
+    ok,
+    arrayBuffer: async () => new TextEncoder().encode(body).buffer,
+  })) as any;
 }
 afterEach(() => { globalThis.fetch = realFetch; });
 

--- a/tests/utils/rpCharInput.test.ts
+++ b/tests/utils/rpCharInput.test.ts
@@ -1,0 +1,81 @@
+// Bun runtime — globalThis is always available; the airbnb/node rule targets Node 8.
+/* eslint-disable node/no-unsupported-features/es-builtins */
+import {
+  describe, it, expect, afterEach,
+} from 'bun:test';
+import {
+  loadCharacterJson, validateDetails, validateStartingMessage, validateCharacterFields,
+} from '../../utils/rpCharInput';
+
+const realFetch = globalThis.fetch;
+function stubFetch(body: string, ok = true): void {
+  globalThis.fetch = (async () => ({ ok, text: async () => body })) as any;
+}
+afterEach(() => { globalThis.fetch = realFetch; });
+
+describe('rpCharInput validators', () => {
+  it('enforces the details token budget', () => {
+    expect(validateDetails('a normal system prompt')).toBeNull();
+    expect(validateDetails('')).not.toBeNull();
+    // ~5000 tokens (20000 chars / 4) exceeds the 4000-token cap.
+    expect(validateDetails('x'.repeat(20000))).not.toBeNull();
+  });
+
+  it('enforces the 6000-char starting message limit', () => {
+    expect(validateStartingMessage('hi there')).toBeNull();
+    expect(validateStartingMessage('a'.repeat(6000))).toBeNull();
+    expect(validateStartingMessage('a'.repeat(6001))).not.toBeNull();
+    expect(validateStartingMessage('')).not.toBeNull();
+  });
+
+  it('validateCharacterFields rejects a bad name', () => {
+    expect(validateCharacterFields({ name: 'ok_name', details: 'd', startingMessage: 's' })).toBeNull();
+    expect(validateCharacterFields({ name: 'bad name', details: 'd', startingMessage: 's' })).not.toBeNull();
+  });
+});
+
+describe('rpCharInput.loadCharacterJson', () => {
+  const att = { url: 'https://example/char.json', size: 100 };
+
+  it('parses a complete object', async () => {
+    stubFetch(JSON.stringify({ name: 'bob', details: 'a bold knight', starting_message: 'Hail!' }));
+    const res = await loadCharacterJson(att);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.fields).toEqual({ name: 'bob', details: 'a bold knight', startingMessage: 'Hail!' });
+    }
+  });
+
+  it('reports every missing field', async () => {
+    stubFetch(JSON.stringify({ name: 'bob' }));
+    const res = await loadCharacterJson(att);
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error).toContain('details');
+      expect(res.error).toContain('starting_message');
+    }
+  });
+
+  it('rejects malformed JSON and non-objects', async () => {
+    stubFetch('not json {');
+    expect((await loadCharacterJson(att)).ok).toBe(false);
+    stubFetch('[]');
+    expect((await loadCharacterJson(att)).ok).toBe(false);
+  });
+
+  it('rejects oversize uploads before fetching', async () => {
+    const res = await loadCharacterJson({ url: 'x', size: 999_999_999 });
+    expect(res.ok).toBe(false);
+  });
+
+  it('ignores unknown fields and never pollutes the prototype', async () => {
+    // Raw string so the literal "__proto__" key is actually present in the JSON.
+    stubFetch('{"name":"bob","details":"d","starting_message":"s","evil":"x","__proto__":{"polluted":true}}');
+    const res = await loadCharacterJson(att);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(Object.keys(res.fields).sort()).toEqual(['details', 'name', 'startingMessage']);
+    }
+    expect(({} as any).polluted).toBeUndefined();
+  });
+});

--- a/tests/utils/rpDelivery.test.ts
+++ b/tests/utils/rpDelivery.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'bun:test';
+import { splitMessage } from '../../utils/rpDelivery';
+
+describe('rpDelivery.splitMessage', () => {
+  it('keeps a short message as a single chunk', () => {
+    expect(splitMessage('hello there')).toEqual(['hello there']);
+  });
+
+  it('splits long unbroken text into <=2000-char chunks losslessly', () => {
+    const chunks = splitMessage('a'.repeat(5000));
+    expect(chunks).toHaveLength(3);
+    expect(chunks.every((c) => c.length <= 2000)).toBe(true);
+    expect(chunks.join('')).toBe('a'.repeat(5000));
+  });
+
+  it('prefers whitespace break points and never emits empty chunks', () => {
+    const text = `${'word '.repeat(600)}end`; // ~3000 chars with spaces
+    const chunks = splitMessage(text);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((c) => c.length > 0 && c.length <= 2000)).toBe(true);
+  });
+});

--- a/tests/utils/rpDelivery.test.ts
+++ b/tests/utils/rpDelivery.test.ts
@@ -13,10 +13,19 @@ describe('rpDelivery.splitMessage', () => {
     expect(chunks.join('')).toBe('a'.repeat(5000));
   });
 
-  it('prefers whitespace break points and never emits empty chunks', () => {
+  it('prefers whitespace break points, never emits empty chunks, and is lossless', () => {
     const text = `${'word '.repeat(600)}end`; // ~3000 chars with spaces
     const chunks = splitMessage(text);
     expect(chunks.length).toBeGreaterThan(1);
     expect(chunks.every((c) => c.length > 0 && c.length <= 2000)).toBe(true);
+    // Boundary whitespace must survive — no spaces/newlines dropped at chunk edges.
+    expect(chunks.join('')).toBe(text);
+  });
+
+  it('preserves a newline sitting exactly on the chunk boundary', () => {
+    const text = `${'a'.repeat(1999)}\n${'b'.repeat(1500)}`;
+    const chunks = splitMessage(text);
+    expect(chunks.join('')).toBe(text);
+    expect(chunks[0].endsWith('\n')).toBe(true);
   });
 });

--- a/tests/utils/rpIdentity.test.ts
+++ b/tests/utils/rpIdentity.test.ts
@@ -73,6 +73,12 @@ describe('rpIdentity.matchMentions', () => {
     expect(ambiguous).toHaveLength(0);
   });
 
+  it('disambiguates a mixed-case name-idprefix handle', () => {
+    const { matched, ambiguous } = matchMentions('@Aventurine-A2E are you there', spawns);
+    expect(matched.map((m) => m.spawnId)).toEqual([1]);
+    expect(ambiguous).toHaveLength(0);
+  });
+
   it('matches by id (full or prefix)', () => {
     expect(matchMentions('@a2e4se', spawns).matched.map((m) => m.spawnId)).toEqual([1]);
     expect(matchMentions('@zzz', spawns).matched.map((m) => m.spawnId)).toEqual([3]);

--- a/tests/utils/rpIdentity.test.ts
+++ b/tests/utils/rpIdentity.test.ts
@@ -1,7 +1,22 @@
 import { describe, it, expect } from 'bun:test';
 import {
-  generateCharId, validateCharName, matchMentions, type SpawnLike,
+  generateCharId, validateCharName, matchMentions, applyUserVar, type SpawnLike,
 } from '../../utils/rpIdentity';
+
+describe('rpIdentity.applyUserVar', () => {
+  it('substitutes {user} when a name is given (self-mode)', () => {
+    expect(applyUserVar('Hello {user}!', 'Finch')).toBe('Hello Finch!');
+    expect(applyUserVar('{user} and {user}', 'Finch')).toBe('Finch and Finch');
+  });
+
+  it('leaves the token literal when name is null (all-mode)', () => {
+    expect(applyUserVar('Hello {user}!', null)).toBe('Hello {user}!');
+  });
+
+  it('is a no-op when there is no token', () => {
+    expect(applyUserVar('no variables here', 'Finch')).toBe('no variables here');
+  });
+});
 
 describe('rpIdentity.generateCharId', () => {
   it('produces 6-char lowercase alphanumeric ids', () => {

--- a/tests/utils/rpIdentity.test.ts
+++ b/tests/utils/rpIdentity.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  generateCharId, validateCharName, matchMentions, type SpawnLike,
+} from '../../utils/rpIdentity';
+
+describe('rpIdentity.generateCharId', () => {
+  it('produces 6-char lowercase alphanumeric ids', () => {
+    for (let i = 0; i < 100; i += 1) {
+      expect(generateCharId()).toMatch(/^[a-z0-9]{6}$/);
+    }
+  });
+});
+
+describe('rpIdentity.validateCharName', () => {
+  it('accepts simple names', () => {
+    expect(validateCharName('aventurine')).toBeNull();
+    expect(validateCharName('Aven_2')).toBeNull();
+  });
+
+  it('rejects spaces, dashes, and overlong names', () => {
+    expect(validateCharName('aven turine')).not.toBeNull();
+    expect(validateCharName('aven-turine')).not.toBeNull();
+    expect(validateCharName('a'.repeat(33))).not.toBeNull();
+    expect(validateCharName('')).not.toBeNull();
+  });
+
+  it('rejects Discord-reserved names', () => {
+    expect(validateCharName('everyone')).not.toBeNull();
+    expect(validateCharName('here')).not.toBeNull();
+    expect(validateCharName('mydiscordbot')).not.toBeNull();
+    expect(validateCharName('clyde2')).not.toBeNull();
+  });
+});
+
+describe('rpIdentity.matchMentions', () => {
+  const spawns: SpawnLike[] = [
+    { spawnId: 1, charId: 'a2e4se', nameLower: 'aventurine' },
+    { spawnId: 2, charId: 'd23efg', nameLower: 'aventurine' }, // same name, different id
+    { spawnId: 3, charId: 'zzz999', nameLower: 'bob' },
+  ];
+
+  it('matches a unique name', () => {
+    const { matched, ambiguous } = matchMentions('hey @bob how are you', spawns);
+    expect(matched.map((m) => m.spawnId)).toEqual([3]);
+    expect(ambiguous).toHaveLength(0);
+  });
+
+  it('flags an ambiguous bare name as ambiguous', () => {
+    const { matched, ambiguous } = matchMentions('yo @aventurine', spawns);
+    expect(matched).toHaveLength(0);
+    expect(ambiguous).toHaveLength(1);
+    expect(ambiguous[0].candidates.map((c) => c.spawnId).sort()).toEqual([1, 2]);
+  });
+
+  it('disambiguates with a name-idprefix handle', () => {
+    const { matched, ambiguous } = matchMentions('@aventurine-a2e are you there', spawns);
+    expect(matched.map((m) => m.spawnId)).toEqual([1]);
+    expect(ambiguous).toHaveLength(0);
+  });
+
+  it('matches by id (full or prefix)', () => {
+    expect(matchMentions('@a2e4se', spawns).matched.map((m) => m.spawnId)).toEqual([1]);
+    expect(matchMentions('@zzz', spawns).matched.map((m) => m.spawnId)).toEqual([3]);
+  });
+
+  it('matches a unique name prefix', () => {
+    expect(matchMentions('@bo', spawns).matched.map((m) => m.spawnId)).toEqual([3]);
+  });
+
+  it('does not trigger mid-word (e.g. emails)', () => {
+    expect(matchMentions('mail me at someone@bob.example', spawns).matched).toHaveLength(0);
+  });
+
+  it('dedupes a character mentioned two ways in one message', () => {
+    const { matched } = matchMentions('@bob aka @zzz999', spawns);
+    expect(matched.map((m) => m.spawnId)).toEqual([3]);
+  });
+
+  it('matches multiple distinct characters in one message', () => {
+    const { matched } = matchMentions('@bob and @aventurine-d23 hi', spawns);
+    expect(matched.map((m) => m.spawnId).sort()).toEqual([2, 3]);
+  });
+});

--- a/utils/rpAvatar.ts
+++ b/utils/rpAvatar.ts
@@ -1,0 +1,156 @@
+import Canvas from 'canvas';
+import { log, logError } from './log';
+
+/**
+ * Avatar handling for roleplay characters. User-uploaded images are center-cropped
+ * and resized to 128×128 PNG, then re-hosted in a per-server asset channel so the
+ * webhook has a stable public URL. Discord attachment URLs are signed and expire,
+ * so we re-derive a fresh URL from the stored message id (cached ~12h) and fall
+ * back to the bot's default avatar when the asset message is gone.
+ */
+
+/** ServerConfig key holding the channel id where processed pfps are uploaded. */
+export const ASSET_CHANNEL_KEY = 'rp_asset_channel';
+
+const AVATAR_SIZE = 128;
+const MAX_INPUT_BYTES = 8 * 1024 * 1024;
+const URL_REFRESH_MS = 12 * 60 * 60 * 1000;
+
+// charId -> last good signed URL + when we fetched it.
+const urlCache = new Map<string, { url: string; at: number }>();
+
+export type ProcessResult =
+  | { ok: true; buffer: Buffer }
+  | { ok: false; error: string };
+
+/**
+ * Validates and normalizes an uploaded attachment to a 128×128 PNG buffer.
+ * `attachment` is a discord.js Attachment (url/contentType/size).
+ */
+export async function processAvatar(attachment: {
+  url: string; contentType?: string | null; size?: number;
+}): Promise<ProcessResult> {
+  if (attachment.contentType && !attachment.contentType.startsWith('image/')) {
+    return { ok: false, error: 'The pfp must be an image (PNG, JPG, WebP, or GIF).' };
+  }
+  if (typeof attachment.size === 'number' && attachment.size > MAX_INPUT_BYTES) {
+    return { ok: false, error: 'That image is too large — keep it under 8 MB.' };
+  }
+
+  let buffer: Buffer;
+  try {
+    const res = await fetch(attachment.url);
+    if (!res.ok) return { ok: false, error: 'Could not download the image. Try re-uploading.' };
+    const bytes = await res.arrayBuffer();
+    if (bytes.byteLength > MAX_INPUT_BYTES) {
+      return { ok: false, error: 'That image is too large — keep it under 8 MB.' };
+    }
+    buffer = Buffer.from(bytes);
+  } catch (err) {
+    logError('Rp: failed to download avatar:', err);
+    return { ok: false, error: 'Could not download the image. Try re-uploading.' };
+  }
+
+  try {
+    const image = await Canvas.loadImage(buffer);
+    const side = Math.min(image.width, image.height);
+    const sx = Math.floor((image.width - side) / 2);
+    const sy = Math.floor((image.height - side) / 2);
+
+    const canvas = Canvas.createCanvas(AVATAR_SIZE, AVATAR_SIZE);
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(image, sx, sy, side, side, 0, 0, AVATAR_SIZE, AVATAR_SIZE);
+    return { ok: true, buffer: canvas.toBuffer('image/png') };
+  } catch (err) {
+    logError('Rp: failed to process avatar image:', err);
+    return { ok: false, error: 'That image couldn\'t be processed. Try a standard PNG or JPG.' };
+  }
+}
+
+export type HostResult =
+  | { ok: true; url: string; messageId: string; channelId: string }
+  | { ok: false; error: string };
+
+/**
+ * Uploads the processed pfp to the guild's configured asset channel and returns the
+ * resulting CDN URL + message id (used later to refresh the signed URL).
+ */
+export async function hostAvatar(
+  client: any,
+  db: any,
+  guildId: string,
+  charId: string,
+  buffer: Buffer,
+): Promise<HostResult> {
+  const channelId = await db.serverConfig.getServerConfig(guildId, ASSET_CHANNEL_KEY);
+  if (!channelId) {
+    return {
+      ok: false,
+      error: 'No roleplay asset channel is configured for this server. An admin must run `/ai rp-setasset` first.',
+    };
+  }
+  try {
+    const channel = await client.channels.fetch(channelId);
+    if (!channel || typeof channel.send !== 'function') {
+      return { ok: false, error: 'The configured asset channel is invalid. Ask an admin to re-run `/ai rp-setasset`.' };
+    }
+    const sent = await channel.send({
+      content: `pfp:${charId}`,
+      files: [{ attachment: buffer, name: `${charId}.png` }],
+    });
+    const url = [...(sent.attachments?.values() ?? [])][0]?.url;
+    if (!url) return { ok: false, error: 'Upload failed — no attachment URL returned.' };
+    urlCache.set(charId, { url, at: Date.now() });
+    return {
+      ok: true, url, messageId: sent.id, channelId,
+    };
+  } catch (err) {
+    logError('Rp: failed to host avatar:', err);
+    return { ok: false, error: 'Could not upload to the asset channel. Check the bot\'s permissions there.' };
+  }
+}
+
+/** Re-fetches the asset message to obtain a fresh signed attachment URL, or null. */
+async function refreshAvatarUrl(client: any, channelId: string, messageId: string): Promise<string | null> {
+  try {
+    const channel = await client.channels.fetch(channelId).catch(() => null);
+    if (!channel || typeof channel.messages?.fetch !== 'function') return null;
+    const msg = await channel.messages.fetch(messageId).catch(() => null);
+    if (!msg) return null;
+    return [...(msg.attachments?.values() ?? [])][0]?.url ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolves a usable avatar URL for webhook delivery, refreshing the signed URL when
+ * stale and marking the pfp broken (returns null → caller uses the default avatar)
+ * when the asset message has been deleted.
+ */
+export async function resolveAvatarUrl(client: any, db: any, character: {
+  charId: string;
+  pfpUrl?: string | null;
+  pfpMessageId?: string | null;
+  pfpChannelId?: string | null;
+}): Promise<string | null> {
+  if (!character.pfpMessageId || !character.pfpChannelId) {
+    return character.pfpUrl ?? null;
+  }
+  const cached = urlCache.get(character.charId);
+  if (cached && Date.now() - cached.at < URL_REFRESH_MS) return cached.url;
+
+  const fresh = await refreshAvatarUrl(client, character.pfpChannelId, character.pfpMessageId);
+  if (fresh) {
+    urlCache.set(character.charId, { url: fresh, at: Date.now() });
+    db.rp.updateCharacterPfp(character.charId, {
+      url: fresh, messageId: character.pfpMessageId, channelId: character.pfpChannelId,
+    }).catch(() => {});
+    return fresh;
+  }
+
+  log(`Rp: avatar for ${character.charId} is broken (asset message gone); falling back to default.`);
+  urlCache.delete(character.charId);
+  db.rp.clearCharacterPfpUrl(character.charId).catch(() => {});
+  return null;
+}

--- a/utils/rpCharInput.ts
+++ b/utils/rpCharInput.ts
@@ -73,13 +73,16 @@ export async function loadCharacterJson(attachment: {
   try {
     const res = await fetch(attachment.url);
     if (!res.ok) return { ok: false, error: 'Could not download the .json file. Try re-uploading.' };
-    text = await res.text();
+    // Cap on the raw byte length (not text.length, which counts UTF-16 units) so a
+    // multibyte payload can't slip past the limit when attachment.size is missing.
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    if (bytes.byteLength > MAX_CHAR_JSON_BYTES) {
+      return { ok: false, error: `That .json is too large (max ${MAX_CHAR_JSON_BYTES / 1024} KB).` };
+    }
+    text = new TextDecoder().decode(bytes);
   } catch (err) {
     logError('Rp: failed to download character json:', err);
     return { ok: false, error: 'Could not download the .json file. Try re-uploading.' };
-  }
-  if (text.length > MAX_CHAR_JSON_BYTES) {
-    return { ok: false, error: `That .json is too large (max ${MAX_CHAR_JSON_BYTES / 1024} KB).` };
   }
 
   let parsed: any;

--- a/utils/rpCharInput.ts
+++ b/utils/rpCharInput.ts
@@ -1,0 +1,112 @@
+import { countTokensOpenRouter } from './tokenizer';
+import {
+  validateCharName, DETAILS_MAX_TOKENS, STARTING_MESSAGE_MAX_LENGTH, MAX_CHAR_JSON_BYTES,
+} from './rpIdentity';
+import { logError } from './log';
+
+/**
+ * Parsing + validation for the two ways to define a character: individual command
+ * options, or an uploaded `.json` (which allows a much larger `details` than a 6000-char
+ * Discord option). The JSON path is an attack surface, so we cap the size, parse in a
+ * try/catch, and pull ONLY the three known string fields — the parsed object is never
+ * spread or trusted structurally.
+ */
+
+export interface CharacterFields {
+  name: string;
+  details: string;
+  startingMessage: string;
+}
+
+export const CHARACTER_JSON_TEMPLATE = `{
+  "name": "aventurine",
+  "details": "Personality, background and speaking style — this is the system prompt. Use {user} to address whoever is talking (self-mode spawns only).",
+  "starting_message": "The line the character opens with when spawned. {user} works here too (self-mode)."
+}`;
+
+/** Fenced template block appended to feedback so creators can see the expected shape. */
+export const JSON_HELP = `\`\`\`json\n${CHARACTER_JSON_TEMPLATE}\n\`\`\``;
+
+export function validateName(name: string): string | null {
+  return validateCharName(name);
+}
+
+export function validateDetails(details: string): string | null {
+  if (!details || !details.trim()) return 'Details are required.';
+  const tokens = countTokensOpenRouter(details);
+  if (tokens > DETAILS_MAX_TOKENS) {
+    return `Details are too long (~${tokens} tokens; the max is ${DETAILS_MAX_TOKENS}). Trim it down.`;
+  }
+  return null;
+}
+
+export function validateStartingMessage(sm: string): string | null {
+  if (!sm || !sm.trim()) return 'Starting message is required.';
+  if (sm.length > STARTING_MESSAGE_MAX_LENGTH) {
+    return `Starting message is too long (max ${STARTING_MESSAGE_MAX_LENGTH} characters).`;
+  }
+  return null;
+}
+
+/** Validates a complete field set (used by the JSON path). Returns the first error or null. */
+export function validateCharacterFields(fields: CharacterFields): string | null {
+  return validateName(fields.name)
+    || validateDetails(fields.details)
+    || validateStartingMessage(fields.startingMessage);
+}
+
+type LoadResult = { ok: true; fields: CharacterFields } | { ok: false; error: string };
+
+/**
+ * Downloads and validates a character `.json` attachment. Enforces the byte cap up
+ * front, tolerates missing fields with actionable feedback, and never trusts the
+ * parsed object beyond three explicitly-read string properties.
+ */
+export async function loadCharacterJson(attachment: {
+  url: string; size?: number;
+}): Promise<LoadResult> {
+  if (typeof attachment.size === 'number' && attachment.size > MAX_CHAR_JSON_BYTES) {
+    return { ok: false, error: `That .json is too large (max ${MAX_CHAR_JSON_BYTES / 1024} KB).` };
+  }
+
+  let text: string;
+  try {
+    const res = await fetch(attachment.url);
+    if (!res.ok) return { ok: false, error: 'Could not download the .json file. Try re-uploading.' };
+    text = await res.text();
+  } catch (err) {
+    logError('Rp: failed to download character json:', err);
+    return { ok: false, error: 'Could not download the .json file. Try re-uploading.' };
+  }
+  if (text.length > MAX_CHAR_JSON_BYTES) {
+    return { ok: false, error: `That .json is too large (max ${MAX_CHAR_JSON_BYTES / 1024} KB).` };
+  }
+
+  let parsed: any;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return { ok: false, error: `That file isn't valid JSON. Expected shape:\n${JSON_HELP}` };
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return { ok: false, error: `The .json must be a single object. Expected shape:\n${JSON_HELP}` };
+  }
+
+  // Read only the fields we know; ignore everything else.
+  const name = typeof parsed.name === 'string' ? parsed.name.trim() : '';
+  const details = typeof parsed.details === 'string' ? parsed.details : '';
+  const startingMessage = typeof parsed.starting_message === 'string' ? parsed.starting_message : '';
+
+  const missing: string[] = [];
+  if (!name) missing.push('name');
+  if (!details.trim()) missing.push('details');
+  if (!startingMessage.trim()) missing.push('starting_message');
+  if (missing.length > 0) {
+    return { ok: false, error: `Your .json is missing: **${missing.join(', ')}**. Expected shape:\n${JSON_HELP}` };
+  }
+
+  const fields: CharacterFields = { name, details, startingMessage };
+  const fieldErr = validateCharacterFields(fields);
+  if (fieldErr) return { ok: false, error: fieldErr };
+  return { ok: true, fields };
+}

--- a/utils/rpChat.ts
+++ b/utils/rpChat.ts
@@ -1,0 +1,250 @@
+import { getOpenRouterClient } from './ai';
+import { countTokensOpenRouterMessages } from './tokenizer';
+import { logError, log } from './log';
+
+/**
+ * Roleplay generation + auto-compaction on DeepSeek. Each spawned character has its
+ * own private history; when the assembled prompt nears the context window we fold the
+ * oldest ~80% of the un-compacted tail into a first-person "memory" and keep the
+ * newest ~20% verbatim. The character's starting message lives in the system prompt,
+ * so it always survives compaction.
+ */
+
+export const RP_MODEL = 'deepseek/deepseek-v3.2';
+const RP_MAX_OUTPUT = 8192;
+const RP_CONTEXT_LIMIT = 128_000;
+// Reduce context once the assembled prompt would exceed ~85% of the window.
+const COMPACTION_TRIGGER_TOKENS = Math.floor(RP_CONTEXT_LIMIT * 0.85);
+// Leave room for the reply + system prompt when hard-truncating.
+const TRUNCATE_TARGET_TOKENS = Math.floor(RP_CONTEXT_LIMIT * 0.7);
+// Don't bother compacting a handful of rows — there's nothing to gain.
+const MIN_ROWS_TO_COMPACT = 8;
+// Fraction of the tail (by tokens) folded into memory; the rest is kept verbatim.
+const COMPACT_FRACTION = 0.8;
+
+// The format the compaction model MUST obey so we can trust the output.
+const MEMORY_OPEN = '<MEMORY>';
+const MEMORY_CLOSE = '</MEMORY>';
+
+export interface RpCharacterDef {
+  charId: string;
+  name: string;
+  details: string;
+  startingMessage: string;
+}
+
+export interface RpSpawnState {
+  spawnId: number;
+  compactionEnabled: boolean;
+  compactedMemory: string | null;
+  compactedUptoId: number | null;
+  compactionFailed: boolean;
+}
+
+export interface RpHistoryTurn {
+  id: number;
+  role: 'user' | 'model';
+  speakerName: string | null;
+  message: string;
+}
+
+type ChatMessage = { role: 'system' | 'user' | 'assistant'; content: string };
+
+function buildSystemPrompt(character: RpCharacterDef, memory: string | null): string {
+  let prompt = `You are roleplaying as ${character.name}, a character in a Discord channel. Stay fully in character at all times. Never break character, never mention being an AI, and never describe the actions or speech of the people you are talking to. Respond only as ${character.name}.
+
+Character details:
+${character.details}
+
+You may be talking with one or more people at once. Each incoming line is prefixed with the speaker's name as "Name: message". Address people naturally by name when it fits. Do not prefix your own reply with your name or a timestamp. Keep replies reasonably concise for a chat.`;
+
+  if (character.startingMessage) {
+    prompt += `\n\nThe conversation opened with you saying:\n"${character.startingMessage}"`;
+  }
+  if (memory) {
+    prompt += `\n\nThis is your memory of everything that has happened so far, experienced from your own perspective. Treat it as established history and stay consistent with it:\n${memory}`;
+  }
+  return prompt;
+}
+
+function turnToMessage(turn: RpHistoryTurn): ChatMessage {
+  if (turn.role === 'user') {
+    const name = turn.speakerName || 'Someone';
+    return { role: 'user', content: `${name}: ${turn.message}` };
+  }
+  return { role: 'assistant', content: turn.message };
+}
+
+function estimateTokens(systemPrompt: string, tail: RpHistoryTurn[]): number {
+  const msgs: ChatMessage[] = [{ role: 'system', content: systemPrompt }, ...tail.map(turnToMessage)];
+  return countTokensOpenRouterMessages(msgs);
+}
+
+async function callDeepseek(messages: ChatMessage[], maxTokens: number): Promise<string> {
+  if (!process.env.OPENROUTER_API_KEY) {
+    throw new Error('OPENROUTER_API_KEY is not set');
+  }
+  const openrouter = getOpenRouterClient();
+  const completion = await openrouter.chat.completions.create({
+    model: RP_MODEL,
+    messages,
+    max_tokens: maxTokens,
+    reasoning: { enabled: false },
+  } as any);
+  return completion.choices?.[0]?.message?.content ?? '';
+}
+
+/** Drops oldest rows until the tail fits the truncation target, keeping the newest. */
+function truncateToFit(tail: RpHistoryTurn[], systemPrompt: string): RpHistoryTurn[] {
+  let kept = [...tail];
+  while (kept.length > 1 && estimateTokens(systemPrompt, kept) > TRUNCATE_TARGET_TOKENS) {
+    kept = kept.slice(1);
+  }
+  return kept;
+}
+
+function parseMemory(raw: string): string | null {
+  const open = raw.indexOf(MEMORY_OPEN);
+  const close = raw.indexOf(MEMORY_CLOSE);
+  if (open === -1 || close === -1 || close <= open) return null;
+  const inner = raw.slice(open + MEMORY_OPEN.length, close).trim();
+  return inner.length > 0 ? inner : null;
+}
+
+/**
+ * Folds the oldest portion of the tail into a fresh `compacted_memory`. Returns the
+ * new memory + the id it covers up to on success; `{ ok: false }` when the model
+ * breaks the required format (caller decides whether to halt or hard-truncate).
+ * `memory` is absent when there was nothing worth folding.
+ */
+async function compact(
+  db: any,
+  spawnId: number,
+  character: RpCharacterDef,
+  tail: RpHistoryTurn[],
+  priorMemory: string | null,
+): Promise<{ ok: boolean; memory?: string; uptoId?: number }> {
+  if (tail.length < MIN_ROWS_TO_COMPACT) return { ok: true };
+
+  // Find the split so ~COMPACT_FRACTION of the tail's tokens are folded.
+  const totalTokens = tail.reduce((sum, t) => sum + countTokensOpenRouterMessages([turnToMessage(t)]), 0);
+  const budget = totalTokens * COMPACT_FRACTION;
+  let acc = 0;
+  let splitIdx = 0;
+  for (let i = 0; i < tail.length; i += 1) {
+    acc += countTokensOpenRouterMessages([turnToMessage(tail[i])]);
+    if (acc >= budget) { splitIdx = i + 1; break; }
+  }
+  // Always keep at least one recent row intact.
+  splitIdx = Math.min(splitIdx, tail.length - 1);
+  const toFold = tail.slice(0, splitIdx);
+  if (toFold.length === 0) return { ok: true };
+  const newUptoId = toFold[toFold.length - 1].id;
+
+  const transcript = toFold
+    .map((t) => (t.role === 'user' ? `${t.speakerName || 'Someone'}: ${t.message}` : `${character.name}: ${t.message}`))
+    .join('\n');
+
+  const systemPrompt = `You maintain the long-term memory of a roleplay character named ${character.name} so the roleplay can continue past the model's context limit. Here is who they are, so the memory stays in-character:
+${character.details}
+
+You are given the character's existing memory (if any) and a transcript of recent events. Rewrite the memory so it ABSORBS the new events. Requirements:
+- Write in ${character.name}'s own first-person perspective, as lived memory.
+- Preserve key facts, relationships, names, the other people's stated preferences and details, unresolved threads, promises, and the emotional progression.
+- Keep the natural arc of how things have developed. Be concise but lose nothing important.
+- Never invent events that are not in the transcript or prior memory.
+Output ONLY the updated memory wrapped exactly as ${MEMORY_OPEN}...${MEMORY_CLOSE} with nothing before or after.`;
+
+  const userPrompt = `${priorMemory ? `Existing memory:\n${priorMemory}\n\n` : ''}Recent events to absorb:\n${transcript}\n\nProduce the updated memory now, wrapped in ${MEMORY_OPEN} and ${MEMORY_CLOSE}.`;
+
+  let raw = '';
+  try {
+    raw = await callDeepseek(
+      [{ role: 'system', content: systemPrompt }, { role: 'user', content: userPrompt }],
+      4096,
+    );
+  } catch (err) {
+    logError(`Rp: compaction request failed for spawn ${spawnId}:`, err);
+    return { ok: false };
+  }
+
+  const memory = parseMemory(raw);
+  if (!memory) {
+    logError(`Rp: compaction returned malformed output for spawn ${spawnId}`);
+    return { ok: false };
+  }
+
+  await db.rp.setCompactionState(spawnId, memory, newUptoId);
+  log(`Rp: compacted spawn ${spawnId} (folded ${toFold.length} rows up to id ${newUptoId})`);
+  return { ok: true, memory, uptoId: newUptoId };
+}
+
+export type RpReplyResult =
+  | { ok: true; text: string }
+  | { ok: false; reason: 'compaction_failed' }
+  | { ok: false; reason: 'error' };
+
+async function loadTail(db: any, spawnId: number, afterId: number): Promise<RpHistoryTurn[]> {
+  const rows = await db.rp.getHistoryAfter(spawnId, afterId);
+  return rows.map((r: any) => ({
+    id: r.id, role: r.role, speakerName: r.speakerName ?? null, message: r.message,
+  }));
+}
+
+/**
+ * Generates the character's next reply from its private history. Assumes the new
+ * incoming user turn(s) are already persisted. Handles auto-compaction, the
+ * compaction-failure halt, and recovery-on-retry (never permanently bricks).
+ */
+export async function generateRpReply(
+  db: any,
+  spawn: RpSpawnState,
+  character: RpCharacterDef,
+): Promise<RpReplyResult> {
+  try {
+    const wasFailed = spawn.compactionFailed;
+    let memory = spawn.compactedMemory;
+    let uptoId = spawn.compactedUptoId ?? 0;
+    let tail = await loadTail(db, spawn.spawnId, uptoId);
+    let systemPrompt = buildSystemPrompt(character, memory);
+
+    if (estimateTokens(systemPrompt, tail) > COMPACTION_TRIGGER_TOKENS) {
+      if (spawn.compactionEnabled) {
+        const res = await compact(db, spawn.spawnId, character, tail, memory);
+        if (res.ok && res.memory) {
+          memory = res.memory;
+          uptoId = res.uptoId ?? uptoId;
+          tail = await loadTail(db, spawn.spawnId, uptoId);
+          systemPrompt = buildSystemPrompt(character, memory);
+        } else if (!res.ok) {
+          if (wasFailed) {
+            // It failed before and is failing again — don't dead-end the character.
+            await db.rp.setCompactionFailed(spawn.spawnId, false);
+            tail = truncateToFit(tail, systemPrompt);
+          } else {
+            await db.rp.setCompactionFailed(spawn.spawnId, true);
+            return { ok: false, reason: 'compaction_failed' };
+          }
+        } else {
+          // Over budget but too little to fold (giant messages) — hard-truncate.
+          tail = truncateToFit(tail, systemPrompt);
+        }
+      } else {
+        tail = truncateToFit(tail, systemPrompt);
+      }
+    } else if (wasFailed) {
+      await db.rp.setCompactionFailed(spawn.spawnId, false);
+    }
+
+    const messages: ChatMessage[] = [
+      { role: 'system', content: systemPrompt },
+      ...tail.map(turnToMessage),
+    ];
+    const text = (await callDeepseek(messages, RP_MAX_OUTPUT)).trim();
+    if (!text) return { ok: false, reason: 'error' };
+    return { ok: true, text };
+  } catch (err) {
+    logError(`Rp: generation failed for spawn ${spawn.spawnId}:`, err);
+    return { ok: false, reason: 'error' };
+  }
+}

--- a/utils/rpChat.ts
+++ b/utils/rpChat.ts
@@ -220,6 +220,11 @@ export async function generateRpReply(
           uptoId = res.uptoId ?? uptoId;
           tail = await loadTail(db, spawn.spawnId, uptoId);
           systemPrompt = buildSystemPrompt(character, memory, userVar);
+          // Compaction can still leave us over budget (a huge memory or character bio),
+          // so re-check and hard-truncate rather than firing an over-limit request.
+          if (estimateTokens(systemPrompt, tail) > COMPACTION_TRIGGER_TOKENS) {
+            tail = truncateToFit(tail, systemPrompt);
+          }
         } else if (!res.ok) {
           if (wasFailed) {
             // It failed before and is failing again — don't dead-end the character.

--- a/utils/rpChat.ts
+++ b/utils/rpChat.ts
@@ -1,5 +1,6 @@
 import { getOpenRouterClient } from './ai';
 import { countTokensOpenRouterMessages } from './tokenizer';
+import { applyUserVar } from './rpIdentity';
 import { logError, log } from './log';
 
 /**
@@ -50,16 +51,18 @@ export interface RpHistoryTurn {
 
 type ChatMessage = { role: 'system' | 'user' | 'assistant'; content: string };
 
-function buildSystemPrompt(character: RpCharacterDef, memory: string | null): string {
+function buildSystemPrompt(character: RpCharacterDef, memory: string | null, userVar: string | null): string {
+  const details = applyUserVar(character.details, userVar);
+  const startingMessage = applyUserVar(character.startingMessage, userVar);
   let prompt = `You are roleplaying as ${character.name}, a character in a Discord channel. Stay fully in character at all times. Never break character, never mention being an AI, and never describe the actions or speech of the people you are talking to. Respond only as ${character.name}.
 
 Character details:
-${character.details}
+${details}
 
 You may be talking with one or more people at once. Each incoming line is prefixed with the speaker's name as "Name: message". Address people naturally by name when it fits. Do not prefix your own reply with your name or a timestamp. Keep replies reasonably concise for a chat.`;
 
-  if (character.startingMessage) {
-    prompt += `\n\nThe conversation opened with you saying:\n"${character.startingMessage}"`;
+  if (startingMessage) {
+    prompt += `\n\nThe conversation opened with you saying:\n"${startingMessage}"`;
   }
   if (memory) {
     prompt += `\n\nThis is your memory of everything that has happened so far, experienced from your own perspective. Treat it as established history and stay consistent with it:\n${memory}`;
@@ -200,13 +203,14 @@ export async function generateRpReply(
   db: any,
   spawn: RpSpawnState,
   character: RpCharacterDef,
+  userVar: string | null = null,
 ): Promise<RpReplyResult> {
   try {
     const wasFailed = spawn.compactionFailed;
     let memory = spawn.compactedMemory;
     let uptoId = spawn.compactedUptoId ?? 0;
     let tail = await loadTail(db, spawn.spawnId, uptoId);
-    let systemPrompt = buildSystemPrompt(character, memory);
+    let systemPrompt = buildSystemPrompt(character, memory, userVar);
 
     if (estimateTokens(systemPrompt, tail) > COMPACTION_TRIGGER_TOKENS) {
       if (spawn.compactionEnabled) {
@@ -215,7 +219,7 @@ export async function generateRpReply(
           memory = res.memory;
           uptoId = res.uptoId ?? uptoId;
           tail = await loadTail(db, spawn.spawnId, uptoId);
-          systemPrompt = buildSystemPrompt(character, memory);
+          systemPrompt = buildSystemPrompt(character, memory, userVar);
         } else if (!res.ok) {
           if (wasFailed) {
             // It failed before and is failing again — don't dead-end the character.

--- a/utils/rpCommand.ts
+++ b/utils/rpCommand.ts
@@ -1,0 +1,81 @@
+import { EmbedBuilder } from 'discord.js';
+import { resolveAvatarUrl } from './rpAvatar';
+import { formatCharHandle } from './rpIdentity';
+
+/**
+ * Shared helpers for the `/ai rp-*` commands: resolving the `char` option (whether
+ * the user picked an autocomplete value or typed a name/id), building the searchable
+ * autocomplete list (`name · @creator · id`), and rendering a character's detail card.
+ */
+
+/** Resolves a `char` option value (a char_id from autocomplete, or a typed name/id). */
+export async function resolveCharOption(db: any, value: string | null): Promise<Record<string, any> | null> {
+  const v = (value ?? '').trim();
+  if (!v) return null;
+  const byId = await db.rp.getCharacter(v);
+  if (byId) return byId;
+  const results = await db.rp.searchCharacters(v);
+  if (results.length === 1) return db.rp.getCharacter(results[0].charId);
+  const exact = results.filter((r: any) => r.nameLower === v.toLowerCase());
+  if (exact.length === 1) return db.rp.getCharacter(exact[0].charId);
+  return null;
+}
+
+/** Builds up-to-25 autocomplete choices for a character search term. */
+export async function buildCharSearchChoices(
+  db: any,
+  client: any,
+  term: string,
+): Promise<{ name: string; value: string }[]> {
+  const rows = await db.rp.searchCharacters(term || '');
+  return rows.slice(0, 25).map((r: any) => {
+    const username = client.users.cache.get(r.creatorId)?.username ?? 'unknown';
+    const label = `${r.name} · @${username} · ${r.charId}`;
+    return { name: label.slice(0, 100), value: r.charId };
+  });
+}
+
+/** Resolves a creator id to a `@username` label (fetches if not cached). */
+export async function resolveCreatorLabel(client: any, creatorId: string): Promise<string> {
+  const cached = client.users.cache.get(creatorId);
+  if (cached) return `@${cached.username}`;
+  try {
+    const user = await client.users.fetch(creatorId);
+    return `@${user.username}`;
+  } catch {
+    return '@unknown';
+  }
+}
+
+/** Renders a character's full detail card (used by rp-details and the create/edit confirmations). */
+export async function characterEmbed(
+  client: any,
+  db: any,
+  character: Record<string, any>,
+  creatorLabel: string,
+): Promise<EmbedBuilder> {
+  const freshPfp = await resolveAvatarUrl(client, db, {
+    charId: character.charId,
+    pfpUrl: character.pfpUrl,
+    pfpMessageId: character.pfpMessageId,
+    pfpChannelId: character.pfpChannelId,
+  });
+
+  const embed = new EmbedBuilder()
+    .setColor('#9B59B6')
+    .setTitle(character.name)
+    .setDescription((character.details || '—').slice(0, 4000))
+    .addFields(
+      { name: 'ID', value: character.charId, inline: true },
+      { name: 'Creator', value: creatorLabel, inline: true },
+      { name: 'Mention', value: `\`${formatCharHandle(character.name, character.charId)}\``, inline: true },
+      { name: 'Starting message', value: (character.startingMessage || '—').slice(0, 1024) },
+    );
+  if (freshPfp) embed.setThumbnail(freshPfp);
+  if (!character.pfpMessageId) {
+    embed.setFooter({ text: 'No pfp set — using the default avatar.' });
+  } else if (!freshPfp) {
+    embed.setFooter({ text: 'pfp is broken (asset message gone) — re-upload with /ai rp-edit.' });
+  }
+  return embed;
+}

--- a/utils/rpCommand.ts
+++ b/utils/rpCommand.ts
@@ -1,6 +1,9 @@
-import { EmbedBuilder } from 'discord.js';
+import { EmbedBuilder, AttachmentBuilder } from 'discord.js';
 import { resolveAvatarUrl } from './rpAvatar';
 import { formatCharHandle } from './rpIdentity';
+
+const DETAILS_PREVIEW_CHARS = 1000;
+const EMBED_FIELD_MAX = 1024;
 
 /**
  * Shared helpers for the `/ai rp-*` commands: resolving the `char` option (whether
@@ -47,13 +50,17 @@ export async function resolveCreatorLabel(client: any, creatorId: string): Promi
   }
 }
 
-/** Renders a character's full detail card (used by rp-details and the create/edit confirmations). */
-export async function characterEmbed(
+/**
+ * Renders a character's detail card. Because `details` can now run to thousands of
+ * tokens, the embed shows a preview and the full `details` / long `starting_message`
+ * ride along as `.txt` attachments. Returns a reply payload ({ embeds, files }).
+ */
+export async function buildCharacterView(
   client: any,
   db: any,
   character: Record<string, any>,
   creatorLabel: string,
-): Promise<EmbedBuilder> {
+): Promise<{ embeds: EmbedBuilder[]; files: AttachmentBuilder[] }> {
   const freshPfp = await resolveAvatarUrl(client, db, {
     charId: character.charId,
     pfpUrl: character.pfpUrl,
@@ -61,21 +68,40 @@ export async function characterEmbed(
     pfpChannelId: character.pfpChannelId,
   });
 
+  const details = character.details || '—';
+  const startingMessage = character.startingMessage || '—';
+  const files: AttachmentBuilder[] = [];
+
+  const detailsPreview = details.length > DETAILS_PREVIEW_CHARS
+    ? `${details.slice(0, DETAILS_PREVIEW_CHARS)}…\n\n*(full details attached as \`details.txt\`)*`
+    : details;
+
   const embed = new EmbedBuilder()
     .setColor('#9B59B6')
     .setTitle(character.name)
-    .setDescription((character.details || '—').slice(0, 4000))
+    .setDescription(detailsPreview)
     .addFields(
       { name: 'ID', value: character.charId, inline: true },
       { name: 'Creator', value: creatorLabel, inline: true },
       { name: 'Mention', value: `\`${formatCharHandle(character.name, character.charId)}\``, inline: true },
-      { name: 'Starting message', value: (character.startingMessage || '—').slice(0, 1024) },
     );
+
+  if (details.length > DETAILS_PREVIEW_CHARS) {
+    files.push(new AttachmentBuilder(Buffer.from(details, 'utf8'), { name: 'details.txt' }));
+  }
+
+  if (startingMessage.length > EMBED_FIELD_MAX) {
+    embed.addFields({ name: 'Starting message', value: '*(attached as `starting_message.txt`)*' });
+    files.push(new AttachmentBuilder(Buffer.from(startingMessage, 'utf8'), { name: 'starting_message.txt' }));
+  } else {
+    embed.addFields({ name: 'Starting message', value: startingMessage });
+  }
+
   if (freshPfp) embed.setThumbnail(freshPfp);
   if (!character.pfpMessageId) {
     embed.setFooter({ text: 'No pfp set — using the default avatar.' });
   } else if (!freshPfp) {
     embed.setFooter({ text: 'pfp is broken (asset message gone) — re-upload with /ai rp-edit.' });
   }
-  return embed;
+  return { embeds: [embed], files };
 }

--- a/utils/rpDelivery.ts
+++ b/utils/rpDelivery.ts
@@ -40,9 +40,11 @@ export function splitMessage(text: string): string[] {
     if (remaining.length <= MAX_LENGTH) { chunks.push(remaining); break; }
     let chunk = remaining.slice(0, MAX_LENGTH);
     const breakIndex = Math.max(chunk.lastIndexOf('\n'), chunk.lastIndexOf(' '));
-    if (breakIndex > 0) chunk = remaining.slice(0, breakIndex);
+    // Keep the break character with the current chunk and don't trim the remainder,
+    // so spaces/newlines at chunk boundaries survive (splitting is lossless).
+    if (breakIndex > 0) chunk = remaining.slice(0, breakIndex + 1);
     chunks.push(chunk);
-    remaining = remaining.slice(chunk.length).trimStart();
+    remaining = remaining.slice(chunk.length);
   }
   return chunks;
 }

--- a/utils/rpDelivery.ts
+++ b/utils/rpDelivery.ts
@@ -1,0 +1,101 @@
+import {
+  ActionRowBuilder, ButtonBuilder, ButtonStyle, type TextChannel,
+} from 'discord.js';
+import { resolveAvatarUrl } from './rpAvatar';
+import { logError } from './log';
+
+/**
+ * Delivers a roleplay character's message through the shared AI webhook, overriding
+ * the per-message username + avatar so each character appears as itself. Model output
+ * is posted with all mentions disabled so a character can never ping anyone.
+ */
+
+const WEBHOOK_NAME = process.env.WEBHOOK_NAME || 'grok-webhook';
+const MAX_LENGTH = 2000;
+
+/** Splits text into <=2000-char chunks, breaking on whitespace where possible. */
+export function splitMessage(text: string): string[] {
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > 0) {
+    if (remaining.length <= MAX_LENGTH) { chunks.push(remaining); break; }
+    let chunk = remaining.slice(0, MAX_LENGTH);
+    const breakIndex = Math.max(chunk.lastIndexOf('\n'), chunk.lastIndexOf(' '));
+    if (breakIndex > 0) chunk = remaining.slice(0, breakIndex);
+    chunks.push(chunk);
+    remaining = remaining.slice(chunk.length).trimStart();
+  }
+  return chunks;
+}
+
+async function getRpWebhook(channel: TextChannel, client: any): Promise<any | null> {
+  try {
+    const webhooks = await channel.fetchWebhooks();
+    let webhook = webhooks.find((wh: any) => wh.name === WEBHOOK_NAME && wh.token);
+    if (!webhook) {
+      webhook = await channel.createWebhook({
+        name: WEBHOOK_NAME,
+        avatar: client.user?.displayAvatarURL(),
+      });
+    }
+    return webhook;
+  } catch (err) {
+    logError('Rp: failed to get/create webhook (missing Manage Webhooks?):', err);
+    return null;
+  }
+}
+
+export interface CharacterDelivery {
+  charId: string;
+  name: string;
+  pfpUrl?: string | null;
+  pfpMessageId?: string | null;
+  pfpChannelId?: string | null;
+}
+
+/** Posts `text` as the given character. Returns false if delivery was impossible. */
+export async function sendAsCharacter(opts: {
+  client: any;
+  db: any;
+  channel: TextChannel;
+  character: CharacterDelivery;
+  text: string;
+  replyToUrl?: string | null;
+  replyToLabel?: string | null;
+}): Promise<boolean> {
+  const {
+    client, db, channel, character, text,
+  } = opts;
+  const webhook = await getRpWebhook(channel, client);
+  if (!webhook) return false;
+
+  const avatarURL = (await resolveAvatarUrl(client, db, character))
+    ?? client.user?.displayAvatarURL();
+  const chunks = splitMessage(text || '…');
+
+  try {
+    for (let i = 0; i < chunks.length; i += 1) {
+      const components: ActionRowBuilder<ButtonBuilder>[] = [];
+      if (i === 0 && opts.replyToUrl) {
+        components.push(new ActionRowBuilder<ButtonBuilder>().addComponents(
+          new ButtonBuilder()
+            .setLabel(`↩ Replying to: ${opts.replyToLabel || 'message'}`.slice(0, 80))
+            .setStyle(ButtonStyle.Link)
+            .setURL(opts.replyToUrl),
+        ));
+      }
+      // eslint-disable-next-line no-await-in-loop
+      await webhook.send({
+        content: chunks[i],
+        username: character.name,
+        avatarURL,
+        components,
+        allowedMentions: { parse: [] },
+      });
+    }
+    return true;
+  } catch (err) {
+    logError(`Rp: failed to send as character ${character.charId}:`, err);
+    return false;
+  }
+}

--- a/utils/rpDelivery.ts
+++ b/utils/rpDelivery.ts
@@ -13,6 +13,25 @@ import { logError } from './log';
 const WEBHOOK_NAME = process.env.WEBHOOK_NAME || 'grok-webhook';
 const MAX_LENGTH = 2000;
 
+// Webhooks can't emit a Discord typing indicator (and the bot's own would show as
+// "Silverwolf", breaking character), so we post this as the character and then edit
+// it into the reply once the model returns.
+export const TYPING_PLACEHOLDER = '*typing.  .  .*';
+
+/** The "↩ Replying to" link button, or [] when there's nothing to link. */
+function replyButtonRow(
+  replyToUrl?: string | null,
+  replyToLabel?: string | null,
+): ActionRowBuilder<ButtonBuilder>[] {
+  if (!replyToUrl) return [];
+  return [new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setLabel(`↩ Replying to: ${replyToLabel || 'message'}`.slice(0, 80))
+      .setStyle(ButtonStyle.Link)
+      .setURL(replyToUrl),
+  )];
+}
+
 /** Splits text into <=2000-char chunks, breaking on whitespace where possible. */
 export function splitMessage(text: string): string[] {
   const chunks: string[] = [];
@@ -75,21 +94,12 @@ export async function sendAsCharacter(opts: {
 
   try {
     for (let i = 0; i < chunks.length; i += 1) {
-      const components: ActionRowBuilder<ButtonBuilder>[] = [];
-      if (i === 0 && opts.replyToUrl) {
-        components.push(new ActionRowBuilder<ButtonBuilder>().addComponents(
-          new ButtonBuilder()
-            .setLabel(`↩ Replying to: ${opts.replyToLabel || 'message'}`.slice(0, 80))
-            .setStyle(ButtonStyle.Link)
-            .setURL(opts.replyToUrl),
-        ));
-      }
       // eslint-disable-next-line no-await-in-loop
       await webhook.send({
         content: chunks[i],
         username: character.name,
         avatarURL,
-        components,
+        components: i === 0 ? replyButtonRow(opts.replyToUrl, opts.replyToLabel) : [],
         allowedMentions: { parse: [] },
       });
     }
@@ -97,5 +107,85 @@ export async function sendAsCharacter(opts: {
   } catch (err) {
     logError(`Rp: failed to send as character ${character.charId}:`, err);
     return false;
+  }
+}
+
+/** Handles to a posted "typing" placeholder so it can be edited into the reply. */
+export interface CharacterTyping {
+  webhook: any;
+  messageId: string;
+  name: string;
+  avatarURL: string;
+}
+
+/**
+ * Posts the character's "typing" placeholder immediately (so the wait reads as the
+ * character thinking, not the bot). Returns handles to edit it, or null if delivery
+ * is impossible (e.g. missing Manage Webhooks).
+ */
+export async function postCharacterPlaceholder(opts: {
+  client: any;
+  db: any;
+  channel: TextChannel;
+  character: CharacterDelivery;
+}): Promise<CharacterTyping | null> {
+  const {
+    client, db, channel, character,
+  } = opts;
+  const webhook = await getRpWebhook(channel, client);
+  if (!webhook) return null;
+  const avatarURL = (await resolveAvatarUrl(client, db, character))
+    ?? client.user?.displayAvatarURL();
+  try {
+    const msg = await webhook.send({
+      content: TYPING_PLACEHOLDER,
+      username: character.name,
+      avatarURL,
+      allowedMentions: { parse: [] },
+    });
+    return {
+      webhook, messageId: msg.id, name: character.name, avatarURL,
+    };
+  } catch (err) {
+    logError(`Rp: failed to post typing placeholder for ${character.charId}:`, err);
+    return null;
+  }
+}
+
+/** Edits the placeholder into the reply's first chunk; overflow follows as new messages. */
+export async function editCharacterReply(typing: CharacterTyping, opts: {
+  text: string;
+  replyToUrl?: string | null;
+  replyToLabel?: string | null;
+}): Promise<boolean> {
+  const chunks = splitMessage(opts.text || '…');
+  try {
+    await typing.webhook.editMessage(typing.messageId, {
+      content: chunks[0],
+      components: replyButtonRow(opts.replyToUrl, opts.replyToLabel),
+      allowedMentions: { parse: [] },
+    });
+    for (let i = 1; i < chunks.length; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await typing.webhook.send({
+        content: chunks[i],
+        username: typing.name,
+        avatarURL: typing.avatarURL,
+        allowedMentions: { parse: [] },
+      });
+    }
+    return true;
+  } catch (err) {
+    logError('Rp: failed to edit typing placeholder into reply:', err);
+    return false;
+  }
+}
+
+/** Removes the placeholder (used when generation fails, so no "typing…" is left dangling). */
+export async function deleteCharacterPlaceholder(typing: CharacterTyping): Promise<void> {
+  try {
+    await typing.webhook.deleteMessage(typing.messageId);
+  } catch {
+    /* already gone / no perms — nothing to do */
   }
 }

--- a/utils/rpIdentity.ts
+++ b/utils/rpIdentity.ts
@@ -81,8 +81,9 @@ export interface MentionMatchResult {
 
 // `@` + (name|id) optionally followed by `-idprefix`. Names exclude `-`, so the
 // dash unambiguously starts the id part. Leading char must not be part of a word
-// (so emails like name@host don't trigger).
-const MENTION_RE = /(?:^|[^\w])@([A-Za-z0-9_]+)(?:-([a-z0-9]+))?/g;
+// (so emails like name@host don't trigger). The id prefix accepts either case and
+// is lowercased before matching, so `@Aventurine-A2E` disambiguates too.
+const MENTION_RE = /(?:^|[^\w])@([A-Za-z0-9_]+)(?:-([A-Za-z0-9]+))?/g;
 
 /**
  * Routes a message to spawned characters by parsing its `@mentions`. A bare token

--- a/utils/rpIdentity.ts
+++ b/utils/rpIdentity.ts
@@ -1,0 +1,108 @@
+/**
+ * Identity helpers for roleplay characters: id allocation, name validation, and
+ * the `@mention` grammar that routes channel messages to spawned characters.
+ *
+ * A character is identified by a 6-char lowercase-alphanumeric `char_id` plus its
+ * `name`. Because names are restricted to `[A-Za-z0-9_]` (no `-`), the dash is a
+ * safe separator for the disambiguated form `@name-idprefix`.
+ */
+
+export const MAX_SPAWNS_PER_CHANNEL = 5;
+export const MAX_CHARS_PER_USER = 25;
+export const CHAR_ID_LENGTH = 6;
+export const NAME_MAX_LENGTH = 32;
+export const DETAILS_MAX_LENGTH = 4000;
+export const STARTING_MESSAGE_MAX_LENGTH = 2000;
+
+const ID_ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789';
+const NAME_RE = /^[A-Za-z0-9_]{1,32}$/;
+// Discord rejects these substrings/values in webhook usernames.
+const RESERVED_NAME_SUBSTRINGS = ['discord', 'clyde'];
+const RESERVED_NAMES = ['everyone', 'here'];
+
+/** Generates a random 6-char lowercase-alphanumeric character id. */
+export function generateCharId(): string {
+  let out = '';
+  for (let i = 0; i < CHAR_ID_LENGTH; i += 1) {
+    out += ID_ALPHABET[Math.floor(Math.random() * ID_ALPHABET.length)];
+  }
+  return out;
+}
+
+/** Returns a user-facing error string if the name is invalid, else null. */
+export function validateCharName(name: string): string | null {
+  const trimmed = (name ?? '').trim();
+  if (!trimmed) return 'Name is required.';
+  if (!NAME_RE.test(trimmed)) {
+    return 'Name must be 1–32 characters, letters/numbers/underscores only (no spaces or dashes).';
+  }
+  const lower = trimmed.toLowerCase();
+  if (RESERVED_NAMES.includes(lower)) return `"${trimmed}" is a reserved name.`;
+  if (RESERVED_NAME_SUBSTRINGS.some((s) => lower.includes(s))) {
+    return 'Name can\'t contain "discord" or "clyde" (Discord blocks those in webhooks).';
+  }
+  return null;
+}
+
+/** `@aventurine-a2e4se` — the always-unique disambiguated handle for a character. */
+export function formatCharHandle(name: string, charId: string): string {
+  return `@${name}-${charId}`;
+}
+
+export interface SpawnLike {
+  spawnId: number;
+  charId: string;
+  nameLower: string;
+}
+
+export interface MentionMatchResult {
+  /** Distinct spawns the message unambiguously addresses. */
+  matched: SpawnLike[];
+  /** Tokens that matched more than one spawn, with the candidates to disambiguate. */
+  ambiguous: { token: string; candidates: SpawnLike[] }[];
+}
+
+// `@` + (name|id) optionally followed by `-idprefix`. Names exclude `-`, so the
+// dash unambiguously starts the id part. Leading char must not be part of a word
+// (so emails like name@host don't trigger).
+const MENTION_RE = /(?:^|[^\w])@([A-Za-z0-9_]+)(?:-([a-z0-9]+))?/g;
+
+/**
+ * Routes a message to spawned characters by parsing its `@mentions`. A bare token
+ * matches by name-prefix OR id-prefix; `name-idprefix` requires both. A token that
+ * resolves to exactly one spawn is "matched"; >1 is "ambiguous"; 0 is ignored.
+ */
+export function matchMentions(content: string, spawns: SpawnLike[]): MentionMatchResult {
+  const matchedById = new Map<number, SpawnLike>();
+  const ambiguous: { token: string; candidates: SpawnLike[] }[] = [];
+  const seenAmbiguousTokens = new Set<string>();
+
+  let m: RegExpExecArray | null;
+  // eslint-disable-next-line no-cond-assign
+  while ((m = MENTION_RE.exec(content)) !== null) {
+    const main = m[1].toLowerCase();
+    const idPart = m[2]?.toLowerCase();
+    const token = idPart ? `${main}-${idPart}` : main;
+
+    let candidates: SpawnLike[];
+    if (idPart) {
+      candidates = spawns.filter((s) => s.nameLower.startsWith(main) && s.charId.startsWith(idPart));
+    } else {
+      candidates = spawns.filter((s) => s.nameLower.startsWith(main) || s.charId.startsWith(main));
+    }
+
+    // Dedup candidates by char (a name and id prefix could hit the same spawn twice).
+    const uniq = new Map<string, SpawnLike>();
+    candidates.forEach((c) => uniq.set(c.charId, c));
+    const list = [...uniq.values()];
+
+    if (list.length === 1) {
+      matchedById.set(list[0].spawnId, list[0]);
+    } else if (list.length > 1 && !seenAmbiguousTokens.has(token)) {
+      seenAmbiguousTokens.add(token);
+      ambiguous.push({ token, candidates: list });
+    }
+  }
+
+  return { matched: [...matchedById.values()], ambiguous };
+}

--- a/utils/rpIdentity.ts
+++ b/utils/rpIdentity.ts
@@ -11,8 +11,16 @@ export const MAX_SPAWNS_PER_CHANNEL = 5;
 export const MAX_CHARS_PER_USER = 25;
 export const CHAR_ID_LENGTH = 6;
 export const NAME_MAX_LENGTH = 32;
-export const DETAILS_MAX_LENGTH = 4000;
-export const STARTING_MESSAGE_MAX_LENGTH = 2000;
+/** Token budget for `details` (the system prompt); enforced via the char/4 estimator. */
+export const DETAILS_MAX_TOKENS = 4000;
+/** Discord caps a string option at 6000 chars — the large path is the .json upload. */
+export const DETAILS_OPTION_MAX_LENGTH = 6000;
+export const STARTING_MESSAGE_MAX_LENGTH = 6000;
+/** Hard cap on an uploaded character .json before we even parse it. */
+export const MAX_CHAR_JSON_BYTES = 128 * 1024;
+
+/** Substituted with the spawner's name in self-mode; left literal in all-mode. */
+export const USER_VAR = '{user}';
 
 const ID_ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789';
 const NAME_RE = /^[A-Za-z0-9_]{1,32}$/;
@@ -47,6 +55,15 @@ export function validateCharName(name: string): string | null {
 /** `@aventurine-a2e4se` — the always-unique disambiguated handle for a character. */
 export function formatCharHandle(name: string, charId: string): string {
   return `@${name}-${charId}`;
+}
+
+/**
+ * Substitutes the `{user}` variable. In self-mode `userName` is the spawner's name;
+ * in all-mode `userName` is null and the token is left literal (there's no single user).
+ */
+export function applyUserVar(text: string, userName: string | null): string {
+  if (!userName || !text.includes(USER_VAR)) return text;
+  return text.split(USER_VAR).join(userName);
 }
 
 export interface SpawnLike {

--- a/utils/rpRuntime.ts
+++ b/utils/rpRuntime.ts
@@ -1,0 +1,225 @@
+import type { TextChannel } from 'discord.js';
+import { matchMentions, formatCharHandle } from './rpIdentity';
+import { generateRpReply } from './rpChat';
+import { sendAsCharacter } from './rpDelivery';
+import { logError } from './log';
+
+/**
+ * Runtime glue for roleplay: routes channel messages to spawned characters and runs
+ * the proactive "all"-mode replies. Generation is throttled (only on a direct mention,
+ * or one proactive reply per channel per scheduler tick); bot/webhook messages never
+ * reach here (processMessage drops them), so characters never hear each other.
+ *
+ * `activeRpChannels` is an in-memory fast-path: the message router returns instantly
+ * unless the channel actually has a spawn, so normal traffic never touches the DB.
+ */
+
+const activeRpChannels = new Set<string>();
+
+/** Rebuilds the active-channel set from the DB (call on boot). */
+export async function recomputeActiveRpChannels(db: any): Promise<void> {
+  try {
+    const channels = await db.rp.getDistinctActiveChannels();
+    activeRpChannels.clear();
+    channels.forEach((c: string) => activeRpChannels.add(c));
+  } catch (err) {
+    logError('Rp: failed to recompute active channels:', err);
+  }
+}
+
+export function markRpChannelActive(channelId: string): void {
+  activeRpChannels.add(channelId);
+}
+
+/** Drops a channel from the fast-path set if it no longer has active spawns. */
+export async function refreshRpChannel(db: any, channelId: string): Promise<void> {
+  const count = await db.rp.countActiveSpawnsInChannel(channelId);
+  if (count > 0) activeRpChannels.add(channelId);
+  else activeRpChannels.delete(channelId);
+}
+
+interface RespondOpts {
+  replyToUrl?: string | null;
+  replyToLabel?: string | null;
+  /** Surface a notice to the user (router uses message.reply); omit to stay silent on errors. */
+  notify?: (text: string) => Promise<void>;
+}
+
+/**
+ * Generates and delivers one reply for a spawned character. Assumes any incoming user
+ * turn is already recorded. Records the model turn on success; surfaces compaction
+ * failure (and re-mention recovery is handled inside generateRpReply).
+ */
+async function respondAsCharacter(
+  client: any,
+  db: any,
+  channel: TextChannel,
+  row: any,
+  opts: RespondOpts = {},
+): Promise<void> {
+  channel.sendTyping?.().catch(() => {});
+
+  const result = await generateRpReply(db, {
+    spawnId: row.spawnId,
+    compactionEnabled: row.compactionEnabled === 1,
+    compactedMemory: row.compactedMemory ?? null,
+    compactedUptoId: row.compactedUptoId ?? null,
+    compactionFailed: row.compactionFailed === 1,
+  }, {
+    charId: row.charId,
+    name: row.charName,
+    details: row.charDetails,
+    startingMessage: row.charStartingMessage,
+  });
+
+  if (result.ok) {
+    await db.rp.addHistory(row.spawnId, 'model', result.text);
+    await db.rp.touchSpawnActivity(row.spawnId);
+    await sendAsCharacter({
+      client,
+      db,
+      channel,
+      character: {
+        charId: row.charId,
+        name: row.charName,
+        pfpUrl: row.charPfpUrl,
+        pfpMessageId: row.charPfpMessageId,
+        pfpChannelId: row.charPfpChannelId,
+      },
+      text: result.text,
+      replyToUrl: opts.replyToUrl,
+      replyToLabel: opts.replyToLabel,
+    });
+    return;
+  }
+
+  if (result.reason === 'compaction_failed') {
+    const notice = `⚠️ **${row.charName}** has run out of context and automatic compaction failed. `
+      + 'Mention them again to retry — if it keeps failing the oldest messages will be dropped instead.';
+    if (opts.notify) await opts.notify(notice);
+    else await channel.send({ content: notice, allowedMentions: { parse: [] } }).catch(() => {});
+    return;
+  }
+
+  // Generic error: surface only when a user is waiting (mention path), else stay quiet.
+  if (opts.notify) {
+    await opts.notify(`⚠️ **${row.charName}** couldn't respond right now. Try again in a moment.`);
+  }
+}
+
+/**
+ * Message-router entry point. Records the message into every spawn that "hears" it
+ * (all-mode hears everyone; self-mode hears only its spawner), then fires immediate
+ * replies for any characters the message directly @mentions.
+ */
+export async function handleRpMessage(client: any, message: any): Promise<void> {
+  const db = client.db;
+  const channelId = message.channel.id;
+  if (!activeRpChannels.has(channelId)) return;
+
+  let spawns: any[];
+  try {
+    spawns = await db.rp.getActiveSpawnsInChannel(channelId);
+  } catch (err) {
+    logError('Rp: failed to load spawns for channel:', err);
+    return;
+  }
+  if (spawns.length === 0) { activeRpChannels.delete(channelId); return; }
+
+  const content = message.content ?? '';
+  const authorId = message.author.id;
+  const speakerName = message.member?.displayName || message.author.username;
+
+  // All-mode characters hear the whole channel; record every message as context.
+  // Self-mode characters only register their spawner's directed mentions (below).
+  const heard = spawns.filter((s) => s.interactability === 'all');
+  await Promise.all(heard.map(async (s) => {
+    await db.rp.addHistory(s.spawnId, 'user', content, { id: authorId, name: speakerName });
+    await db.rp.touchSpawnActivity(s.spawnId);
+  }));
+
+  if (!content.includes('@')) return;
+
+  const spawnLikes = spawns.map((s) => ({ spawnId: s.spawnId, charId: s.charId, nameLower: s.charNameLower }));
+  const { matched, ambiguous } = matchMentions(content, spawnLikes);
+
+  for (const amb of ambiguous) {
+    const lines = amb.candidates
+      .map((c) => {
+        const sp = spawns.find((s) => s.spawnId === c.spawnId);
+        return sp ? `• \`${formatCharHandle(sp.charName, sp.charId)}\`` : null;
+      })
+      .filter(Boolean)
+      .join('\n');
+    // eslint-disable-next-line no-await-in-loop
+    await message.reply({
+      content: `\`@${amb.token}\` matches multiple characters here — be more specific:\n${lines}`,
+      allowedMentions: { repliedUser: false },
+    }).catch(() => {});
+  }
+
+  for (const sl of matched) {
+    const spawn = spawns.find((s) => s.spawnId === sl.spawnId);
+    if (!spawn) continue;
+    if (spawn.interactability === 'self') {
+      // Self-mode ignores everyone but its spawner, and records only directed mentions
+      // (all-mode mentions were already recorded by the "heard" pass above).
+      if (authorId !== spawn.spawnerId) continue;
+      // eslint-disable-next-line no-await-in-loop
+      await db.rp.addHistory(spawn.spawnId, 'user', content, { id: authorId, name: speakerName });
+      // eslint-disable-next-line no-await-in-loop
+      await db.rp.touchSpawnActivity(spawn.spawnId);
+    }
+    const jump = `https://discord.com/channels/${message.guildId}/${channelId}/${message.id}`;
+    // eslint-disable-next-line no-await-in-loop
+    await respondAsCharacter(client, db, message.channel as TextChannel, spawn, {
+      replyToUrl: jump,
+      replyToLabel: speakerName,
+      notify: (t: string) => message.reply({ content: t, allowedMentions: { repliedUser: false } })
+        .then(() => {}).catch(() => {}),
+    });
+  }
+}
+
+/**
+ * One scheduler tick: each active "all"-mode character with an un-answered user turn
+ * is a candidate; we fire at most one proactive reply per channel (so 5 characters
+ * don't all pile on). Channels with nothing new stay dormant (hibernation).
+ */
+export async function runProactiveRpTick(client: any): Promise<void> {
+  if (typeof client.isReady === 'function' && !client.isReady()) return;
+  const db = client.db;
+
+  let spawns: any[];
+  try {
+    spawns = await db.rp.getActiveAllSpawns();
+  } catch (err) {
+    logError('Rp: failed to load all-mode spawns:', err);
+    return;
+  }
+  if (spawns.length === 0) return;
+
+  const byChannel = new Map<string, any[]>();
+  for (const s of spawns) {
+    const list = byChannel.get(s.channelId) ?? [];
+    list.push(s);
+    byChannel.set(s.channelId, list);
+  }
+
+  for (const [channelId, list] of byChannel) {
+    const candidates: any[] = [];
+    for (const s of list) {
+      // eslint-disable-next-line no-await-in-loop
+      const lastRole = await db.rp.getLastHistoryRole(s.spawnId);
+      if (lastRole === 'user') candidates.push(s);
+    }
+    if (candidates.length === 0) continue;
+
+    const chosen = candidates[Math.floor(Math.random() * candidates.length)];
+    // eslint-disable-next-line no-await-in-loop
+    const channel = await client.channels.fetch(channelId).catch(() => null);
+    if (!channel || typeof channel.send !== 'function') continue;
+    // eslint-disable-next-line no-await-in-loop
+    await respondAsCharacter(client, db, channel as TextChannel, chosen, {});
+  }
+}

--- a/utils/rpRuntime.ts
+++ b/utils/rpRuntime.ts
@@ -18,6 +18,12 @@ import { logError } from './log';
 
 const activeRpChannels = new Set<string>();
 
+// Spawn ids currently generating/delivering a reply. The message router (fire-and-
+// forget) and the 30s proactive scheduler can both target the same spawn at once;
+// this serializes them so they can't read the same last user turn and post duplicate
+// or out-of-order replies. Single process, so an in-memory lock suffices.
+const inFlightSpawns = new Set<number>();
+
 /** Rebuilds the active-channel set from the DB (call on boot). */
 export async function recomputeActiveRpChannels(db: any): Promise<void> {
   try {
@@ -61,63 +67,85 @@ async function respondAsCharacter(
   row: any,
   opts: RespondOpts = {},
 ): Promise<void> {
-  const character = {
-    charId: row.charId,
-    name: row.charName,
-    pfpUrl: row.charPfpUrl,
-    pfpMessageId: row.charPfpMessageId,
-    pfpChannelId: row.charPfpChannelId,
-  };
+  const spawnId: number = row.spawnId;
+  // Drop overlapping triggers for the same spawn (see inFlightSpawns above). The
+  // skipped trigger's message is already in history, so the in-flight reply picks it up.
+  if (inFlightSpawns.has(spawnId)) return;
+  inFlightSpawns.add(spawnId);
+  try {
+    const character = {
+      charId: row.charId,
+      name: row.charName,
+      pfpUrl: row.charPfpUrl,
+      pfpMessageId: row.charPfpMessageId,
+      pfpChannelId: row.charPfpChannelId,
+    };
 
-  // Post "typing.  .  ." as the character right away, then edit it into the reply —
-  // the wait reads as the character thinking rather than "Silverwolf is typing".
-  const typing = await postCharacterPlaceholder({
-    client, db, channel, character,
-  });
+    // Post "typing.  .  ." as the character right away, then edit it into the reply —
+    // the wait reads as the character thinking rather than "Silverwolf is typing".
+    const typing = await postCharacterPlaceholder({
+      client, db, channel, character,
+    });
 
-  const result = await generateRpReply(db, {
-    spawnId: row.spawnId,
-    compactionEnabled: row.compactionEnabled === 1,
-    compactedMemory: row.compactedMemory ?? null,
-    compactedUptoId: row.compactedUptoId ?? null,
-    compactionFailed: row.compactionFailed === 1,
-  }, {
-    charId: row.charId,
-    name: row.charName,
-    details: row.charDetails,
-    startingMessage: row.charStartingMessage,
-  }, opts.userVar ?? null);
+    const result = await generateRpReply(db, {
+      spawnId,
+      compactionEnabled: row.compactionEnabled === 1,
+      compactedMemory: row.compactedMemory ?? null,
+      compactedUptoId: row.compactedUptoId ?? null,
+      compactionFailed: row.compactionFailed === 1,
+    }, {
+      charId: row.charId,
+      name: row.charName,
+      details: row.charDetails,
+      startingMessage: row.charStartingMessage,
+    }, opts.userVar ?? null);
 
-  if (result.ok) {
-    await db.rp.addHistory(row.spawnId, 'model', result.text);
-    await db.rp.touchSpawnActivity(row.spawnId);
-    if (typing) {
-      await editCharacterReply(typing, {
-        text: result.text, replyToUrl: opts.replyToUrl, replyToLabel: opts.replyToLabel,
-      });
-    } else {
-      // Placeholder couldn't be posted (raced/perms) — fall back to a plain send.
-      await sendAsCharacter({
-        client, db, channel, character, text: result.text, replyToUrl: opts.replyToUrl, replyToLabel: opts.replyToLabel,
-      });
+    if (result.ok) {
+      // Deliver first; only persist the model turn once it actually reached the
+      // channel, so a webhook failure can't seed history with a line nobody saw.
+      const delivered = typing
+        ? await editCharacterReply(typing, {
+          text: result.text, replyToUrl: opts.replyToUrl, replyToLabel: opts.replyToLabel,
+        })
+        : await sendAsCharacter({
+          client,
+          db,
+          channel,
+          character,
+          text: result.text,
+          replyToUrl: opts.replyToUrl,
+          replyToLabel: opts.replyToLabel,
+        });
+      if (delivered) {
+        await db.rp.addHistory(spawnId, 'model', result.text);
+        await db.rp.touchSpawnActivity(spawnId);
+        return;
+      }
+      // Delivery failed — clear any dangling placeholder and don't record the turn.
+      if (typing) await deleteCharacterPlaceholder(typing);
+      if (opts.notify) {
+        await opts.notify(`⚠️ **${row.charName}** couldn't post its reply right now. Try again in a moment.`);
+      }
+      return;
     }
-    return;
-  }
 
-  // Generation failed — clear the dangling "typing…" before surfacing anything.
-  if (typing) await deleteCharacterPlaceholder(typing);
+    // Generation failed — clear the dangling "typing…" before surfacing anything.
+    if (typing) await deleteCharacterPlaceholder(typing);
 
-  if (result.reason === 'compaction_failed') {
-    const notice = `⚠️ **${row.charName}** has run out of context and automatic compaction failed. `
-      + 'Mention them again to retry — if it keeps failing the oldest messages will be dropped instead.';
-    if (opts.notify) await opts.notify(notice);
-    else await channel.send({ content: notice, allowedMentions: { parse: [] } }).catch(() => {});
-    return;
-  }
+    if (result.reason === 'compaction_failed') {
+      const notice = `⚠️ **${row.charName}** has run out of context and automatic compaction failed. `
+        + 'Mention them again to retry — if it keeps failing the oldest messages will be dropped instead.';
+      if (opts.notify) await opts.notify(notice);
+      else await channel.send({ content: notice, allowedMentions: { parse: [] } }).catch(() => {});
+      return;
+    }
 
-  // Generic error: surface only when a user is waiting (mention path), else stay quiet.
-  if (opts.notify) {
-    await opts.notify(`⚠️ **${row.charName}** couldn't respond right now. Try again in a moment.`);
+    // Generic error: surface only when a user is waiting (mention path), else stay quiet.
+    if (opts.notify) {
+      await opts.notify(`⚠️ **${row.charName}** couldn't respond right now. Try again in a moment.`);
+    }
+  } finally {
+    inFlightSpawns.delete(spawnId);
   }
 }
 

--- a/utils/rpRuntime.ts
+++ b/utils/rpRuntime.ts
@@ -41,6 +41,8 @@ export async function refreshRpChannel(db: any, channelId: string): Promise<void
 interface RespondOpts {
   replyToUrl?: string | null;
   replyToLabel?: string | null;
+  /** Self-mode: the spawner's name for `{user}` substitution. Null in all-mode. */
+  userVar?: string | null;
   /** Surface a notice to the user (router uses message.reply); omit to stay silent on errors. */
   notify?: (text: string) => Promise<void>;
 }
@@ -70,7 +72,7 @@ async function respondAsCharacter(
     name: row.charName,
     details: row.charDetails,
     startingMessage: row.charStartingMessage,
-  });
+  }, opts.userVar ?? null);
 
   if (result.ok) {
     await db.rp.addHistory(row.spawnId, 'model', result.text);
@@ -171,10 +173,13 @@ export async function handleRpMessage(client: any, message: any): Promise<void> 
       await db.rp.touchSpawnActivity(spawn.spawnId);
     }
     const jump = `https://discord.com/channels/${message.guildId}/${channelId}/${message.id}`;
+    // Self-mode substitutes {user} with the spawner (who is the only one talking to it).
+    const userVar = spawn.interactability === 'self' ? speakerName : null;
     // eslint-disable-next-line no-await-in-loop
     await respondAsCharacter(client, db, message.channel as TextChannel, spawn, {
       replyToUrl: jump,
       replyToLabel: speakerName,
+      userVar,
       notify: (t: string) => message.reply({ content: t, allowedMentions: { repliedUser: false } })
         .then(() => {}).catch(() => {}),
     });

--- a/utils/rpRuntime.ts
+++ b/utils/rpRuntime.ts
@@ -1,7 +1,9 @@
 import type { TextChannel } from 'discord.js';
 import { matchMentions, formatCharHandle } from './rpIdentity';
 import { generateRpReply } from './rpChat';
-import { sendAsCharacter } from './rpDelivery';
+import {
+  sendAsCharacter, postCharacterPlaceholder, editCharacterReply, deleteCharacterPlaceholder,
+} from './rpDelivery';
 import { logError } from './log';
 
 /**
@@ -59,7 +61,19 @@ async function respondAsCharacter(
   row: any,
   opts: RespondOpts = {},
 ): Promise<void> {
-  channel.sendTyping?.().catch(() => {});
+  const character = {
+    charId: row.charId,
+    name: row.charName,
+    pfpUrl: row.charPfpUrl,
+    pfpMessageId: row.charPfpMessageId,
+    pfpChannelId: row.charPfpChannelId,
+  };
+
+  // Post "typing.  .  ." as the character right away, then edit it into the reply —
+  // the wait reads as the character thinking rather than "Silverwolf is typing".
+  const typing = await postCharacterPlaceholder({
+    client, db, channel, character,
+  });
 
   const result = await generateRpReply(db, {
     spawnId: row.spawnId,
@@ -77,23 +91,21 @@ async function respondAsCharacter(
   if (result.ok) {
     await db.rp.addHistory(row.spawnId, 'model', result.text);
     await db.rp.touchSpawnActivity(row.spawnId);
-    await sendAsCharacter({
-      client,
-      db,
-      channel,
-      character: {
-        charId: row.charId,
-        name: row.charName,
-        pfpUrl: row.charPfpUrl,
-        pfpMessageId: row.charPfpMessageId,
-        pfpChannelId: row.charPfpChannelId,
-      },
-      text: result.text,
-      replyToUrl: opts.replyToUrl,
-      replyToLabel: opts.replyToLabel,
-    });
+    if (typing) {
+      await editCharacterReply(typing, {
+        text: result.text, replyToUrl: opts.replyToUrl, replyToLabel: opts.replyToLabel,
+      });
+    } else {
+      // Placeholder couldn't be posted (raced/perms) — fall back to a plain send.
+      await sendAsCharacter({
+        client, db, channel, character, text: result.text, replyToUrl: opts.replyToUrl, replyToLabel: opts.replyToLabel,
+      });
+    }
     return;
   }
+
+  // Generation failed — clear the dangling "typing…" before surfacing anything.
+  if (typing) await deleteCharacterPlaceholder(typing);
 
   if (result.reason === 'compaction_failed') {
     const notice = `⚠️ **${row.charName}** has run out of context and automatic compaction failed. `


### PR DESCRIPTION
## Summary

Adds an **AI roleplay** system to the bot: users define characters that reply through the shared AI webhook *as themselves* (own name + avatar), spawned per-channel. Characters hold **private, per-spawn history** with automatic compaction near the context window, and can either respond only to their spawner (`self`) or join the channel conversation proactively (`all`).

Everything lives under the `/ai` command group and three new DB tables. The website is untouched.

> **Status:** automated checks are green, but this is a large feature that still needs **live Discord testing** (per the branch's intent). Opening the PR to track it — not necessarily merge-ready until the manual pass is done.

## Commands (`/ai …`)
- `rp-create-char` — define a character (name / details / starting message / auto-cropped 128×128 pfp) **or** upload a `.json` template (pfp stays a separate attachment).
- `rp-edit` — creator-only edits (fields or `.json`).
- `rp-details` — preview a character; long fields attach as `.txt`.
- `rp-spawn` — spawn into a channel (`interactability: self|all`, `compaction: on|off`, ≤5/channel). Re-running only reconfigures the spawn.
- `rp-remove` — despawn (spawner or admin); optional history wipe; reports who spawned it.
- `rp-setasset` — admin-only; sets the per-server asset channel used to re-host avatars.

## Behavior
- **Model:** `deepseek/deepseek-v3.2` via OpenRouter, tools disabled, 8192 max output.
- **Mentions:** `@name` / `@id` / `@name-id` route replies in `messageCreate`; ambiguous mentions ask for disambiguation.
- **`all`-mode:** a 30s scheduler fires **≤1 proactive reply per channel per tick**; dormant channels hibernate. Bot/webhook messages are never heard → **no bot-to-bot loops**.
- **Compaction:** near the 128k window the oldest ~80% (by tokens) is folded into a first-person memory; validated, with retry-on-mention and a hard-truncate fallback. Spawns are **soft-deleted** so history survives remove/re-spawn.
- **`{user}` variable:** substituted with the spawner's name in `self`-mode only (left literal in `all`-mode).
- **Typing:** the character posts `*typing.  .  .*` as itself, then that message is **edited in place** into the reply (overflow >2000 chars follows as new messages). Replaces the old `channel.sendTyping()` that broke character by showing "Silverwolf".

## Architecture
- **DB:** `RpCharacter`, `RpSpawn` (`UNIQUE(channel_id, char_id)`, soft-delete via `active`), `RpHistory` — new `tables/`, `queries/rpQueries.ts`, `models/RpModel.ts`, registered as `db.rp`. Indexes created in `Database.init()`.
- **Avatars:** re-hosted to a canonical per-server Discord asset channel; signed CDN URLs are refreshed from the stored message id (12h cache) with a graceful broken-URL fallback.
- **Runtime:** in-memory `activeRpChannels` set as a fast-path so normal (non-RP) traffic never hits the DB; message router + proactive scheduler in `utils/rpRuntime.ts` / `classes/rpScheduler.ts`.

## Security / attack surface
- `.json` upload is **size-capped**, parsed in a try/catch, and reads **only** the three known string fields (never spread) — prototype-pollution covered by a test.
- `details` token-capped (~4k), `starting_message` char-capped (6k, split on delivery).
- All character output posts with `allowedMentions: { parse: [] }` — a character can never ping anyone.

## Testing
- `bun test` green (RpModel, rpIdentity, rpCharInput incl. oversize/malformed/missing/unknown-field/prototype-pollution, rpDelivery splitMessage).
- `bun run typecheck` and `bun run lint` clean for all new files.
- ⏳ **Pending:** live Discord run (webhook posting, avatar hosting, compaction under real load).

## Reviewer notes
- The edit-based typing placeholder means the finished reply carries Discord's small **"(edited)"** tag — an accepted cosmetic tradeoff for staying in character.
- `RP_MODEL = 'deepseek/deepseek-v3.2'` should be confirmed against the live OpenRouter slug on first real call.
- Avatars are re-encoded as **PNG** (node-canvas can't emit WebP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI roleplay commands for creating, viewing, editing, spawning, removing, and configuring roleplay assets.
  * Roleplay now supports scheduled proactive ticks, mention-based routing, and command autocomplete.
  * Webhook-based character delivery with avatar handling, typing placeholders, and safe long-message chunking.
  * Introduced a dedicated roleplay database layer with character/spawn/history management and context compaction.
* **Bug Fixes**
  * Enforced stricter ownership checks, per-channel spawn limits, and safer JSON/avatar error handling.
* **Tests**
  * Added end-to-end and unit tests covering character input, delivery, identity/mentions, and RP model behavior.
* **Documentation**
  * Expanded AI/bot architecture documentation in AGENTS.md.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->