### PR TITLE
fix[quote]: newline/long-text layout fixes, text limits, vertical format

### DIFF
--- a/classes/silverwolf.ts
+++ b/classes/silverwolf.ts
@@ -350,6 +350,11 @@ All wrongs reserved.
           }
         }
 
+        // format:v / format:vertical → portrait layout (default landscape)
+        const formatParam = getParam('format') || getParam('fmt');
+        let quoteFormat = 'landscape';
+        if (formatParam && /^v(ertical)?$/i.test(formatParam)) quoteFormat = 'vertical';
+
         // txt:#hex → text colour
         const txtParam = getParam('txt');
         let textColor = null;
@@ -376,7 +381,7 @@ All wrongs reserved.
 
         log(`original message: ${originalMessage}`);
         log(`quote params: ${JSON.stringify({
-          background, avatarSource, profileColor, fontStyle, textColor,
+          background, avatarSource, profileColor, fontStyle, textColor, quoteFormat,
         })}`);
 
         const result = await (quoteDefault as any)(
@@ -389,6 +394,7 @@ All wrongs reserved.
           profileColor,
           avatarSource,
           fontStyle,
+          quoteFormat,
         );
 
         await sentMessage.edit({ content: null, files: [result] });

--- a/commands/fakequote.ts
+++ b/commands/fakequote.ts
@@ -2,6 +2,7 @@ import { Command } from './classes/Command';
 import { logError } from '../utils/log';
 import quote, {
   FAKEQUOTE_FONTS,
+  FAKEQUOTE_FORMATS,
   FAKEQUOTE_BACKGROUNDS,
   FAKEQUOTE_PROFILE_COLORS,
   FAKEQUOTE_AVATAR_SOURCES,
@@ -28,6 +29,13 @@ class FakeQuote extends Command {
         description: 'override the display name shown below the quote',
         type: 3,
         required: false,
+      },
+      {
+        name: 'format',
+        description: 'image layout (default: landscape)',
+        type: 3,
+        required: false,
+        choices: fakeQuoteChoices(FAKEQUOTE_FORMATS),
       },
       {
         name: 'background',
@@ -83,6 +91,7 @@ class FakeQuote extends Command {
         interaction.options.getString('profile_color'),
         interaction.options.getString('avatar_source'),
         interaction.options.getString('font_style'),
+        interaction.options.getString('format'),
       );
 
       await interaction.editReply({ content: null, files: [result] });

--- a/site_src/bot-bridge.ts
+++ b/site_src/bot-bridge.ts
@@ -56,6 +56,7 @@ import quote, {
   FAKEQUOTE_BACKGROUND_VALUES,
   FAKEQUOTE_PROFILE_COLOR_VALUES,
   FAKEQUOTE_FONT_VALUES,
+  FAKEQUOTE_FORMAT_VALUES,
 } from '../utils/quote';
 import { gamblerBoardTitle } from '../utils/leaderboards';
 import { getNextBirthdayInfo } from '../utils/birthdays';
@@ -1240,6 +1241,7 @@ export interface FakeQuoteParams {
   textColor?: string | null;
   profileColor?: string | null;
   fontStyle?: string | null;
+  format?: string | null;
 }
 
 export async function generateFakeQuoteWeb(
@@ -1268,6 +1270,10 @@ export async function generateFakeQuoteWeb(
   if (!FAKEQUOTE_FONT_VALUES.includes(fontStyle)) {
     return { ok: false, error: 'invalid_options' };
   }
+  const format = params.format ?? 'landscape';
+  if (!FAKEQUOTE_FORMAT_VALUES.includes(format)) {
+    return { ok: false, error: 'invalid_options' };
+  }
 
   let person;
   try {
@@ -1292,6 +1298,7 @@ export async function generateFakeQuoteWeb(
       profileColor,
       'global',
       fontStyle,
+      format,
     );
     const base64 = buffer.toString('base64');
     return { ok: true, image: `data:image/png;base64,${base64}` };

--- a/site_src/pages/games/fakequote.ts
+++ b/site_src/pages/games/fakequote.ts
@@ -4,6 +4,7 @@ import type { NavUser } from '../../components/navbar';
 import { inlineJSON } from '../../inline';
 import {
   FAKEQUOTE_FONTS as FONTS,
+  FAKEQUOTE_FORMATS as FORMATS,
   FAKEQUOTE_PROFILE_COLORS as PROFILE_COLOURS,
 } from '../../../utils/quote';
 
@@ -38,6 +39,12 @@ export function FakeQuotePage(opts: { nonce: string; lv999?: boolean; user?: Nav
     font-size: 0.95rem;
     text-align: center;
     padding: 1rem;
+  }
+  .fq-viewport.portrait {
+    aspect-ratio: 4 / 5;
+    max-width: 480px;
+    margin-left: auto;
+    margin-right: auto;
   }
   .fq-viewport img {
     display: block;
@@ -212,6 +219,9 @@ export function FakeQuotePage(opts: { nonce: string; lv999?: boolean; user?: Nav
   const profileOptions = PROFILE_COLOURS.map(
     (p) => html`<option value="${p.value}">${p.label}</option>`,
   );
+  const formatOptions = FORMATS.map(
+    (f) => html`<option value="${f.value}">${f.label}</option>`,
+  );
 
   const formScript = raw(`
 <script nonce="${nonce}">
@@ -349,6 +359,7 @@ export function FakeQuotePage(opts: { nonce: string; lv999?: boolean; user?: Nav
       textColor: textColourHex.value.trim() || null,
       profileColor: form.elements.namedItem('profileColor').value,
       fontStyle: form.elements.namedItem('fontStyle').value,
+      format: form.elements.namedItem('format').value,
     };
 
     let res;
@@ -396,6 +407,8 @@ export function FakeQuotePage(opts: { nonce: string; lv999?: boolean; user?: Nav
     imageEl.style.display = 'block';
     placeholder.style.display = 'none';
     viewport.classList.add('has-image');
+    // Match the preview box to the rendered image's orientation.
+    viewport.classList.toggle('portrait', body.format === 'vertical');
     setMessage('Done.', false);
     startCooldown();
   }
@@ -425,6 +438,11 @@ export function FakeQuotePage(opts: { nonce: string; lv999?: boolean; user?: Nav
       <label>
         Profile colour
         <select name="profileColor">${profileOptions}</select>
+      </label>
+
+      <label class="full">
+        Format
+        <select name="format">${formatOptions}</select>
       </label>
 
       <label class="full">

--- a/site_src/routes/games-api.ts
+++ b/site_src/routes/games-api.ts
@@ -147,6 +147,7 @@ export function registerGameApiRoutes(app: Hono<AppEnv>, silverwolf: Silverwolf)
         textColor: get('textColor'),
         profileColor: get('profileColor'),
         fontStyle: get('fontStyle'),
+        format: get('format'),
       });
       if (!result.ok && result.error === 'rate_limited') {
         const headers: Record<string, string> = {};

--- a/utils/quote.ts
+++ b/utils/quote.ts
@@ -271,7 +271,37 @@ function measureSegmentsWidth(ctx: CanvasCtx, lineSegs: Segment[], fontSize: num
 // ─── Segment-Aware Word Wrapping ──────────────────────────────────────────────
 
 /**
+ * Splits a word wider than maxWidth into character chunks that each fit.
+ * Code-point aware so surrogate pairs are never split in half.
+ */
+function breakLongWord(ctx: CanvasCtx, word: string, maxWidth: number): string[] {
+  const chars = [...word];
+  const pieces: string[] = [];
+  let start = 0;
+
+  while (start < chars.length) {
+    // Binary search for the largest prefix that still fits
+    let lo = 1;
+    let hi = chars.length - start;
+    while (lo < hi) {
+      const mid = Math.ceil((lo + hi) / 2);
+      if (ctx.measureText(chars.slice(start, start + mid).join('')).width <= maxWidth) {
+        lo = mid;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    pieces.push(chars.slice(start, start + lo).join(''));
+    start += lo;
+  }
+
+  return pieces;
+}
+
+/**
  * Splits a flat segment array into "lines" (arrays of segments).
+ * `\n` in text segments forces a hard line break; words wider than
+ * maxWidth are broken at character level so no line ever overflows.
  */
 function wrapSegments(ctx: CanvasCtx, segments: Segment[], maxWidth: number, fontSize: number): Segment[][] {
   const lines: Segment[][] = [[]];
@@ -285,6 +315,19 @@ function wrapSegments(ctx: CanvasCtx, segments: Segment[], maxWidth: number, fon
     } else {
       lineArr.push({ type: 'text', value: str });
     }
+  };
+
+  // Appends a word to a fresh line, character-breaking it if it alone
+  // exceeds maxWidth.
+  const appendWordToLine = (word: string, prefix: string) => {
+    if (ctx.measureText(word).width <= maxWidth) {
+      appendText(lines[lines.length - 1], `${prefix}${word}`);
+      return;
+    }
+    breakLongWord(ctx, word, maxWidth).forEach((piece, pieceIdx) => {
+      if (pieceIdx > 0) lines.push([]);
+      appendText(lines[lines.length - 1], pieceIdx === 0 ? `${prefix}${piece}` : piece);
+    });
   };
 
   segments.forEach((seg, segIdx) => {
@@ -306,37 +349,52 @@ function wrapSegments(ctx: CanvasCtx, segments: Segment[], maxWidth: number, fon
     }
 
     const raw = (seg as any).value as string;
+    const chunks = raw.split('\n');
 
-    if (raw.trim().length === 0) {
-      if (!lineIsEmpty()) {
-        appendText(lines[lines.length - 1], ' ');
+    chunks.forEach((chunk, chunkIdx) => {
+      if (chunkIdx > 0) lines.push([]); // hard line break
+
+      if (chunk.trim().length === 0) {
+        // Whitespace between segments becomes a single separating space,
+        // but never at the start of a line.
+        if (chunk.length > 0 && !lineIsEmpty()) {
+          appendText(lines[lines.length - 1], ' ');
+        }
+        return;
       }
-      return;
-    }
 
-    const hasLeadingSpace = raw.startsWith(' ');
-    const words = raw.split(' ').filter((word) => word.length > 0);
+      const hasLeadingSpace = chunk.startsWith(' ');
+      const words = chunk.split(' ').filter((word) => word.length > 0);
 
-    words.forEach((word, wordIdx) => {
-      const current = lines[lines.length - 1];
-      const currentWidth = measureSegmentsWidth(ctx, current, fontSize);
-      let prefix = '';
-      if (!lineIsEmpty()) {
-        if (wordIdx > 0 || hasLeadingSpace) prefix = ' ';
-      }
-      const wordWidth = ctx.measureText(`${prefix}${word}`).width;
+      words.forEach((word, wordIdx) => {
+        const current = lines[lines.length - 1];
+        const currentWidth = measureSegmentsWidth(ctx, current, fontSize);
+        let prefix = '';
+        if (!lineIsEmpty()) {
+          if (wordIdx > 0 || hasLeadingSpace) prefix = ' ';
+        }
+        const wordWidth = ctx.measureText(`${prefix}${word}`).width;
 
-      if (currentWidth + wordWidth <= maxWidth || lineIsEmpty()) {
-        appendText(current, `${prefix}${word}`);
-      } else {
-        lines.push([]);
-        appendText(lines[lines.length - 1], word);
-      }
+        if (lineIsEmpty()) {
+          appendWordToLine(word, prefix);
+        } else if (currentWidth + wordWidth <= maxWidth) {
+          appendText(current, `${prefix}${word}`);
+        } else {
+          lines.push([]);
+          appendWordToLine(word, '');
+        }
+      });
     });
   });
 
   return lines;
 }
+
+// ─── Text Limits ──────────────────────────────────────────────────────────────
+// Below MIN_QUOTE_FONT_SIZE the quote is unreadable, so instead of shrinking
+// further we truncate with an ellipsis. MAX_QUOTE_CHARS caps the input outright.
+const MIN_QUOTE_FONT_SIZE = 14;
+const MAX_QUOTE_CHARS = 2000;
 
 // ─── Font Size Shrinking ──────────────────────────────────────────────────────
 
@@ -363,7 +421,7 @@ function adjustFontSize(
   let totalHeight = lines.length * lineHeight;
 
   while (
-    fontSize > 10
+    fontSize > MIN_QUOTE_FONT_SIZE
     && (
       totalHeight > height
       || anyLineExceedsWidth(ctx, lines, fontSize, maxWidth)
@@ -422,9 +480,13 @@ function drawSegmentedLine(
   centerX: number,
   y: number,
   fontSize: number,
+  fontFamily: string,
   emojiCache: Map<string, any>,
   textColor: string,
 ): void {
+  // ctx.font may have been changed since the lines were wrapped (e.g. by
+  // nickname sizing) — restore it so measurement matches rendering.
+  ctx.font = buildFont(fontSize, fontFamily);
   const totalWidth = measureSegmentsWidth(ctx, lineSegs, fontSize);
   let drawX = centerX - totalWidth / 2;
 
@@ -474,6 +536,114 @@ function fitNickname(
   return size;
 }
 
+// ─── Avatar Drawing ───────────────────────────────────────────────────────────
+
+/**
+ * Draws the avatar at (0, 0) scaled to w×h and applies the requested
+ * profileColor filter in place.
+ */
+function drawFilteredAvatar(ctx: CanvasCtx, pfpImage: any, w: number, h: number, profileColor: string): void {
+  ctx.drawImage(pfpImage, 0, 0, w, h);
+  if (profileColor === 'bw') {
+    const imageData = ctx.getImageData(0, 0, w, h);
+    const { data } = imageData;
+    for (let i = 0; i < data.length; i += 4) {
+      const avg = (data[i] + data[i + 1] + data[i + 2]) / 3;
+      data[i] = avg; data[i + 1] = avg; data[i + 2] = avg;
+    }
+    ctx.putImageData(imageData, 0, 0);
+    log('Converted pfp to black and white');
+  } else if (profileColor === 'inverted') {
+    const imageData = ctx.getImageData(0, 0, w, h);
+    const { data } = imageData;
+    for (let i = 0; i < data.length; i += 4) {
+      data[i] = 255 - data[i];
+      data[i + 1] = 255 - data[i + 1];
+      data[i + 2] = 255 - data[i + 2];
+    }
+    ctx.putImageData(imageData, 0, 0);
+    log('Inverted pfp');
+  } else if (profileColor === 'sepia') {
+    const imageData = ctx.getImageData(0, 0, w, h);
+    const { data } = imageData;
+    for (let i = 0; i < data.length; i += 4) {
+      const avg = (data[i] + data[i + 1] + data[i + 2]) / 3;
+      data[i] = Math.min(avg + 100, 255);
+      data[i + 1] = Math.min(avg + 50, 255);
+      data[i + 2] = avg;
+    }
+    ctx.putImageData(imageData, 0, 0);
+    log('Drew sepia pfp');
+  } else if (profileColor === 'nightmare') {
+    const imageData = ctx.getImageData(0, 0, w, h);
+    const { data } = imageData;
+    for (let i = 0; i < data.length; i += 4) {
+      data[i] = 255 - data[i];
+      data[i + 1] = 255 - data[i + 1];
+      data[i + 2] = 255 - data[i + 2];
+    }
+    for (let i = 0; i < data.length; i += 4) {
+      data[i] = Math.min(data[i] + 100, 255);
+      data[i + 1] = data[i + 1] * 0.5;
+      data[i + 2] = data[i + 2] * 0.5;
+      if (Math.random() < 0.4) {
+        const noiseR = Math.floor(Math.random() * 120) - 60;
+        const noiseG = Math.floor(Math.random() * 120) - 60;
+        const noiseB = Math.floor(Math.random() * 120) - 60;
+        data[i] = Math.min(Math.max(data[i] + noiseR, 0), 255);
+        data[i + 1] = Math.min(Math.max(data[i + 1] + noiseG, 0), 255);
+        data[i + 2] = Math.min(Math.max(data[i + 2] + noiseB, 0), 255);
+      }
+    }
+    ctx.putImageData(imageData, 0, 0);
+    log('Applied nightmare effect to pfp');
+  } else {
+    log('Drew normal pfp');
+  }
+}
+
+// ─── Ellipsis Truncation ──────────────────────────────────────────────────────
+
+/**
+ * Keeps at most maxLines lines and ends the last kept line with `suffix`
+ * (default …"), trimming its tail until it fits maxWidth again.
+ * ctx.font must already be set to the rendering font.
+ */
+function truncateWithEllipsis(
+  ctx: CanvasCtx,
+  _lines: Segment[][],
+  maxLines: number,
+  fontSize: number,
+  maxWidth: number,
+  suffix = '…"',
+): Segment[][] {
+  const lines = _lines.slice(0, Math.max(1, maxLines));
+  const lastLine = lines[lines.length - 1];
+  const lastSeg = lastLine[lastLine.length - 1];
+  if (lastSeg && lastSeg.type === 'text') {
+    lastSeg.value = `${lastSeg.value.replace(/["\s]+$/, '')}${suffix}`;
+  } else {
+    lastLine.push({ type: 'text', value: suffix });
+  }
+
+  // Trim the tail until the ellipsised line fits the width again
+  while (measureSegmentsWidth(ctx, lastLine, fontSize) > maxWidth) {
+    const tail = lastLine[lastLine.length - 1] as { type: 'text'; value: string };
+    const chars = [...tail.value];
+    if (chars.length > suffix.length) {
+      chars.splice(chars.length - suffix.length - 1, 1); // remove the char before the suffix
+      tail.value = chars.join('');
+    } else if (lastLine.length > 1) {
+      lastLine.splice(lastLine.length - 2, 1); // drop the emoji before the tail
+    } else {
+      break;
+    }
+  }
+
+  log('Truncated quote text with ellipsis');
+  return lines;
+}
+
 // ─── Avatar URL Resolution ────────────────────────────────────────────────────
 
 function resolveAvatarUrl(person: User | APIUser): string {
@@ -488,6 +658,154 @@ function resolveAvatarUrl(person: User | APIUser): string {
   return `https://cdn.discordapp.com/embed/avatars/${defaultIndex}.png`;
 }
 
+// ─── Vertical (Portrait) Renderer ─────────────────────────────────────────────
+
+interface VerticalQuoteInput {
+  message: string; // sanitized + clipped, WITHOUT surrounding quote marks
+  nickname: string;
+  username: string;
+  backgroundColor: string;
+  textColor: string;
+  profileColor: string;
+  pfp: string;
+  fontFamily: string;
+}
+
+/**
+ * Portrait layout: avatar on top fading into the background colour, big
+ * quotation-mark glyph, centred quote text, divider, name and @username.
+ */
+async function renderVerticalQuote(input: VerticalQuoteInput): Promise<Buffer> {
+  const {
+    message, nickname, username, backgroundColor, textColor, profileColor, pfp, fontFamily,
+  } = input;
+
+  const WIDTH = 640;
+  const HEIGHT = 800;
+  const AVATAR_SIZE = 640; // full-width square at the top
+  const MAX_TEXT_WIDTH = 560;
+  const MAX_TEXT_HEIGHT = 250;
+  const CONTENT_BOTTOM = 760; // baseline the content block sits above
+
+  const canvas = Canvas.createCanvas(WIDTH, HEIGHT);
+  const ctx = canvas.getContext('2d');
+  log('Created vertical canvas');
+
+  const bgHex = backgroundColor === 'white' ? '#ffffff' : '#000000';
+  const bgRgb = backgroundColor === 'white' ? '255, 255, 255' : '0, 0, 0';
+  ctx.fillStyle = bgHex;
+  ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+  // ── Avatar ────────────────────────────────────────────────────────────────
+  const pfpImage = await Canvas.loadImage(pfp);
+  drawFilteredAvatar(ctx, pfpImage, AVATAR_SIZE, AVATAR_SIZE, profileColor);
+
+  // ── Wrap, shrink, truncate ────────────────────────────────────────────────
+  let fontSize = 32;
+  const rawSegments = parseSegments(message);
+
+  ctx.font = buildFont(fontSize, fontFamily);
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'top';
+
+  let lines = wrapSegments(ctx, rawSegments, MAX_TEXT_WIDTH, fontSize);
+  fontSize = adjustFontSize(ctx, lines, MAX_TEXT_WIDTH, fontSize, fontFamily, MAX_TEXT_HEIGHT);
+  ctx.font = buildFont(fontSize, fontFamily);
+  lines = wrapSegments(ctx, rawSegments, MAX_TEXT_WIDTH, fontSize);
+
+  const lineHeight = fontSize * 1.2;
+  const maxLines = Math.max(1, Math.floor(MAX_TEXT_HEIGHT / lineHeight));
+  if (lines.length > maxLines) {
+    lines = truncateWithEllipsis(ctx, lines, maxLines, fontSize, MAX_TEXT_WIDTH, '…');
+  }
+
+  const emojiCache = await loadEmojiImages(lines);
+  log('Loaded emoji images');
+
+  // ── Content block layout (bottom-anchored) ────────────────────────────────
+  const nickFontSize = fitNickname(ctx, nickname, MAX_TEXT_WIDTH, fontFamily, 32);
+  const userFontSize = Math.min(20, Math.max(12, nickFontSize - 10));
+  const showUser = username !== nickname;
+
+  const glyphSize = 56;
+  const gapAfterGlyph = 14;
+  const textHeight = lines.length * lineHeight;
+  const gapAfterText = 26;
+  const gapAfterDivider = 18;
+  const nickHeight = nickFontSize * 1.2;
+  const userHeight = showUser ? userFontSize * 1.3 + 4 : 0;
+
+  const totalHeight = glyphSize + gapAfterGlyph + textHeight
+    + gapAfterText + gapAfterDivider + nickHeight + userHeight;
+  let y = CONTENT_BOTTOM - totalHeight;
+  const centerX = WIDTH / 2;
+
+  // ── Gradient fade (avatar → content) ──────────────────────────────────────
+  // Anchored to wherever the content block starts so the text always sits on
+  // an opaque background, however tall the quote is.
+  const fadeBottom = Math.min(AVATAR_SIZE, y + 50);
+  const fadeTop = Math.max(0, fadeBottom - 320);
+  const gradient = ctx.createLinearGradient(0, fadeTop, 0, fadeBottom);
+  gradient.addColorStop(0, `rgba(${bgRgb}, 0)`);
+  gradient.addColorStop(0.5, `rgba(${bgRgb}, 0.55)`);
+  gradient.addColorStop(0.8, `rgba(${bgRgb}, 0.9)`);
+  gradient.addColorStop(1, `rgba(${bgRgb}, 1)`);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, fadeTop, WIDTH, fadeBottom - fadeTop);
+  if (fadeBottom < AVATAR_SIZE) {
+    ctx.fillStyle = bgHex;
+    ctx.fillRect(0, fadeBottom, WIDTH, AVATAR_SIZE - fadeBottom);
+  }
+  log('Filled vertical gradient');
+
+  // Quotation-mark glyph
+  ctx.fillStyle = textColor;
+  ctx.font = `bold ${glyphSize}px "${fontFamily}"`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'top';
+  ctx.fillText('“”', centerX, y);
+  y += glyphSize + gapAfterGlyph;
+
+  // Quote text
+  lines.forEach((lineSegs, index) => {
+    drawSegmentedLine(ctx, lineSegs, centerX, y + index * lineHeight, fontSize, fontFamily, emojiCache, textColor);
+  });
+  y += textHeight + gapAfterText;
+  log('Drew vertical quote');
+
+  // Divider
+  ctx.strokeStyle = textColor;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(centerX - 90, y);
+  ctx.lineTo(centerX + 90, y);
+  ctx.stroke();
+  y += gapAfterDivider;
+
+  // Name + @username
+  ctx.fillStyle = textColor;
+  ctx.font = buildFont(nickFontSize, fontFamily, 'normal');
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'top';
+  ctx.fillText(nickname, centerX, y);
+  y += nickHeight + 4;
+  if (showUser) {
+    ctx.fillStyle = '#808080';
+    ctx.font = buildFont(userFontSize, fontFamily, 'normal');
+    ctx.fillText(`@${username}`, centerX, y);
+  }
+  log('Drew vertical nickname');
+
+  // Footer watermark
+  ctx.fillStyle = '#808080';
+  ctx.font = buildFont(16, fontFamily, 'normal');
+  ctx.textAlign = 'right';
+  ctx.textBaseline = 'bottom';
+  ctx.fillText('silverwolf', WIDTH - 12, HEIGHT - 10);
+
+  return canvas.toBuffer();
+}
+
 // ─── Main Quote Function ──────────────────────────────────────────────────────
 
 async function quote(
@@ -500,11 +818,20 @@ async function quote(
   _profileColor: string | null,
   _avatarSource: string | null,
   _fontStyle: string | null,
+  _format: string | null = null,
 ): Promise<Buffer> {
   const { username } = _person;
   const nickname = _nickname || username;
-  const resolvedMessage = await resolveMentions(guild, _message);
-  const message = `"${resolvedMessage}"`;
+  const resolvedMessage = (await resolveMentions(guild, _message))
+    .replace(/\r\n?/g, '\n') // normalise CRLF / lone CR to \n
+    .replace(/\t/g, ' ')
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\x00-\x08\x0B-\x1F\x7F]/g, '');
+  const messageChars = [...resolvedMessage];
+  const clippedMessage = messageChars.length > MAX_QUOTE_CHARS
+    ? `${messageChars.slice(0, MAX_QUOTE_CHARS).join('').trimEnd()}…`
+    : resolvedMessage;
+  const message = `"${clippedMessage}"`;
   const backgroundColor = _backgroundColor || 'black';
   const profileColor = _profileColor || 'normal';
   const avatarSource = _avatarSource || 'global';
@@ -539,6 +866,20 @@ async function quote(
     pfp = resolveAvatarUrl(_person);
   }
 
+  // ── Vertical (portrait) format ────────────────────────────────────────────
+  if (_format === 'vertical') {
+    return renderVerticalQuote({
+      message: clippedMessage,
+      nickname,
+      username,
+      backgroundColor,
+      textColor,
+      profileColor,
+      pfp,
+      fontFamily,
+    });
+  }
+
   // ── Canvas Setup ──────────────────────────────────────────────────────────
   const canvas = Canvas.createCanvas(1024, 512);
   const ctx = canvas.getContext('2d');
@@ -551,68 +892,7 @@ async function quote(
 
   // ── Profile Picture ───────────────────────────────────────────────────────
   const pfpImage = await Canvas.loadImage(pfp);
-
-  if (profileColor === 'bw') {
-    ctx.drawImage(pfpImage, 0, 0, 512, 512);
-    const imageData = ctx.getImageData(0, 0, 512, 512);
-    const { data } = imageData;
-    for (let i = 0; i < data.length; i += 4) {
-      const avg = (data[i] + data[i + 1] + data[i + 2]) / 3;
-      data[i] = avg; data[i + 1] = avg; data[i + 2] = avg;
-    }
-    ctx.putImageData(imageData, 0, 0);
-    log('Converted pfp to black and white');
-  } else if (profileColor === 'inverted') {
-    ctx.drawImage(pfpImage, 0, 0, 512, 512);
-    const imageData = ctx.getImageData(0, 0, 512, 512);
-    const { data } = imageData;
-    for (let i = 0; i < data.length; i += 4) {
-      data[i] = 255 - data[i];
-      data[i + 1] = 255 - data[i + 1];
-      data[i + 2] = 255 - data[i + 2];
-    }
-    ctx.putImageData(imageData, 0, 0);
-    log('Inverted pfp');
-  } else if (profileColor === 'sepia') {
-    ctx.drawImage(pfpImage, 0, 0, 512, 512);
-    const imageData = ctx.getImageData(0, 0, 512, 512);
-    const { data } = imageData;
-    for (let i = 0; i < data.length; i += 4) {
-      const avg = (data[i] + data[i + 1] + data[i + 2]) / 3;
-      data[i] = Math.min(avg + 100, 255);
-      data[i + 1] = Math.min(avg + 50, 255);
-      data[i + 2] = avg;
-    }
-    ctx.putImageData(imageData, 0, 0);
-    log('Drew sepia pfp');
-  } else if (profileColor === 'nightmare') {
-    ctx.drawImage(pfpImage, 0, 0, 512, 512);
-    const imageData = ctx.getImageData(0, 0, 512, 512);
-    const { data } = imageData;
-    for (let i = 0; i < data.length; i += 4) {
-      data[i] = 255 - data[i];
-      data[i + 1] = 255 - data[i + 1];
-      data[i + 2] = 255 - data[i + 2];
-    }
-    for (let i = 0; i < data.length; i += 4) {
-      data[i] = Math.min(data[i] + 100, 255);
-      data[i + 1] = data[i + 1] * 0.5;
-      data[i + 2] = data[i + 2] * 0.5;
-      if (Math.random() < 0.4) {
-        const noiseR = Math.floor(Math.random() * 120) - 60;
-        const noiseG = Math.floor(Math.random() * 120) - 60;
-        const noiseB = Math.floor(Math.random() * 120) - 60;
-        data[i] = Math.min(Math.max(data[i] + noiseR, 0), 255);
-        data[i + 1] = Math.min(Math.max(data[i + 1] + noiseG, 0), 255);
-        data[i + 2] = Math.min(Math.max(data[i + 2] + noiseB, 0), 255);
-      }
-    }
-    ctx.putImageData(imageData, 0, 0);
-    log('Applied nightmare effect to pfp');
-  } else {
-    ctx.drawImage(pfpImage, 0, 0, 512, 512);
-    log('Drew normal pfp');
-  }
+  drawFilteredAvatar(ctx, pfpImage, 512, 512, profileColor);
 
   // ── Gradient Fade (pfp → text area) ──────────────────────────────────────
   const gradient = ctx.createLinearGradient(384, 0, 512, 0);
@@ -671,10 +951,23 @@ async function quote(
   let totalHeight = calcTotalHeight(fontSize, lines, nickFontSize, userFontSize);
 
   // If still overflowing, shrink quote font further and re-wrap
-  while (totalHeight > MAX_CONTENT_HEIGHT && fontSize > 10) {
+  while (totalHeight > MAX_CONTENT_HEIGHT && fontSize > MIN_QUOTE_FONT_SIZE) {
     fontSize -= 1;
     ctx.font = buildFont(fontSize, fontFamily);
     lines = wrapSegments(ctx, rawSegments, MAX_TEXT_WIDTH, fontSize);
+    totalHeight = calcTotalHeight(fontSize, lines, nickFontSize, userFontSize);
+  }
+
+  // ── Ellipsis truncation ───────────────────────────────────────────────────
+  // Even at the minimum font the text doesn't fit (e.g. newline spam): drop
+  // trailing lines and end the last kept line with …" instead of squeezing
+  // the name off the canvas.
+  if (totalHeight > MAX_CONTENT_HEIGHT) {
+    ctx.font = buildFont(fontSize, fontFamily);
+    const lh = fontSize * 1.2;
+    const reservedHeight = totalHeight - lines.length * lh; // nickname/username block
+    const maxLines = Math.max(1, Math.floor((MAX_CONTENT_HEIGHT - reservedHeight) / lh));
+    lines = truncateWithEllipsis(ctx, lines, maxLines, fontSize, MAX_TEXT_WIDTH);
     totalHeight = calcTotalHeight(fontSize, lines, nickFontSize, userFontSize);
   }
 
@@ -690,6 +983,7 @@ async function quote(
       TEXT_CENTER_X,
       textY + index * lineHeight,
       fontSize,
+      fontFamily,
       emojiCache,
       textColor,
     );
@@ -747,6 +1041,11 @@ export const FAKEQUOTE_FONTS: FakeQuoteOption[] = [
   { value: 'bebas-neue', label: 'Bebas Neue (Condensed)' },
 ];
 
+export const FAKEQUOTE_FORMATS: FakeQuoteOption[] = [
+  { value: 'landscape', label: 'Landscape (Classic)' },
+  { value: 'vertical', label: 'Vertical (Portrait)' },
+];
+
 export const FAKEQUOTE_BACKGROUNDS: FakeQuoteOption[] = [
   { value: 'black', label: 'Black' },
   { value: 'white', label: 'White' },
@@ -768,6 +1067,7 @@ export const FAKEQUOTE_AVATAR_SOURCES: FakeQuoteOption[] = [
 const valuesOf = (opts: FakeQuoteOption[]) => opts.map((o) => o.value);
 
 export const FAKEQUOTE_FONT_VALUES = valuesOf(FAKEQUOTE_FONTS);
+export const FAKEQUOTE_FORMAT_VALUES = valuesOf(FAKEQUOTE_FORMATS);
 export const FAKEQUOTE_BACKGROUND_VALUES = valuesOf(FAKEQUOTE_BACKGROUNDS);
 export const FAKEQUOTE_PROFILE_COLOR_VALUES = valuesOf(FAKEQUOTE_PROFILE_COLORS);
 export const FAKEQUOTE_AVATAR_SOURCE_VALUES = valuesOf(FAKEQUOTE_AVATAR_SOURCES);


### PR DESCRIPTION
## What changed

### Bug fixes (`utils/quote.ts`)
- **Newlines broke the layout**: node-canvas (Pango) renders `\n` inside `fillText` as real line breaks, but the wrapper treated the whole message as one line, so lines overlapped the nickname. `wrapSegments` now treats `\n` as a hard line break, and the message is sanitized up front (CRLF → `\n`, tabs → space, other control chars stripped).
- **Long texts overlapped**: `fitNickname()` runs after the quote lines are wrapped and left `ctx.font` at the nickname size (up to 36px). `drawSegmentedLine` never reset it, so shrunk quote text was measured small but drawn big. It now sets the font itself before measuring/drawing.
- Words wider than the text area (300+ char unbroken strings) are now broken at character level (code-point aware) instead of overflowing the canvas.

### Text limits
- `MIN_QUOTE_FONT_SIZE = 14` — below this the quote is unreadable, so instead of shrinking further, trailing lines are dropped and the last visible line ends with `…"`. The name/username block can no longer be pushed off-canvas by newline spam.
- `MAX_QUOTE_CHARS = 2000` — hard input cap (matches Discord's message limit). Effective visible max is ~1,800 chars at 14px before the ellipsis kicks in.

### New: vertical (portrait) format
Make-it-a-Quote-style 640×800 layout: avatar on top, dynamic gradient fade anchored to wherever the content block starts (text always lands on an opaque background regardless of quote length), quote glyph, centered text, divider, name, @username. Reuses the same wrap/shrink/ellipsis pipeline and avatar filters (extracted into shared `drawFilteredAvatar` / `truncateWithEllipsis` helpers).

Available on all three surfaces from one shared `FAKEQUOTE_FORMATS` list:
- Reply-mention: `@Silverwolf format:v` (also `format:vertical` / `fmt:v`), composes with existing `bg:` / `pfpc:` / `font:` / `txt:` params
- `/fakequote` slash command: new optional `format` choice
- Website fakequote page: format dropdown, passed through `games-api.ts` and enum-validated in `bot-bridge.ts` (rejected with `invalid_options` if not whitelisted); the preview box switches to 4:5 for portrait renders

## Notes for review
- Verified by rendering real canvas output for: multi-line messages, 500–3000 char walls, 300-char unbroken words, CRLF input, 30/60/120-line newline spam, and all vertical cases (short/long/newline-spam/white bg) — plus re-rendering the landscape matrix after the helper extraction to confirm no regression.
- `tsc --noEmit` has one pre-existing unrelated failure in `tests/footballAnnouncements.test.ts` (missing shootout fields); ESLint passes on all touched files.
- Defaults unchanged everywhere: omitted `format` renders the classic landscape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new quote format option, including a vertical/portrait layout.
  * The fake quote experience now lets users choose the quote format in the app and web flow.

* **Bug Fixes**
  * Improved quote text handling for long words, line breaks, and oversized text.
  * Better support for emoji and special characters in rendered quotes.
  * Added stricter validation for quote format values to avoid invalid output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->