### PR TITLE
hotfix[dev]: /memstats memory diagnostics command

### DIFF
--- a/commands/memstats.ts
+++ b/commands/memstats.ts
@@ -14,7 +14,7 @@ class MemStats extends DevCommand {
     super(client, 'memstats', 'Show process memory and cache diagnostics.', [
       {
         name: 'gc',
-        description: 'Force a full garbage collection before measuring',
+        description: 'Force a full GC before measuring (synchronous — briefly stalls the bot)',
         type: 5,
         required: false,
       },
@@ -24,7 +24,16 @@ class MemStats extends DevCommand {
   async run(interaction: any): Promise<void> {
     try {
       const report = await collectMemStats(this.client, interaction.options.getBoolean('gc') ?? false);
-      await interaction.editReply({ content: report });
+      // The report is normally a few hundred chars, but never let it hit Discord's
+      // 2000-char content limit right when the numbers get interesting.
+      if (report.length > 1900) {
+        await interaction.editReply({
+          content: 'Report too long for a message — attached instead.',
+          files: [{ attachment: Buffer.from(report, 'utf8'), name: 'memstats.txt' }],
+        });
+      } else {
+        await interaction.editReply({ content: report });
+      }
     } catch (error) {
       logError('memstats failed:', error);
       await interaction.editReply({ content: 'Failed to collect memory stats.' });

--- a/commands/memstats.ts
+++ b/commands/memstats.ts
@@ -1,0 +1,35 @@
+import { DevCommand } from './classes/DevCommand';
+import { collectMemStats } from '../utils/memStats';
+import { logError } from '../utils/log';
+
+/**
+ * Dev diagnostic: reports process memory, discord.js cache sizes, roleplay
+ * in-memory state, and DB footprint. Run it periodically while the bot grows to
+ * see WHERE the memory lives (JS heap vs native, which cache). The `gc` option
+ * forces a full GC first — if rss drops a lot, it's heap high-water/lazy GC
+ * rather than a true leak.
+ */
+class MemStats extends DevCommand {
+  constructor(client: any) {
+    super(client, 'memstats', 'Show process memory and cache diagnostics.', [
+      {
+        name: 'gc',
+        description: 'Force a full garbage collection before measuring',
+        type: 5,
+        required: false,
+      },
+    ], { blame: 'user', ephemeral: true });
+  }
+
+  async run(interaction: any): Promise<void> {
+    try {
+      const report = await collectMemStats(this.client, interaction.options.getBoolean('gc') ?? false);
+      await interaction.editReply({ content: report });
+    } catch (error) {
+      logError('memstats failed:', error);
+      await interaction.editReply({ content: 'Failed to collect memory stats.' });
+    }
+  }
+}
+
+export default MemStats;

--- a/database/models/RpModel.ts
+++ b/database/models/RpModel.ts
@@ -285,6 +285,12 @@ class RpModel {
     return this.db.executeSelectAllQuery(rpQueries.GET_HISTORY_AFTER, [spawnId, afterId]);
   }
 
+  /** Whole-table history footprint (row count + total message bytes) for diagnostics. */
+  async getHistoryStats(): Promise<{ count: number; bytes: number }> {
+    const row = await this.db.executeSelectQuery(rpQueries.HISTORY_STATS, []);
+    return { count: row?.count ?? 0, bytes: row?.bytes ?? 0 };
+  }
+
   async countHistory(spawnId: number): Promise<number> {
     const row = await this.db.executeSelectQuery(rpQueries.COUNT_HISTORY, [spawnId]);
     return row?.count ?? 0;

--- a/database/queries/rpQueries.ts
+++ b/database/queries/rpQueries.ts
@@ -114,6 +114,8 @@ const rpQueries = {
     ) AS has
   `,
   COUNT_HISTORY: 'SELECT COUNT(*) AS count FROM RpHistory WHERE spawn_id = ?',
+  // Whole-table footprint (row count + total message bytes) for /memstats diagnostics.
+  HISTORY_STATS: 'SELECT COUNT(*) AS count, COALESCE(SUM(LENGTH(message)), 0) AS bytes FROM RpHistory',
   DELETE_HISTORY_BY_SPAWN: 'DELETE FROM RpHistory WHERE spawn_id = ?',
 
   // ── Indexes (run on init) ─────────────────────────────────────────────────

--- a/database/queries/rpQueries.ts
+++ b/database/queries/rpQueries.ts
@@ -115,7 +115,9 @@ const rpQueries = {
   `,
   COUNT_HISTORY: 'SELECT COUNT(*) AS count FROM RpHistory WHERE spawn_id = ?',
   // Whole-table footprint (row count + total message bytes) for /memstats diagnostics.
-  HISTORY_STATS: 'SELECT COUNT(*) AS count, COALESCE(SUM(LENGTH(message)), 0) AS bytes FROM RpHistory',
+  // CAST to BLOB so LENGTH counts bytes, not characters. Full scan is acceptable: the
+  // query runs only from the dev-gated /memstats command, never on a hot path.
+  HISTORY_STATS: 'SELECT COUNT(*) AS count, COALESCE(SUM(LENGTH(CAST(message AS BLOB))), 0) AS bytes FROM RpHistory',
   DELETE_HISTORY_BY_SPAWN: 'DELETE FROM RpHistory WHERE spawn_id = ?',
 
   // ── Indexes (run on init) ─────────────────────────────────────────────────

--- a/utils/memStats.ts
+++ b/utils/memStats.ts
@@ -1,0 +1,72 @@
+import fs from 'fs';
+import path from 'path';
+import { getRpRuntimeStats } from './rpRuntime';
+import { getRpWebhookIdCount } from './rpDelivery';
+import { getAvatarUrlCacheSize } from './rpAvatar';
+
+/**
+ * Memory diagnostics for the /memstats dev command. Collects process memory,
+ * discord.js cache sizes, the RP feature's in-memory state, and DB footprint so a
+ * leak can be localised (JS heap vs native, which cache, or just DB/log growth)
+ * without attaching an inspector to the prod container.
+ */
+
+const DB_PATH = path.join(import.meta.dir, '../persistence/database.db');
+
+function mb(bytes: number): string {
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function fileSize(filePath: string): number {
+  try {
+    return fs.statSync(filePath).size;
+  } catch {
+    return 0;
+  }
+}
+
+export async function collectMemStats(client: any, forceGc = false): Promise<string> {
+  const before = process.memoryUsage();
+  if (forceGc) Bun.gc(true);
+  const mem = forceGc ? process.memoryUsage() : before;
+
+  // discord.js caches
+  let messageCacheTotal = 0;
+  let memberCacheTotal = 0;
+  for (const channel of client.channels.cache.values()) {
+    messageCacheTotal += (channel as any).messages?.cache?.size ?? 0;
+  }
+  for (const guild of client.guilds.cache.values()) {
+    memberCacheTotal += (guild as any).members?.cache?.size ?? 0;
+  }
+
+  const rp = getRpRuntimeStats();
+  const rpHistory = await client.db.rp.getHistoryStats();
+
+  const lines = [
+    `**Process memory**${forceGc ? ' (after forced GC)' : ''}`,
+    `rss: ${mb(mem.rss)} | heapUsed: ${mb(mem.heapUsed)} | heapTotal: ${mb(mem.heapTotal)}`,
+    `external: ${mb(mem.external)} | arrayBuffers: ${mb(mem.arrayBuffers)}`,
+  ];
+  if (forceGc) {
+    lines.push(`freed by GC: rss ${mb(before.rss - mem.rss)}, heapUsed ${mb(before.heapUsed - mem.heapUsed)}`);
+  }
+  lines.push(
+    '',
+    '**discord.js caches**',
+    `guilds: ${client.guilds.cache.size} | channels: ${client.channels.cache.size} | users: ${client.users.cache.size}`,
+    `messages (all channels): ${messageCacheTotal} | members (all guilds): ${memberCacheTotal}`,
+    '',
+    '**Roleplay in-memory state**',
+    `activeRpChannels: ${rp.activeChannels} | inFlightSpawns: ${rp.inFlightSpawns}`
+      + ` | rpWebhookIds: ${getRpWebhookIdCount()} | avatarUrlCache: ${getAvatarUrlCacheSize()}`,
+    '',
+    '**Tracked message history**',
+    `deletedMessages: ${client.deletedMessages?.length ?? 0} | editedMessages: ${client.editedMessages?.length ?? 0}`,
+    '',
+    '**Persistence**',
+    `database.db: ${mb(fileSize(DB_PATH))}`
+      + ` | RpHistory rows: ${rpHistory.count.toLocaleString()} (${mb(rpHistory.bytes)} of message text)`,
+  );
+  return lines.join('\n');
+}

--- a/utils/rpAvatar.ts
+++ b/utils/rpAvatar.ts
@@ -19,6 +19,11 @@ const URL_REFRESH_MS = 12 * 60 * 60 * 1000;
 // charId -> last good signed URL + when we fetched it.
 const urlCache = new Map<string, { url: string; at: number }>();
 
+/** Size of the avatar-url cache, for /memstats diagnostics. */
+export function getAvatarUrlCacheSize(): number {
+  return urlCache.size;
+}
+
 export type ProcessResult =
   | { ok: true; buffer: Buffer }
   | { ok: false; error: string };

--- a/utils/rpDelivery.ts
+++ b/utils/rpDelivery.ts
@@ -28,6 +28,11 @@ export function isRpWebhookId(id: string | null | undefined): boolean {
   return !!id && rpWebhookIds.has(id);
 }
 
+/** Size of the remembered webhook-id set, for /memstats diagnostics. */
+export function getRpWebhookIdCount(): number {
+  return rpWebhookIds.size;
+}
+
 /** The "↩ Replying to" link button, or [] when there's nothing to link. */
 function replyButtonRow(
   replyToUrl?: string | null,

--- a/utils/rpRuntime.ts
+++ b/utils/rpRuntime.ts
@@ -31,6 +31,11 @@ const activeRpChannels = new Set<string>();
 // or out-of-order replies. Single process, so an in-memory lock suffices.
 const inFlightSpawns = new Set<number>();
 
+/** Sizes of the runtime's in-memory sets, for /memstats diagnostics. */
+export function getRpRuntimeStats(): { activeChannels: number; inFlightSpawns: number } {
+  return { activeChannels: activeRpChannels.size, inFlightSpawns: inFlightSpawns.size };
+}
+
 /** Rebuilds the active-channel set from the DB (call on boot). */
 export async function recomputeActiveRpChannels(db: any): Promise<void> {
   try {


### PR DESCRIPTION
## Why

Prod memory has been climbing steadily since the roleplay deploy (~160 MB baseline → 800 MB and rising, against the 1 GB container limit). A static audit of the RP feature found no unbounded in-memory structure, so the next step is runtime instrumentation to see **where** the memory actually lives.

## What

Dev-only `/memstats` command (auto-registered, `DevCommand`-gated) reporting:

- `process.memoryUsage()` — the `heapUsed` / `rss` / `external` / `arrayBuffers` split distinguishes a JS-heap leak from a native one (canvas / sqlite / sockets)
- Optional `gc:true` — forces `Bun.gc(true)` first and reports how much was freed; a big rss drop means heap high-water churn, not a true leak
- discord.js cache sizes (guilds, channels, users, messages, members)
- RP in-memory state (`activeRpChannels`, `inFlightSpawns`, webhook-id set, avatar URL cache)
- deleted/edited message tracker lengths
- DB footprint: `database.db` file size + `RpHistory` row count and total message bytes (new `HISTORY_STATS` query + `db.rp.getHistoryStats()`)

## Usage

Run `/memstats` a few times over a few hours while memory climbs — whichever number climbs in step with rss is the culprit. If `heapUsed` stays flat while the container number grows, suspect cgroup page cache from log/DB writes rather than the process (check `docker stats` vs `ps` rss, and log rotation).

## Notes

- `bun test` RP suites pass; lint clean; the one `tsc` error (`footballAnnouncements.test.ts`) is pre-existing on master
- No behavior change for non-dev users

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `memstats` dev command that generates a detailed memory and runtime usage report.
  * The report can optionally trigger garbage collection for a refreshed snapshot.
  * Includes cache, in-memory state, message history, and database footprint summaries for easier troubleshooting.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->