### PR TITLE
fix[ai]: rp characters hear bots (no loop), spaces in names, public replies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,7 @@ refreshed from the stored message id). Model `deepseek/deepseek-v3.2`, no tools,
 private history** with auto-compaction (oldest ~80% folded into a first-person memory) near the 128k
 window. Spawns are **soft-deleted** so history survives removal/re-spawn. Names allow letters,
 numbers, underscores and single spaces (no dashes); `@name` / `@id` / `@name-id` mentions route in
-`messageCreate` and match the name with spaces stripped (`@SilverWolf` / `@Silver`). `all`-mode
+`messageCreate` and match the space-stripped name by prefix (`@SilverWolf` / `@Silver`). `all`-mode
 characters also chime in via the scheduler (≤1 reply/channel/tick). Bot/webhook/app messages **are**
 heard as context (`RpHistory.from_bot`) — including other characters, whose replies are fed to the
 rest of the channel at generation time (`propagateReplyToChannel`) — but only an **unanswered human

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Bun process**. It serves fun/games both as slash commands and as web pages, plus
 **The website is public, so security and performance are first-class concerns — code defensively:
 validate every input, never trust client data, keep the CSP tight.**
 
-**Last updated: 2026-06-30**
+**Last updated: 2026-07-02**
 
 > **Maintenance rule.** Edit this file only on *substantive architectural* change — new
 > architecture, new auth, new data flows/services, schema or security-model changes, or when
@@ -103,14 +103,19 @@ reply through the shared AI webhook as themselves — name + a 128×128 avatar r
 asset channel (ServerConfig key `rp_asset_channel`, set via `/ai rp-setasset`; signed CDN URLs are
 refreshed from the stored message id). Model `deepseek/deepseek-v3.2`, no tools, **per-character
 private history** with auto-compaction (oldest ~80% folded into a first-person memory) near the 128k
-window. Spawns are **soft-deleted** so history survives removal/re-spawn. `@name` / `@id` /
-`@name-id` mentions route in `messageCreate`; `all`-mode characters also chime in via the scheduler
-(≤1 reply/channel/tick; bot/webhook messages are never heard → no bot-to-bot loops). An in-memory
-active-channel set keeps non-RP traffic off the DB. Characters are defined via command fields **or** an
-uploaded `.json` (`utils/rpCharInput.ts` — size-capped, parsed in a try/catch, only the three known
-string fields read, never spread — the upload attack surface); `details` is token-capped (~4k),
-`starting_message` char-capped (6k, split on delivery). `{user}` in details/starting-message is
-substituted with the spawner's name in **self**-mode only (left literal in `all`-mode).
+window. Spawns are **soft-deleted** so history survives removal/re-spawn. Names allow letters,
+numbers, underscores and single spaces (no dashes); `@name` / `@id` / `@name-id` mentions route in
+`messageCreate` and match the name with spaces stripped (`@SilverWolf` / `@Silver`). `all`-mode
+characters also chime in via the scheduler (≤1 reply/channel/tick). Bot/webhook/app messages **are**
+heard as context (`RpHistory.from_bot`) — including other characters, whose replies are fed to the
+rest of the channel at generation time (`propagateReplyToChannel`) — but only an **unanswered human
+turn** ever triggers a reply, so characters can react to each other without an infinite bot-to-bot
+loop. An in-memory active-channel set keeps non-RP traffic off the DB. Characters are defined via
+command fields **or** an uploaded `.json` (`utils/rpCharInput.ts` — size-capped, parsed in a
+try/catch, only the three known string fields read, never spread — the upload attack surface);
+`details` is token-capped (~4k), `starting_message` char-capped (6k, split on delivery). `{user}` in
+details/starting-message is substituted with the spawner's name in **self**-mode only (left literal
+in `all`-mode). The `/ai rp-*` command replies are non-ephemeral (public) except admin `rp-setasset`.
 
 **Database** (`bun:sqlite`, `persistence/database.db`). Layered: `tables/` (TableDefinition schema
 objects) → `models/` (DAOs) → `queries/` (SQL strings). **Access pattern:**

--- a/classes/silverwolf.ts
+++ b/classes/silverwolf.ts
@@ -265,16 +265,18 @@ All wrongs reserved.
       return;
     }
 
+    // Roleplay hears the whole channel — including other bots/apps — as context, but
+    // only human messages can trigger a reply (enforced in handleRpMessage). Route it
+    // before the bot short-circuit and the human-only behaviours below. Fire-and-forget;
+    // returns immediately (in-memory check) unless the channel actually has spawns.
+    handleRpMessage(this, message).catch((err) => logError('Rp: message handling failed:', err));
+
     if (message.author.bot) {
       log(`Bot message received from ${message.author.username} (${message.author.id}) in ${message.channel.name} (${message.channel.id}) in ${message.guild.name} (${message.guild.id}): ${message.content}`);
       return;
     }
 
     log(`> Message received from ${message.author.username} (${message.author.id}) in ${message.channel.name} (${message.channel.id}) in ${message.guild.name} (${message.guild.id}): ${message.content}`);
-
-    // Roleplay: route to any characters spawned in this channel. Fire-and-forget;
-    // returns immediately (in-memory check) unless the channel actually has spawns.
-    handleRpMessage(this, message).catch((err) => logError('Rp: message handling failed:', err));
 
     const guildConfig = await loadResolvedServerConfig(this.db, message.guild.id);
 

--- a/commands/ai_rp_create.ts
+++ b/commands/ai_rp_create.ts
@@ -15,7 +15,7 @@ class AiRpCreate extends Command {
   constructor(client: any) {
     super(client, 'rp-create-char', 'Create a roleplay character (fill the fields, or upload a .json)', [
       {
-        name: 'name', description: 'Short name (letters/numbers/underscore, no spaces)', type: 3, required: false, max_length: NAME_MAX_LENGTH,
+        name: 'name', description: 'Name — letters, numbers, spaces, underscores (no dashes)', type: 3, required: false, max_length: NAME_MAX_LENGTH,
       },
       {
         name: 'details', description: 'Personality / system prompt (use a .json for longer)', type: 3, required: false, max_length: DETAILS_OPTION_MAX_LENGTH,
@@ -29,7 +29,7 @@ class AiRpCreate extends Command {
       {
         name: 'json', description: 'Upload a character .json instead of the fields (allows larger details)', type: 11, required: false,
       },
-    ], { isSubcommandOf: 'ai', blame: 'xei', ephemeral: true });
+    ], { isSubcommandOf: 'ai', blame: 'xei' });
   }
 
   async run(interaction: any): Promise<void> {

--- a/commands/ai_rp_details.ts
+++ b/commands/ai_rp_details.ts
@@ -11,7 +11,7 @@ class AiRpDetails extends Command {
       {
         name: 'char', description: 'Character (search by name or id)', type: 3, required: true, autocomplete: true,
       },
-    ], { isSubcommandOf: 'ai', blame: 'xei', ephemeral: true });
+    ], { isSubcommandOf: 'ai', blame: 'xei' });
   }
 
   async autocomplete(interaction: any): Promise<void> {

--- a/commands/ai_rp_edit.ts
+++ b/commands/ai_rp_edit.ts
@@ -31,7 +31,7 @@ class AiRpEdit extends Command {
       {
         name: 'json', description: 'Replace name+details+starting_message from a .json (larger details allowed)', type: 11, required: false,
       },
-    ], { isSubcommandOf: 'ai', blame: 'xei', ephemeral: true });
+    ], { isSubcommandOf: 'ai', blame: 'xei' });
   }
 
   async autocomplete(interaction: any): Promise<void> {

--- a/commands/ai_rp_remove.ts
+++ b/commands/ai_rp_remove.ts
@@ -17,7 +17,7 @@ class AiRpRemove extends Command {
         type: 5,
         required: false,
       },
-    ], { isSubcommandOf: 'ai', blame: 'xei', ephemeral: true });
+    ], { isSubcommandOf: 'ai', blame: 'xei' });
   }
 
   async autocomplete(interaction: any): Promise<void> {

--- a/commands/ai_rp_spawn.ts
+++ b/commands/ai_rp_spawn.ts
@@ -32,7 +32,7 @@ class AiRpSpawn extends Command {
           { name: 'disabled', value: 'disabled' },
         ],
       },
-    ], { isSubcommandOf: 'ai', blame: 'xei', ephemeral: true });
+    ], { isSubcommandOf: 'ai', blame: 'xei' });
   }
 
   async autocomplete(interaction: any): Promise<void> {

--- a/database/Database.ts
+++ b/database/Database.ts
@@ -181,6 +181,7 @@ class Database {
     this.db.run(rpQueries.CREATE_INDEX_SPAWN_CHANNEL);
     this.db.run(rpQueries.CREATE_INDEX_SPAWN_ALL);
     this.db.run(rpQueries.CREATE_INDEX_HISTORY_SPAWN);
+    this.db.run(rpQueries.CREATE_INDEX_HISTORY_SPAWN_ROLE);
     this.db.run(rpQueries.CREATE_INDEX_CHAR_NAME);
     this.db.run(rpQueries.CREATE_INDEX_CHAR_CREATOR);
 

--- a/database/models/RpModel.ts
+++ b/database/models/RpModel.ts
@@ -168,6 +168,16 @@ class RpModel {
   }
 
   /**
+   * True when a human (non-bot) user turn is still waiting on a reply. Bot/webhook
+   * turns never count, so a character hears other bots/characters without the
+   * proactive scheduler triggering an endless back-and-forth.
+   */
+  async hasUnansweredHumanTurn(spawnId: number): Promise<boolean> {
+    const row = await this.db.executeSelectQuery(rpQueries.HAS_UNANSWERED_HUMAN_TURN, [spawnId, spawnId]);
+    return !!(row?.has);
+  }
+
+  /**
    * Spawns (or reactivates/reconfigures) a character in a channel, enforcing the
    * per-channel cap transactionally. Reactivating a removed spawn or a brand-new
    * one counts against the cap; a pure reconfigure of an already-active spawn does not.
@@ -263,9 +273,10 @@ class RpModel {
     role: 'user' | 'model',
     message: string,
     speaker?: { id: string | null; name: string | null },
+    fromBot = false,
   ): Promise<void> {
     await this.db.executeQuery(rpQueries.ADD_HISTORY, [
-      spawnId, role, speaker?.id ?? null, speaker?.name ?? null, message,
+      spawnId, role, speaker?.id ?? null, speaker?.name ?? null, message, fromBot ? 1 : 0,
     ]);
   }
 

--- a/database/queries/rpQueries.ts
+++ b/database/queries/rpQueries.ts
@@ -95,13 +95,24 @@ const rpQueries = {
 
   // ── History ───────────────────────────────────────────────────────────────
   ADD_HISTORY: `
-    INSERT INTO RpHistory (spawn_id, role, speaker_id, speaker_name, message)
-    VALUES (?, ?, ?, ?, ?)
+    INSERT INTO RpHistory (spawn_id, role, speaker_id, speaker_name, message, from_bot)
+    VALUES (?, ?, ?, ?, ?, ?)
   `,
   // The un-compacted tail (rows newer than compacted_upto_id), oldest first.
   GET_HISTORY_AFTER: 'SELECT * FROM RpHistory WHERE spawn_id = ? AND id > ? ORDER BY id ASC',
   // Role of the newest turn — 'user' means the character has something to respond to.
   GET_LAST_HISTORY_ROLE: 'SELECT role FROM RpHistory WHERE spawn_id = ? ORDER BY id DESC LIMIT 1',
+  // Is there a *human* (from_bot = 0) user turn the character hasn't replied to yet?
+  // Bot/webhook turns (other characters, other apps) are context only — they never
+  // count as unanswered, so the proactive scheduler can't set off a bot-to-bot loop.
+  // Params: (spawnId, spawnId).
+  HAS_UNANSWERED_HUMAN_TURN: `
+    SELECT EXISTS(
+      SELECT 1 FROM RpHistory
+      WHERE spawn_id = ? AND role = 'user' AND from_bot = 0
+        AND id > COALESCE((SELECT MAX(id) FROM RpHistory WHERE spawn_id = ? AND role = 'model'), 0)
+    ) AS has
+  `,
   COUNT_HISTORY: 'SELECT COUNT(*) AS count FROM RpHistory WHERE spawn_id = ?',
   DELETE_HISTORY_BY_SPAWN: 'DELETE FROM RpHistory WHERE spawn_id = ?',
 

--- a/database/queries/rpQueries.ts
+++ b/database/queries/rpQueries.ts
@@ -120,6 +120,8 @@ const rpQueries = {
   CREATE_INDEX_SPAWN_CHANNEL: 'CREATE INDEX IF NOT EXISTS idx_rpspawn_channel_active ON RpSpawn (channel_id, active)',
   CREATE_INDEX_SPAWN_ALL: 'CREATE INDEX IF NOT EXISTS idx_rpspawn_active_interact ON RpSpawn (active, interactability)',
   CREATE_INDEX_HISTORY_SPAWN: 'CREATE INDEX IF NOT EXISTS idx_rphistory_spawn_id ON RpHistory (spawn_id, id)',
+  // Covers HAS_UNANSWERED_HUMAN_TURN (filters by role, runs per all-mode spawn each tick).
+  CREATE_INDEX_HISTORY_SPAWN_ROLE: 'CREATE INDEX IF NOT EXISTS idx_rphistory_spawn_role_id ON RpHistory (spawn_id, role, id)',
   CREATE_INDEX_CHAR_NAME: 'CREATE INDEX IF NOT EXISTS idx_rpcharacter_name_lower ON RpCharacter (name_lower)',
   CREATE_INDEX_CHAR_CREATOR: 'CREATE INDEX IF NOT EXISTS idx_rpcharacter_creator ON RpCharacter (creator_id)',
 };

--- a/database/tables/rpHistoryTable.ts
+++ b/database/tables/rpHistoryTable.ts
@@ -4,8 +4,11 @@ import type { TableDefinition } from '../types';
  * One turn in a spawned character's private conversation. Keyed by spawn_id (stable
  * across remove/re-spawn since spawns are soft-deleted). User turns carry speaker
  * attribution so the model can address people by name in a multi-user channel;
- * model turns leave them null. Raw rows are never erased on compaction — they're
- * just skipped during replay once folded into RpSpawn.compacted_memory.
+ * model turns leave them null. `from_bot` marks turns authored by a bot/webhook/app
+ * (including other RP characters) — they're kept as *context* but never count as an
+ * "unanswered" turn, so a character can hear other bots without being triggered into
+ * an infinite reply loop. Raw rows are never erased on compaction — they're just
+ * skipped during replay once folded into RpSpawn.compacted_memory.
  */
 export interface RpHistoryRow {
   id: number;
@@ -14,6 +17,7 @@ export interface RpHistoryRow {
   speaker_id: string | null;
   speaker_name: string | null;
   message: string;
+  from_bot: number;
   timestamp: string;
 }
 
@@ -26,6 +30,7 @@ const rpHistoryTable: TableDefinition = {
     { name: 'speaker_id', type: 'VARCHAR DEFAULT NULL' },
     { name: 'speaker_name', type: 'VARCHAR DEFAULT NULL' },
     { name: 'message', type: 'TEXT NOT NULL' },
+    { name: 'from_bot', type: 'INTEGER NOT NULL DEFAULT 0' },
     { name: 'timestamp', type: 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP' },
   ],
   primaryKey: ['id'],

--- a/tests/database/RpModel.test.ts
+++ b/tests/database/RpModel.test.ts
@@ -159,6 +159,27 @@ describe('RpModel', () => {
     expect(await rp.getLastHistoryRole(spawnId)).toBeNull();
   });
 
+  it('only counts unanswered HUMAN turns (bot turns never trigger — the loop guard)', async () => {
+    const id = await makeChar('user-1', 'listener');
+    const spawn = await rp.trySpawn({
+      channelId: CHANNEL, guildId: GUILD, charId: id, spawnerId: 'user-1', interactability: 'all', compactionEnabled: true,
+    });
+    const spawnId = spawn.spawnId!;
+    expect(await rp.hasUnansweredHumanTurn(spawnId)).toBe(false);
+
+    // A human message → unanswered.
+    await rp.addHistory(spawnId, 'user', 'hello', { id: 'user-2', name: 'Finch' });
+    expect(await rp.hasUnansweredHumanTurn(spawnId)).toBe(true);
+
+    // The character replies → answered.
+    await rp.addHistory(spawnId, 'model', 'hi Finch');
+    expect(await rp.hasUnansweredHumanTurn(spawnId)).toBe(false);
+
+    // Another character's line (from_bot) is context only — it must NOT re-trigger a reply.
+    await rp.addHistory(spawnId, 'user', 'Aventurine: evening', { id: null, name: 'Aventurine' }, true);
+    expect(await rp.hasUnansweredHumanTurn(spawnId)).toBe(false);
+  });
+
   it('tracks distinct active channels for the router fast-path', async () => {
     const id = await makeChar('user-1', 'router');
     const res = await rp.trySpawn({

--- a/tests/utils/rpCharInput.test.ts
+++ b/tests/utils/rpCharInput.test.ts
@@ -33,7 +33,9 @@ describe('rpCharInput validators', () => {
 
   it('validateCharacterFields rejects a bad name', () => {
     expect(validateCharacterFields({ name: 'ok_name', details: 'd', startingMessage: 's' })).toBeNull();
-    expect(validateCharacterFields({ name: 'bad name', details: 'd', startingMessage: 's' })).not.toBeNull();
+    // Spaces are allowed now; a dash (the id separator) is the invalid case.
+    expect(validateCharacterFields({ name: 'Silver Wolf', details: 'd', startingMessage: 's' })).toBeNull();
+    expect(validateCharacterFields({ name: 'bad-name', details: 'd', startingMessage: 's' })).not.toBeNull();
   });
 });
 

--- a/tests/utils/rpIdentity.test.ts
+++ b/tests/utils/rpIdentity.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'bun:test';
 import {
-  generateCharId, validateCharName, matchMentions, applyUserVar, type SpawnLike,
+  generateCharId, validateCharName, matchMentions, applyUserVar, formatCharHandle, type SpawnLike,
 } from '../../utils/rpIdentity';
 
 describe('rpIdentity.applyUserVar', () => {
@@ -32,11 +32,17 @@ describe('rpIdentity.validateCharName', () => {
     expect(validateCharName('Aven_2')).toBeNull();
   });
 
-  it('rejects spaces, dashes, and overlong names', () => {
-    expect(validateCharName('aven turine')).not.toBeNull();
+  it('rejects dashes, overlong names, and malformed spacing', () => {
     expect(validateCharName('aven-turine')).not.toBeNull();
     expect(validateCharName('a'.repeat(33))).not.toBeNull();
     expect(validateCharName('')).not.toBeNull();
+    expect(validateCharName('aven  turine')).not.toBeNull(); // doubled space
+  });
+
+  it('allows single spaces between words', () => {
+    expect(validateCharName('Silver Wolf')).toBeNull();
+    expect(validateCharName('a b c')).toBeNull();
+    expect(validateCharName('a'.repeat(32))).toBeNull();
   });
 
   it('rejects Discord-reserved names', () => {
@@ -100,5 +106,32 @@ describe('rpIdentity.matchMentions', () => {
   it('matches multiple distinct characters in one message', () => {
     const { matched } = matchMentions('@bob and @aventurine-d23 hi', spawns);
     expect(matched.map((m) => m.spawnId).sort()).toEqual([2, 3]);
+  });
+});
+
+describe('rpIdentity.formatCharHandle', () => {
+  it('strips spaces so the handle stays a single parseable token', () => {
+    expect(formatCharHandle('Silver Wolf', 'silw01')).toBe('@SilverWolf-silw01');
+    expect(formatCharHandle('bob', 'bob123')).toBe('@bob-bob123');
+  });
+});
+
+describe('rpIdentity.matchMentions with spaced names', () => {
+  const spawns: SpawnLike[] = [
+    { spawnId: 1, charId: 'silw01', nameLower: 'silver wolf' },
+    { spawnId: 2, charId: 'bob123', nameLower: 'bob' },
+  ];
+
+  it('matches a spaced name written as one token (any case)', () => {
+    expect(matchMentions('hey @SilverWolf', spawns).matched.map((m) => m.spawnId)).toEqual([1]);
+    expect(matchMentions('yo @silverwolf ok', spawns).matched.map((m) => m.spawnId)).toEqual([1]);
+  });
+
+  it('matches a spaced name by its first-word prefix', () => {
+    expect(matchMentions('@Silver you there', spawns).matched.map((m) => m.spawnId)).toEqual([1]);
+  });
+
+  it('disambiguates a spaced name with the stripped id handle', () => {
+    expect(matchMentions('@SilverWolf-silw01 hi', spawns).matched.map((m) => m.spawnId)).toEqual([1]);
   });
 });

--- a/utils/rpDelivery.ts
+++ b/utils/rpDelivery.ts
@@ -18,6 +18,16 @@ const MAX_LENGTH = 2000;
 // it into the reply once the model returns.
 export const TYPING_PLACEHOLDER = '*typing.  .  .*';
 
+// Ids of the webhook(s) we post RP output through. A message from one of these whose
+// username matches an active character is our own echo — and since only we hold this
+// webhook's token, another app that merely reuses a character's name posts through a
+// *different* webhook, so it can't be misclassified. The router uses this to skip our
+// own posts (incl. the "*typing*" placeholder) out of the "heard" context.
+const rpWebhookIds = new Set<string>();
+export function isRpWebhookId(id: string | null | undefined): boolean {
+  return !!id && rpWebhookIds.has(id);
+}
+
 /** The "↩ Replying to" link button, or [] when there's nothing to link. */
 function replyButtonRow(
   replyToUrl?: string | null,
@@ -59,6 +69,9 @@ async function getRpWebhook(channel: TextChannel, client: any): Promise<any | nu
         avatar: client.user?.displayAvatarURL(),
       });
     }
+    // Remember this webhook's id so the router can recognise our own output. Recorded
+    // before we post through it, so a placeholder's messageCreate can't race ahead.
+    if (webhook?.id) rpWebhookIds.add(webhook.id);
     return webhook;
   } catch (err) {
     logError('Rp: failed to get/create webhook (missing Manage Webhooks?):', err);

--- a/utils/rpIdentity.ts
+++ b/utils/rpIdentity.ts
@@ -32,6 +32,9 @@ const NAME_RE = /^[A-Za-z0-9_]+( [A-Za-z0-9_]+)*$/;
 const RESERVED_NAME_SUBSTRINGS = ['discord', 'clyde'];
 const RESERVED_NAMES = ['everyone', 'here'];
 
+/** Strips whitespace so a spaced name collapses to a single mention token / handle. */
+const stripSpaces = (s: string): string => s.replace(/\s+/g, '');
+
 /** Generates a random 6-char lowercase-alphanumeric character id. */
 export function generateCharId(): string {
   let out = '';
@@ -61,7 +64,7 @@ export function validateCharName(name: string): string | null {
  * so the handle stays a single parseable token (a "Silver Wolf" → `@SilverWolf-<id>`).
  */
 export function formatCharHandle(name: string, charId: string): string {
-  return `@${name.replace(/\s+/g, '')}-${charId}`;
+  return `@${stripSpaces(name)}-${charId}`;
 }
 
 /**
@@ -104,7 +107,7 @@ export function matchMentions(content: string, spawns: SpawnLike[]): MentionMatc
   const ambiguous: { token: string; candidates: SpawnLike[] }[] = [];
   const seenAmbiguousTokens = new Set<string>();
   // Compare against the space-stripped name, since a mention is a single token.
-  const nameKey = (s: SpawnLike): string => s.nameLower.replace(/\s+/g, '');
+  const nameKey = (s: SpawnLike): string => stripSpaces(s.nameLower);
 
   let m: RegExpExecArray | null;
   // eslint-disable-next-line no-cond-assign

--- a/utils/rpIdentity.ts
+++ b/utils/rpIdentity.ts
@@ -3,8 +3,10 @@
  * the `@mention` grammar that routes channel messages to spawned characters.
  *
  * A character is identified by a 6-char lowercase-alphanumeric `char_id` plus its
- * `name`. Because names are restricted to `[A-Za-z0-9_]` (no `-`), the dash is a
- * safe separator for the disambiguated form `@name-idprefix`.
+ * `name`. Names allow letters, numbers, underscores and single spaces but never `-`,
+ * so the dash stays a safe separator for the disambiguated form `@name-idprefix`.
+ * Mentions and handles ignore spaces (a "Silver Wolf" is `@SilverWolf` / `@Silver`),
+ * since a raw `@Silver Wolf` can't be told apart from the surrounding sentence.
  */
 
 export const MAX_SPAWNS_PER_CHANNEL = 5;
@@ -23,7 +25,9 @@ export const MAX_CHAR_JSON_BYTES = 128 * 1024;
 export const USER_VAR = '{user}';
 
 const ID_ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789';
-const NAME_RE = /^[A-Za-z0-9_]{1,32}$/;
+// Letters/numbers/underscores in words, single spaces between them (no leading,
+// trailing, or doubled spaces, and no dashes). Length is checked separately.
+const NAME_RE = /^[A-Za-z0-9_]+( [A-Za-z0-9_]+)*$/;
 // Discord rejects these substrings/values in webhook usernames.
 const RESERVED_NAME_SUBSTRINGS = ['discord', 'clyde'];
 const RESERVED_NAMES = ['everyone', 'here'];
@@ -41,8 +45,8 @@ export function generateCharId(): string {
 export function validateCharName(name: string): string | null {
   const trimmed = (name ?? '').trim();
   if (!trimmed) return 'Name is required.';
-  if (!NAME_RE.test(trimmed)) {
-    return 'Name must be 1–32 characters, letters/numbers/underscores only (no spaces or dashes).';
+  if (trimmed.length > NAME_MAX_LENGTH || !NAME_RE.test(trimmed)) {
+    return `Name must be 1–${NAME_MAX_LENGTH} characters — letters, numbers, underscores and single spaces (no dashes).`;
   }
   const lower = trimmed.toLowerCase();
   if (RESERVED_NAMES.includes(lower)) return `"${trimmed}" is a reserved name.`;
@@ -52,9 +56,12 @@ export function validateCharName(name: string): string | null {
   return null;
 }
 
-/** `@aventurine-a2e4se` — the always-unique disambiguated handle for a character. */
+/**
+ * `@aventurine-a2e4se` — the always-unique disambiguated handle. Spaces are stripped
+ * so the handle stays a single parseable token (a "Silver Wolf" → `@SilverWolf-<id>`).
+ */
 export function formatCharHandle(name: string, charId: string): string {
-  return `@${name}-${charId}`;
+  return `@${name.replace(/\s+/g, '')}-${charId}`;
 }
 
 /**
@@ -82,7 +89,9 @@ export interface MentionMatchResult {
 // `@` + (name|id) optionally followed by `-idprefix`. Names exclude `-`, so the
 // dash unambiguously starts the id part. Leading char must not be part of a word
 // (so emails like name@host don't trigger). The id prefix accepts either case and
-// is lowercased before matching, so `@Aventurine-A2E` disambiguates too.
+// is lowercased before matching, so `@Aventurine-A2E` disambiguates too. Names can
+// contain spaces, but a mention is a single token, so we match against the name with
+// its spaces removed (`@SilverWolf`, or the first-word prefix `@Silver`).
 const MENTION_RE = /(?:^|[^\w])@([A-Za-z0-9_]+)(?:-([A-Za-z0-9]+))?/g;
 
 /**
@@ -94,6 +103,8 @@ export function matchMentions(content: string, spawns: SpawnLike[]): MentionMatc
   const matchedById = new Map<number, SpawnLike>();
   const ambiguous: { token: string; candidates: SpawnLike[] }[] = [];
   const seenAmbiguousTokens = new Set<string>();
+  // Compare against the space-stripped name, since a mention is a single token.
+  const nameKey = (s: SpawnLike): string => s.nameLower.replace(/\s+/g, '');
 
   let m: RegExpExecArray | null;
   // eslint-disable-next-line no-cond-assign
@@ -104,9 +115,9 @@ export function matchMentions(content: string, spawns: SpawnLike[]): MentionMatc
 
     let candidates: SpawnLike[];
     if (idPart) {
-      candidates = spawns.filter((s) => s.nameLower.startsWith(main) && s.charId.startsWith(idPart));
+      candidates = spawns.filter((s) => nameKey(s).startsWith(main) && s.charId.startsWith(idPart));
     } else {
-      candidates = spawns.filter((s) => s.nameLower.startsWith(main) || s.charId.startsWith(main));
+      candidates = spawns.filter((s) => nameKey(s).startsWith(main) || s.charId.startsWith(main));
     }
 
     // Dedup candidates by char (a name and id prefix could hit the same spawn twice).

--- a/utils/rpRuntime.ts
+++ b/utils/rpRuntime.ts
@@ -2,7 +2,7 @@ import type { TextChannel } from 'discord.js';
 import { matchMentions, formatCharHandle } from './rpIdentity';
 import { generateRpReply } from './rpChat';
 import {
-  sendAsCharacter, postCharacterPlaceholder, editCharacterReply, deleteCharacterPlaceholder,
+  sendAsCharacter, postCharacterPlaceholder, editCharacterReply, deleteCharacterPlaceholder, isRpWebhookId,
 } from './rpDelivery';
 import { logError } from './log';
 
@@ -86,8 +86,15 @@ async function propagateReplyToChannel(
     spawns
       .filter((s) => s.interactability === 'all' && s.spawnId !== authoringSpawnId)
       .map(async (s) => {
-        await db.rp.addHistory(s.spawnId, 'user', text, { id: null, name: charName }, true);
-        await db.rp.touchSpawnActivity(s.spawnId);
+        // Isolate per-spawn: a transient DB error while sharing context with one
+        // character must not reject back into respondAsCharacter (which only has a
+        // finally), or it would abort the rest of the mention loop / scheduler tick.
+        try {
+          await db.rp.addHistory(s.spawnId, 'user', text, { id: null, name: charName }, true);
+          await db.rp.touchSpawnActivity(s.spawnId);
+        } catch (err) {
+          logError(`Rp: failed to propagate reply to spawn ${s.spawnId}:`, err);
+        }
       }),
   );
 }
@@ -214,8 +221,10 @@ export async function handleRpMessage(client: any, message: any): Promise<void> 
   // Our own character output arrives here as a webhook message too. Skip it — the
   // reply is fed to the other characters at generation time (propagateReplyToChannel)
   // with the real text, so echoing the raw "*typing*" placeholder would only pollute
-  // their context. Identify it by webhook + a username matching a spawned character.
-  const isOwnRpOutput = !!message.webhookId
+  // their context. Identify it by *our* RP webhook id (only we can post through it)
+  // plus a username matching a spawned character, so another app that reuses a
+  // character's name (a different webhook) is still heard normally.
+  const isOwnRpOutput = isRpWebhookId(message.webhookId)
     && spawns.some((s) => s.charName === message.author?.username);
 
   // All-mode characters hear the whole channel — humans AND other bots/apps — as

--- a/utils/rpRuntime.ts
+++ b/utils/rpRuntime.ts
@@ -9,8 +9,15 @@ import { logError } from './log';
 /**
  * Runtime glue for roleplay: routes channel messages to spawned characters and runs
  * the proactive "all"-mode replies. Generation is throttled (only on a direct mention,
- * or one proactive reply per channel per scheduler tick); bot/webhook messages never
- * reach here (processMessage drops them), so characters never hear each other.
+ * or one proactive reply per channel per scheduler tick).
+ *
+ * Bot/webhook/app messages ARE heard (recorded as context, tagged from_bot) so a
+ * character is aware of what other bots — including other RP characters — said, but
+ * they can never *trigger* a reply: only an unanswered human turn does. That's the
+ * loop guard (a character replying can't set off another character replying forever).
+ * A character's own webhook output isn't echoed back into history here — it's fed to
+ * the other characters directly at generation time (see propagateReplyToChannel), so
+ * they get the real reply text rather than the "*typing*" placeholder.
  *
  * `activeRpChannels` is an in-memory fast-path: the message router returns instantly
  * unless the channel actually has a spawn, so normal traffic never touches the DB.
@@ -53,6 +60,36 @@ interface RespondOpts {
   userVar?: string | null;
   /** Surface a notice to the user (router uses message.reply); omit to stay silent on errors. */
   notify?: (text: string) => Promise<void>;
+}
+
+/**
+ * After a character speaks, feed its reply to the OTHER "all"-mode characters in the
+ * same channel as context (from_bot, so it never triggers them → no bot loop). Done
+ * here rather than from the webhook echo so they get the final reply text — correctly
+ * attributed and free of the "*typing*" placeholder.
+ */
+async function propagateReplyToChannel(
+  db: any,
+  channelId: string,
+  authoringSpawnId: number,
+  charName: string,
+  text: string,
+): Promise<void> {
+  let spawns: any[];
+  try {
+    spawns = await db.rp.getActiveSpawnsInChannel(channelId);
+  } catch (err) {
+    logError('Rp: failed to propagate reply to channel:', err);
+    return;
+  }
+  await Promise.all(
+    spawns
+      .filter((s) => s.interactability === 'all' && s.spawnId !== authoringSpawnId)
+      .map(async (s) => {
+        await db.rp.addHistory(s.spawnId, 'user', text, { id: null, name: charName }, true);
+        await db.rp.touchSpawnActivity(s.spawnId);
+      }),
+  );
 }
 
 /**
@@ -119,6 +156,8 @@ async function respondAsCharacter(
       if (delivered) {
         await db.rp.addHistory(spawnId, 'model', result.text);
         await db.rp.touchSpawnActivity(spawnId);
+        // Let the other "all"-mode characters here hear what this one just said.
+        await propagateReplyToChannel(db, channel.id, spawnId, row.charName, result.text);
         return;
       }
       // Delivery failed — clear any dangling placeholder and don't record the turn.
@@ -171,14 +210,27 @@ export async function handleRpMessage(client: any, message: any): Promise<void> 
   const content = message.content ?? '';
   const authorId = message.author.id;
   const speakerName = message.member?.displayName || message.author.username;
+  const isBot = !!(message.author?.bot || message.webhookId);
+  // Our own character output arrives here as a webhook message too. Skip it — the
+  // reply is fed to the other characters at generation time (propagateReplyToChannel)
+  // with the real text, so echoing the raw "*typing*" placeholder would only pollute
+  // their context. Identify it by webhook + a username matching a spawned character.
+  const isOwnRpOutput = !!message.webhookId
+    && spawns.some((s) => s.charName === message.author?.username);
 
-  // All-mode characters hear the whole channel; record every message as context.
-  // Self-mode characters only register their spawner's directed mentions (below).
-  const heard = spawns.filter((s) => s.interactability === 'all');
-  await Promise.all(heard.map(async (s) => {
-    await db.rp.addHistory(s.spawnId, 'user', content, { id: authorId, name: speakerName });
-    await db.rp.touchSpawnActivity(s.spawnId);
-  }));
+  // All-mode characters hear the whole channel — humans AND other bots/apps — as
+  // context (bot turns tagged so they can't trigger a reply). Self-mode characters
+  // only register their spawner's directed mentions (below).
+  if (!isOwnRpOutput) {
+    const heard = spawns.filter((s) => s.interactability === 'all');
+    await Promise.all(heard.map(async (s) => {
+      await db.rp.addHistory(s.spawnId, 'user', content, { id: authorId, name: speakerName }, isBot);
+      await db.rp.touchSpawnActivity(s.spawnId);
+    }));
+  }
+
+  // Bots/webhooks/apps are heard but can never trigger a reply — the loop guard.
+  if (isBot) return;
 
   if (!content.includes('@')) return;
 
@@ -227,9 +279,10 @@ export async function handleRpMessage(client: any, message: any): Promise<void> 
 }
 
 /**
- * One scheduler tick: each active "all"-mode character with an un-answered user turn
- * is a candidate; we fire at most one proactive reply per channel (so 5 characters
- * don't all pile on). Channels with nothing new stay dormant (hibernation).
+ * One scheduler tick: each active "all"-mode character with an un-answered *human*
+ * message is a candidate; we fire at most one proactive reply per channel (so 5
+ * characters don't all pile on). Bot/character chatter never makes a candidate, so
+ * idle channels stay dormant (hibernation) instead of looping forever.
  */
 export async function runProactiveRpTick(client: any): Promise<void> {
   if (typeof client.isReady === 'function' && !client.isReady()) return;
@@ -255,8 +308,8 @@ export async function runProactiveRpTick(client: any): Promise<void> {
     const candidates: any[] = [];
     for (const s of list) {
       // eslint-disable-next-line no-await-in-loop
-      const lastRole = await db.rp.getLastHistoryRole(s.spawnId);
-      if (lastRole === 'user') candidates.push(s);
+      const hasUnanswered = await db.rp.hasUnansweredHumanTurn(s.spawnId);
+      if (hasUnanswered) candidates.push(s);
     }
     if (candidates.length === 0) continue;
 


### PR DESCRIPTION
## Summary

Post-deploy follow-ups to the roleplay feature ([#192](https://github.com/Mewtwo2387/silverwolf/pull/192), now live). Three requested fixes.

## 1. Characters hear bots/apps — without infinite loops
Previously `processMessage` dropped all bot messages before RP routing, so characters couldn't hear each other or other apps.

- RP routing now runs **before** the bot short-circuit; human-only behaviors (keywords, Pokémon, quote) still skip bots.
- New **`RpHistory.from_bot`** column (auto-`ALTER`ed onto the live DB on next boot; existing rows default to `0` = human). Bot/webhook/app turns are stored as **context** only.
- Only an **unanswered *human* turn** triggers a reply — new `hasUnansweredHumanTurn` gate on both the mention path and the 30s proactive scheduler. This is the loop guard.
- Characters hear **each other**: a reply is fed to the other all-mode characters at generation time (`propagateReplyToChannel`) with the real text, and each character's own webhook echo (including the `*typing*` placeholder) is skipped so it never pollutes context.

Net: characters can react to one another and to other bots, but a reply can never re-trigger another reply forever.

## 2. Spaces in character names
Names may now contain **single spaces** (still no dashes — that's the id separator; no leading/trailing/doubled spaces). Mentions and the `@handle` ignore spaces, so a character "Silver Wolf" is `@SilverWolf`, `@Silver` (first-word prefix), or `@SilverWolf-<id>`.

## 3. Public command replies
Dropped `ephemeral` from `rp-create`, `rp-edit`, `rp-details`, `rp-spawn`, `rp-remove` — they post in-channel now (the full character card/details included, by request). Admin `rp-setasset` stays ephemeral.

## Behavior note (5 all-mode characters in one channel)
Proactive replies stay throttled to **≤1 per channel per 30s tick**; direct `@mentions` reply immediately. With hearing enabled, one human message now gets answered by multiple all-mode characters **one at a time across successive ticks**, each aware of what the others already said — and it stops once the human turn is answered (no ping-pong).

## Testing
- `bun test` — **252 pass / 0 fail**, incl. new coverage for the loop guard (`hasUnansweredHumanTurn` + `from_bot`), spaced-name mentions, and the space-stripped handle.
- `bun run lint` clean; `bun run typecheck` clean except a **pre-existing** `tests/footballAnnouncements.test.ts` type error unrelated to this change.

## Reviewer notes
- `from_bot` migrates via the existing auto-`ALTER` (`Database.updateTable`), no manual migration.
- Own-output detection uses `webhookId` + a username matching a spawned character; a non-RP bot named exactly like a spawned character would be misclassified (rare, benign).
- In a busy all-mode channel, other bots' chatter now counts toward each character's context (more compaction churn) — inherent to "hear bots."

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Roleplay characters can now use multi-word names with single spaces.
  * Spaced names are handled more reliably in mentions and disambiguation.
  * Character replies can now propagate as shared channel context for other active characters.

* **Bug Fixes**
  * Bot, webhook, and app messages now count as context without endlessly triggering reply loops.
  * Proactive roleplay responses now wait for an unanswered human turn before continuing.
  * Roleplay command replies are now public by default, except for the admin asset-setting command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->