### PR TITLE
feat[ai]: @mi persona (MiMo-V2.5) with image/video/audio input

### DIFF
--- a/classes/handlers/keywordsBehaviorHandler.ts
+++ b/classes/handlers/keywordsBehaviorHandler.ts
@@ -7,7 +7,9 @@ import { resolvePersona, generateContent, generateTitleForHistory } from '../../
 import { IMAGE_GEN_TOOL_NAME } from '../../utils/imageGen';
 import { trimHistoryToFit } from '../../utils/tokenizer';
 import { extractPdfsFromMessage } from '../../utils/pdf';
-import { collectMediaFromMessage, tryAcquireMediaSlot, releaseMediaSlot } from '../../utils/aiMedia';
+import {
+  collectMediaFromMessage, hasQualifyingMedia, tryAcquireMediaSlot, releaseMediaSlot,
+} from '../../utils/aiMedia';
 
 const WEBHOOK_NAME = process.env.WEBHOOK_NAME || 'grok-webhook';
 
@@ -123,8 +125,8 @@ const scriptHandlers = {
     let mediaPlaceholders: string[] = [];
     const mediaNotices: string[] = [];
     let mediaSlotHeld = false;
-    const hasMediaCandidates = message.attachments.size > 0 || (contextMsg?.attachments.size ?? 0) > 0;
-    if (persona.mediaInput && persona.provider === 'openrouter' && hasMediaCandidates) {
+    if (persona.mediaInput && persona.provider === 'openrouter'
+      && hasQualifyingMedia(message, contextMsg)) {
       if (!tryAcquireMediaSlot()) {
         mediaNotices.push('⚠ Too many attachment-reading requests in flight right now — answering without your attachments. Try again in a moment.');
       } else {

--- a/classes/handlers/keywordsBehaviorHandler.ts
+++ b/classes/handlers/keywordsBehaviorHandler.ts
@@ -7,6 +7,7 @@ import { resolvePersona, generateContent, generateTitleForHistory } from '../../
 import { IMAGE_GEN_TOOL_NAME } from '../../utils/imageGen';
 import { trimHistoryToFit } from '../../utils/tokenizer';
 import { extractPdfsFromMessage } from '../../utils/pdf';
+import { collectMediaFromMessage, tryAcquireMediaSlot, releaseMediaSlot } from '../../utils/aiMedia';
 
 const WEBHOOK_NAME = process.env.WEBHOOK_NAME || 'grok-webhook';
 
@@ -114,12 +115,41 @@ const scriptHandlers = {
     }
 
     const { blocks: pdfBlocks, notices: pdfNotices } = await extractPdfsFromMessage(message);
-    for (const notice of pdfNotices) {
+
+    // Media (image/video/audio) attachments — persona-gated, openrouter-only.
+    // Base64 buffers live in mediaParts for the duration of this generation
+    // and are never persisted; only text placeholders enter the prompt/history.
+    let mediaParts: any[] = [];
+    let mediaPlaceholders: string[] = [];
+    const mediaNotices: string[] = [];
+    let mediaSlotHeld = false;
+    const hasMediaCandidates = message.attachments.size > 0 || (contextMsg?.attachments.size ?? 0) > 0;
+    if (persona.mediaInput && persona.provider === 'openrouter' && hasMediaCandidates) {
+      if (!tryAcquireMediaSlot()) {
+        mediaNotices.push('⚠ Too many attachment-reading requests in flight right now — answering without your attachments. Try again in a moment.');
+      } else {
+        mediaSlotHeld = true;
+        try {
+          const collected = await collectMediaFromMessage(message, contextMsg);
+          mediaParts = collected.parts;
+          mediaPlaceholders = collected.placeholders;
+          mediaNotices.push(...collected.notices);
+        } catch (mediaErr) {
+          logError('AiChat: media collection failed, proceeding without attachments:', mediaErr);
+          mediaNotices.push('⚠ Couldn\'t process your attachments — answering without them.');
+          mediaParts = [];
+          mediaPlaceholders = [];
+        }
+      }
+    }
+
+    for (const notice of [...pdfNotices, ...mediaNotices]) {
       // eslint-disable-next-line no-await-in-loop
       await message.reply({ content: notice, allowedMentions: { repliedUser: false } })
-        .catch((e) => { logError('PDF notice reply failed:', e); });
+        .catch((e) => { logError('Attachment notice reply failed:', e); });
     }
     const pdfPrefix = pdfBlocks.length > 0 ? `${pdfBlocks.join('\n\n')}\n\n` : '';
+    const mediaSuffix = mediaPlaceholders.length > 0 ? `\n${mediaPlaceholders.join('\n')}` : '';
 
     let prompt = '';
 
@@ -127,9 +157,9 @@ const scriptHandlers = {
       const promptName = (contextMsg.author.username === displayName) ? 'You' : contextMsg.author.username;
       prompt = `${pdfPrefix}Previous message by ${promptName}: "${contextMsg.content}"
 
-      User ${username} said: ${query}`;
+      User ${username} said: ${query}${mediaSuffix}`;
     } else {
-      prompt = `${pdfPrefix}User ${username} said: ${query}`;
+      prompt = `${pdfPrefix}User ${username} said: ${query}${mediaSuffix}`;
     }
 
     log(`Prompt: ${prompt}`);
@@ -179,19 +209,43 @@ const scriptHandlers = {
       const webhooks = await (message.channel as TextChannel).fetchWebhooks();
       let webhook = webhooks.find((wh: any) => wh.name === WEBHOOK_NAME && wh.token);
 
-      const { text, images, toolCalls } = await generateContent({
+      const generateOnce = (withMedia: boolean) => generateContent({
         provider: persona.provider,
         model: persona.model,
         systemPrompt: persona.systemPrompt ?? '',
         prompt,
         history,
         webSearchEnabled: persona.webSearchEnabled,
+        mediaParts: withMedia ? mediaParts : [],
+        providerRouting: persona.providerRouting,
         // Image generation is Discord-only (delivery rides this webhook); the
         // rate limit is keyed to the requesting Discord user.
         imageGen: hasMemory
           ? { userId: message.author.id, db: (message.client as any).db }
           : undefined,
       });
+
+      let genResult;
+      let mediaDropped = false;
+      try {
+        genResult = await generateOnce(mediaParts.length > 0);
+      } catch (genErr) {
+        // A provider rejecting the media (bad codec, too long, …) shouldn't eat
+        // the whole reply — drop attachments and answer text-only.
+        if (mediaParts.length === 0) throw genErr;
+        logError('AiChat: generation with media failed, retrying text-only:', genErr);
+        mediaDropped = true;
+        genResult = await generateOnce(false);
+      } finally {
+        // Buffers are only referenced by mediaParts; free the slot as soon as
+        // the provider round-trip is over.
+        mediaParts = [];
+        if (mediaSlotHeld) {
+          releaseMediaSlot();
+          mediaSlotHeld = false;
+        }
+      }
+      const { text, images, toolCalls } = genResult;
 
       if (!webhook) {
         webhook = await (message.channel as TextChannel).createWebhook({
@@ -223,7 +277,13 @@ const scriptHandlers = {
         ? `-# 🔎 searched the web (${searchCallCount})\n`
         : '';
       const imagePrefix = imageCallHappened ? '-# 🎨 generated an image\n' : '';
-      let remainingText = `${searchPrefix}${imagePrefix}${(text || '').toString()}`;
+      const mediaReadPrefix = mediaPlaceholders.length > 0 && !mediaDropped
+        ? `-# 📎 read ${mediaPlaceholders.length} attachment${mediaPlaceholders.length === 1 ? '' : 's'}\n`
+        : '';
+      const mediaFailPrefix = mediaDropped
+        ? '-# ⚠ the model rejected the attachments — answered without them\n'
+        : '';
+      let remainingText = `${searchPrefix}${imagePrefix}${mediaReadPrefix}${mediaFailPrefix}${(text || '').toString()}`;
       let previousMsg: any = null;
       let filesToAttach: any[] = images || [];
 
@@ -364,6 +424,10 @@ const scriptHandlers = {
         }
       }
     } catch (err) {
+      if (mediaSlotHeld) {
+        releaseMediaSlot();
+        mediaSlotHeld = false;
+      }
       logError('AI unified handler error', err);
       await message.reply(
         'Either, our code is fucked, their API is fucked, or you are just fucked. Please try again later.',

--- a/data/aiPersonas.json
+++ b/data/aiPersonas.json
@@ -66,6 +66,17 @@
       "systemPrompt": "Generate a concise title of 5-10 words max summarizing the conversation topic. Output only the raw title text — no quotes, no prefixes, no punctuation at the end. Do not think, reason, plan, or explain. Respond immediately with the title and nothing else."
     },
     {
+      "name": "MiMo",
+      "triggers": ["@mi"],
+      "provider": "openrouter",
+      "model": "xiaomi/mimo-v2.5",
+      "providerRouting": { "only": ["xiaomi"], "allow_fallbacks": false },
+      "mediaInput": true,
+      "systemPrompt": "You are MiMo-V2.5, Xiaomi's omnimodal AI assistant. You can natively see images, watch videos, and hear audio the user attaches. Respond clearly, concisely, and politely. When media is attached, describe or analyze it directly — never claim you cannot see or hear attachments. Keep answers under a few sentences unless more detail is explicitly requested.",
+      "avatarURL": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/ae/Xiaomi_logo_%282021-%29.svg/512px-Xiaomi_logo_%282021-%29.svg.png",
+      "webSearchEnabled": true
+    },
+    {
       "name": "Deepseek",
       "triggers": ["@ds", "deepseek"],
       "provider": "openrouter",

--- a/data/keywords.json
+++ b/data/keywords.json
@@ -41,7 +41,7 @@
     "reply": ":childepanic_Emlette: I literally was on my drive to work this morning and I couldn't stop thinking of Childe- like okay its normal for me- but like-- I started thinking about how Keiko mentioned- water bondage 👀 and it snowballed into something- lewder. And all I could think about was Tartaglia who is tall and im small; starting out with a battle or maybe like a spar, idk man he's very into fighting I wouldn't be surprised if it made him hard. And like- he obviously knows how to use things to his advantage. So like- water bondage- just not in a hot way. Or at least intended. But obviously Tartaglia plays with his opponents- like fr. And hes turned on bc hes gotten a good fight. And I can't stop imagining how grabby he'd get- im rambling ill wrap it up. I can imagine the hair pulling, maybe a smol growl, and how he'd have so little mercy, bc he is a man who destroys. Bonus points if he uses his delusion at all and sparks up the hydro. Extra bonus points if he's rough with little mercy 👀 He doesn't even need gentle aftercare or cuddling- I mean id like to cuddle him but if he doesn't; that's okay :peepoBlushShake: id be a mess after anyone. He can step on me or split me open and i'll say thank you. \n\nI should write a fanfic sometime...\n\nAnyway yall im down bad... what else is new :7qiqipeek:"
   },
   {
-    "triggers" : ["@grok", "@gork", "jarvis", "@gpt", "@sw", "@xiaomi", "@ds"],
+    "triggers" : ["@grok", "@gork", "jarvis", "@gpt", "@sw", "@xiaomi", "@ds", "@mi"],
     "script" : "grok"
   },
   {

--- a/utils/ai.ts
+++ b/utils/ai.ts
@@ -44,6 +44,10 @@ export interface Persona {
   responseModalities?: string[];
   avatarURL?: string;
   webSearchEnabled?: boolean;
+  /** OpenRouter provider-routing object (e.g. { only: ['xiaomi'], allow_fallbacks: false }). */
+  providerRouting?: Record<string, any>;
+  /** When true, Discord image/video/audio attachments are sent to the model (openrouter only). */
+  mediaInput?: boolean;
 }
 
 export interface ToolCallRecord {
@@ -131,6 +135,14 @@ interface GenerateContentOptions {
   webSearchEnabled?: boolean;
   /** When set, the model is offered the generate_image tool (Discord-only delivery). */
   imageGen?: ImageGenContext;
+  /**
+   * Multimodal content parts (image_url / video_url / input_audio) appended to
+   * the current user turn. OpenRouter provider only; base64 data — never
+   * persisted to history by callers (see utils/aiMedia.ts).
+   */
+  mediaParts?: any[];
+  /** OpenRouter provider-routing body field (pin/exclude providers). */
+  providerRouting?: Record<string, any>;
 }
 
 interface ImageAttachment {
@@ -222,6 +234,7 @@ function getImageGenConfig(): { model: string; modalities: string[] } {
 
 async function generateContent({
   provider, model, systemPrompt, prompt, history = [], webSearchEnabled = false, imageGen,
+  mediaParts = [], providerRouting,
 }: GenerateContentOptions): Promise<GenerateContentResult> {
   const now = new Date();
   const nowUTC = formatUtcTimestamp(now);
@@ -268,10 +281,16 @@ ${systemPrompt || ''}
     const useTools = toolDefs.length > 0;
     const toolNote = searchToolNote + imageGenNote;
 
+    // With media the current turn becomes a content-part array; the base64
+    // parts live only in this request body and are dropped when it completes.
+    const userText = formatMessageWithTimestamp(prompt, now);
+    const userContent = mediaParts.length > 0
+      ? [{ type: 'text', text: userText }, ...mediaParts]
+      : userText;
     const requestMessages: any[] = [
       { role: 'system' as const, content: systemPrompt + toolNote },
       ...historyMessages,
-      { role: 'user' as const, content: formatMessageWithTimestamp(prompt, now) },
+      { role: 'user' as const, content: userContent },
     ];
 
     const toolCalls: ToolCallRecord[] = [];
@@ -286,6 +305,9 @@ ${systemPrompt || ''}
         messages: requestMessages,
         max_tokens: 8192,
       };
+      if (providerRouting) {
+        requestBody.provider = providerRouting;
+      }
       if (toolsAvailable && !isLastForcedClose) {
         requestBody.tools = toolDefs;
       } else if (toolsAvailable && isLastForcedClose

--- a/utils/ai.ts
+++ b/utils/ai.ts
@@ -341,8 +341,21 @@ ${systemPrompt || ''}
 
       const actualPromptTokens = completion.usage?.prompt_tokens;
       if (actualPromptTokens && actualPromptTokens > 0) {
+        // Array content (multimodal turns): count the text part, not the media
+        // — otherwise calibration learns an inflated multiplier from media turns.
         const estimated = countTokensOpenRouterMessages(
-          requestMessages.map((m: any) => ({ role: m.role, content: typeof m.content === 'string' ? m.content : '' })),
+          requestMessages.map((m: any) => {
+            let contentText = '';
+            if (typeof m.content === 'string') {
+              contentText = m.content;
+            } else if (Array.isArray(m.content)) {
+              contentText = m.content
+                .filter((p: any) => p?.type === 'text' && typeof p.text === 'string')
+                .map((p: any) => p.text)
+                .join('\n');
+            }
+            return { role: m.role, content: contentText };
+          }),
         );
         recordUsage(model, estimated, actualPromptTokens);
       }

--- a/utils/aiMedia.ts
+++ b/utils/aiMedia.ts
@@ -1,0 +1,215 @@
+import type { Message, Attachment } from 'discord.js';
+import { logError, logWarning } from './log';
+
+/**
+ * Collects image/video/audio attachments from a Discord message (and the
+ * message it replies to) into OpenRouter multimodal content parts.
+ *
+ * Everything is downloaded into memory and sent as base64 data URLs — never
+ * written to disk, never stored in history. Base64 is deliberate: Discord CDN
+ * URLs are signed and expire (~24h), audio has no URL support at all on
+ * OpenRouter, and provider-side URL fetchers are blocked by some hosts.
+ * Peak RAM per request is bounded by TOTAL_MEDIA_BYTES (+33% base64 overhead)
+ * and the concurrency slot below; buffers are garbage-collected when the
+ * generation completes — this is flat data, not a pdfjs-style object graph,
+ * so no subprocess is needed (see pdf.ts for the contrast).
+ */
+
+const FETCH_TIMEOUT_MS = Number(process.env.DISCORD_FETCH_TIMEOUT_MS) || 15_000;
+
+// Per-request caps. Sizes are checked against Discord's attachment metadata
+// BEFORE downloading, so an oversized file never costs a single byte.
+const MAX_IMAGES = 5;
+const MAX_VIDEOS = 1;
+const MAX_AUDIO = 1;
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+const MAX_VIDEO_BYTES = 25 * 1024 * 1024;
+const MAX_AUDIO_BYTES = 15 * 1024 * 1024;
+const TOTAL_MEDIA_BYTES = 30 * 1024 * 1024;
+
+// Only this many messages may hold media buffers at once (download → generate
+// → release). Protects the 1g container limit from concurrent video uploads.
+const MAX_CONCURRENT_MEDIA = 2;
+let activeMediaSlots = 0;
+
+export function tryAcquireMediaSlot(): boolean {
+  if (activeMediaSlots >= MAX_CONCURRENT_MEDIA) return false;
+  activeMediaSlots += 1;
+  return true;
+}
+
+export function releaseMediaSlot(): void {
+  activeMediaSlots = Math.max(0, activeMediaSlots - 1);
+}
+
+export function getActiveMediaSlots(): number {
+  return activeMediaSlots;
+}
+
+// Whitelists. Image list matches what the Xiaomi endpoint actually accepts
+// (its 400 error enumerates bmp/gif/png/jpeg/webp); video/audio lists match
+// OpenRouter's documented formats.
+const IMAGE_TYPES: Record<string, string> = {
+  'image/png': 'image/png',
+  'image/jpeg': 'image/jpeg',
+  'image/jpg': 'image/jpeg',
+  'image/webp': 'image/webp',
+  'image/gif': 'image/gif',
+  'image/bmp': 'image/bmp',
+};
+const VIDEO_TYPES: Record<string, string> = {
+  'video/mp4': 'video/mp4',
+  'video/mpeg': 'video/mpeg',
+  'video/webm': 'video/webm',
+  'video/quicktime': 'video/mov',
+};
+// contentType → OpenRouter input_audio `format` value. Discord voice messages
+// are audio/ogg (opus) — verified accepted as format "ogg".
+const AUDIO_TYPES: Record<string, string> = {
+  'audio/ogg': 'ogg',
+  'audio/opus': 'opus',
+  'audio/mpeg': 'mp3',
+  'audio/mp3': 'mp3',
+  'audio/wav': 'wav',
+  'audio/x-wav': 'wav',
+  'audio/flac': 'flac',
+  'audio/x-flac': 'flac',
+  'audio/aac': 'aac',
+  'audio/mp4': 'm4a',
+  'audio/x-m4a': 'm4a',
+};
+
+type MediaKind = 'image' | 'video' | 'audio';
+
+export interface MediaCollectionResult {
+  /** OpenRouter content parts (image_url / video_url / input_audio). */
+  parts: any[];
+  /** Text placeholders for the stored prompt, e.g. "[attached image: cat.png]". */
+  placeholders: string[];
+  /** User-facing notes about skipped/failed attachments. */
+  notices: string[];
+}
+
+function classify(att: Attachment): { kind: MediaKind; mime: string } | null {
+  const ct = (att.contentType || '').split(';')[0].trim().toLowerCase();
+  if (IMAGE_TYPES[ct]) return { kind: 'image', mime: IMAGE_TYPES[ct] };
+  if (VIDEO_TYPES[ct]) return { kind: 'video', mime: VIDEO_TYPES[ct] };
+  if (AUDIO_TYPES[ct]) return { kind: 'audio', mime: ct };
+  return null;
+}
+
+function fmtMB(bytes: number): string {
+  return `${Math.round(bytes / (1024 * 1024))}MB`;
+}
+
+async function downloadAttachment(att: Attachment, cap: number): Promise<Buffer | null> {
+  try {
+    const res = await fetch(att.url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+    if (!res.ok) {
+      logWarning(`[aiMedia] download failed (${res.status}) for ${att.name}`);
+      return null;
+    }
+    const buf = Buffer.from(await res.arrayBuffer());
+    // Discord metadata said it fit, but never trust that the bytes agree.
+    if (buf.byteLength > cap) {
+      logWarning(`[aiMedia] ${att.name} exceeded cap after download (${buf.byteLength} > ${cap})`);
+      return null;
+    }
+    return buf;
+  } catch (err) {
+    logError(`[aiMedia] download error for ${att.name}:`, err);
+    return null;
+  }
+}
+
+/**
+ * Gathers media from `message` first, then from the replied-to message (so a
+ * "@mi what's in this?" reply to a voice message / image works). Enforces
+ * per-type counts, per-file and total byte budgets; everything over a cap is
+ * skipped with a notice rather than failing the request.
+ */
+export async function collectMediaFromMessage(
+  message: Message,
+  contextMsg: Message | null = null,
+): Promise<MediaCollectionResult> {
+  const parts: any[] = [];
+  const placeholders: string[] = [];
+  const notices: string[] = [];
+
+  const counts: Record<MediaKind, number> = { image: 0, video: 0, audio: 0 };
+  const maxCounts: Record<MediaKind, number> = { image: MAX_IMAGES, video: MAX_VIDEOS, audio: MAX_AUDIO };
+  const byteCaps: Record<MediaKind, number> = {
+    image: MAX_IMAGE_BYTES, video: MAX_VIDEO_BYTES, audio: MAX_AUDIO_BYTES,
+  };
+  let totalBytes = 0;
+  const skippedOverCount: Record<MediaKind, number> = { image: 0, video: 0, audio: 0 };
+  let skippedUnsupported = 0;
+
+  const candidates: { att: Attachment; kind: MediaKind; mime: string; fromReply: boolean }[] = [];
+  const gather = (msg: Message, fromReply: boolean) => {
+    for (const att of msg.attachments.values()) {
+      const ct = (att.contentType || '').split(';')[0].trim().toLowerCase();
+      if (ct === 'application/pdf' || (att.name || '').toLowerCase().endsWith('.pdf')) continue; // pdf.ts owns these
+      const cls = classify(att);
+      if (!cls) {
+        skippedUnsupported += 1;
+        continue;
+      }
+      candidates.push({
+        att, kind: cls.kind, mime: cls.mime, fromReply,
+      });
+    }
+  };
+  gather(message, false);
+  if (contextMsg) gather(contextMsg, true);
+
+  if (candidates.length === 0 && skippedUnsupported === 0) {
+    return { parts, placeholders, notices };
+  }
+
+  for (const { att, kind, mime } of candidates) {
+    if (counts[kind] >= maxCounts[kind]) {
+      skippedOverCount[kind] += 1;
+      continue;
+    }
+    const cap = byteCaps[kind];
+    if (att.size > cap) {
+      notices.push(`⚠ Skipped **${att.name}** — ${kind}s are capped at ${fmtMB(cap)} (yours is ${fmtMB(att.size)}).`);
+      continue;
+    }
+    if (totalBytes + att.size > TOTAL_MEDIA_BYTES) {
+      notices.push(`⚠ Skipped **${att.name}** — total media budget of ${fmtMB(TOTAL_MEDIA_BYTES)} per request reached.`);
+      continue;
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    const buf = await downloadAttachment(att, cap);
+    if (!buf) {
+      notices.push(`⚠ Couldn't download **${att.name}** — continuing without it.`);
+      continue;
+    }
+    totalBytes += buf.byteLength;
+    counts[kind] += 1;
+
+    const b64 = buf.toString('base64');
+    if (kind === 'image') {
+      parts.push({ type: 'image_url', image_url: { url: `data:${mime};base64,${b64}` } });
+    } else if (kind === 'video') {
+      parts.push({ type: 'video_url', video_url: { url: `data:${mime};base64,${b64}` } });
+    } else {
+      parts.push({ type: 'input_audio', input_audio: { data: b64, format: AUDIO_TYPES[mime] || 'mp3' } });
+    }
+    placeholders.push(`[attached ${kind}: ${att.name || 'file'}]`);
+  }
+
+  for (const kind of Object.keys(skippedOverCount) as MediaKind[]) {
+    if (skippedOverCount[kind] > 0) {
+      notices.push(`⚠ Only the first ${maxCounts[kind]} ${kind}${maxCounts[kind] === 1 ? '' : 's'} per request ${maxCounts[kind] === 1 ? 'is' : 'are'} processed — skipped ${skippedOverCount[kind]} extra.`);
+    }
+  }
+  if (skippedUnsupported > 0 && parts.length === 0 && candidates.length === 0) {
+    notices.push('⚠ Attachment type not supported — I can read images (png/jpg/webp/gif/bmp), video (mp4/webm/mov) and audio (ogg/mp3/wav/flac/m4a).');
+  }
+
+  return { parts, placeholders, notices };
+}

--- a/utils/aiMedia.ts
+++ b/utils/aiMedia.ts
@@ -61,7 +61,9 @@ const VIDEO_TYPES: Record<string, string> = {
   'video/mp4': 'video/mp4',
   'video/mpeg': 'video/mpeg',
   'video/webm': 'video/webm',
-  'video/quicktime': 'video/mov',
+  // OpenRouter's docs list "video/mov" as a supported *format*, but the data
+  // URL must carry the real MIME type for providers that validate it.
+  'video/quicktime': 'video/quicktime',
 };
 // contentType → OpenRouter input_audio `format` value. Discord voice messages
 // are audio/ogg (opus) — verified accepted as format "ogg".
@@ -100,6 +102,17 @@ function classify(att: Attachment): { kind: MediaKind; mime: string } | null {
 
 function fmtMB(bytes: number): string {
   return `${Math.round(bytes / (1024 * 1024))}MB`;
+}
+
+/**
+ * Cheap pre-check: does this message (or the replied-to message) carry at
+ * least one attachment collectMediaFromMessage would actually process?
+ * Used by callers to avoid burning a concurrency slot on e.g. a PDF-only
+ * message.
+ */
+export function hasQualifyingMedia(message: Message, contextMsg: Message | null = null): boolean {
+  const check = (msg: Message) => [...msg.attachments.values()].some((att) => classify(att) !== null);
+  return check(message) || (contextMsg ? check(contextMsg) : false);
 }
 
 async function downloadAttachment(att: Attachment, cap: number): Promise<Buffer | null> {
@@ -186,6 +199,12 @@ export async function collectMediaFromMessage(
     const buf = await downloadAttachment(att, cap);
     if (!buf) {
       notices.push(`⚠ Couldn't download **${att.name}** — continuing without it.`);
+      continue;
+    }
+    // Re-check the total budget against real bytes — the pre-download check
+    // used Discord metadata, which the per-file cap already refuses to trust.
+    if (totalBytes + buf.byteLength > TOTAL_MEDIA_BYTES) {
+      notices.push(`⚠ Skipped **${att.name}** — total media budget of ${fmtMB(TOTAL_MEDIA_BYTES)} per request reached.`);
       continue;
     }
     totalBytes += buf.byteLength;

--- a/utils/tokenizer.ts
+++ b/utils/tokenizer.ts
@@ -60,6 +60,9 @@ const CONTEXT_LIMITS: Record<string, number> = {
   'nvidia/nemotron-3-ultra-550b-a55b:free': 1_000_000,
   'deepseek/deepseek-v4-flash': 1_000_000,
   'xiaomi/mimo-v2-flash:nitro': 256_000,
+  // 1M on the pinned Xiaomi endpoint; media (base64 parts) is not counted by
+  // the tokenizer, so leave the standard reserve headroom to absorb it.
+  'xiaomi/mimo-v2.5': 1_000_000,
   // Default for unknown models
   default: 128_000,
 };


### PR DESCRIPTION
## What

Adds a new `@mi` AI persona backed by **xiaomi/mimo-v2.5** (OpenRouter, pinned to the Xiaomi provider) that can natively read Discord attachments: **images, video, and audio — including voice messages referenced via reply**.

- `utils/aiMedia.ts` (new): collects media from the triggering message and the replied-to message, validates type + size against Discord attachment metadata **before** downloading, downloads to memory only, and emits base64 content parts + text placeholders + user-facing skip notices.
- `utils/ai.ts`: `generateContent` accepts `mediaParts` (current user turn becomes an OpenRouter content-part array) and `providerRouting` (provider pin passed into the request body).
- `keywordsBehaviorHandler.ts`: persona-gated media collection, notices ride the existing PDF-notice path, `📎 read N attachments` footnote on success, and a **text-only retry with a ⚠ notice** if the provider rejects the media.
- `aiPersonas.json`: MiMo persona with `provider: { only: ["xiaomi"], allow_fallbacks: false }` — the DigitalOcean fallback endpoint only has 32k context vs Xiaomi's 1M.
- `tokenizer.ts`: 1M context entry for the model.
- `keywords.json`: `@mi` routed to the AI handler.

## Why base64 instead of Discord CDN URLs

Verified against the live endpoint: OpenRouter audio input has **no URL support** (base64 only), Discord CDN URLs are signed and expire ~24h, and the Xiaomi provider's server-side URL fetcher is blocked by some hosts. Base64-in-memory sidesteps all three. Ogg/Opus (Discord voice messages) confirmed accepted with `format: "ogg"`.

## Memory & safety guardrails

The PDF-style subprocess is **not** needed here — no parsing happens bot-side (bytes are moved opaquely: download → base64 → request body → GC). Bounded by:

- Per-request caps: 5 images (10MB each), 1 video (25MB), 1 audio (15MB), 30MB total — oversize files are rejected from metadata without downloading a byte.
- Byte-cap re-verification after download (metadata not trusted).
- 2-slot concurrency semaphore (released in `finally` + outer catch) so parallel media requests stay well under the 1g container limit; excess requests degrade to text-only with a notice.
- Type whitelists per modality (image list matches the provider's own accepted set: bmp/gif/png/jpeg/webp).
- Media is never persisted — `AiHistory` gets `[attached image: name]` placeholders only, so nothing leaks into history replay or token budgets.

## Reviewer notes

- A 10-attachment mixed-type message is handled: caps applied per type, PDFs still flow through the existing `pdf.ts` pipeline, unsupported types skipped with notices.
- Non-media personas (`@ds`, `@gpt`, …) are unchanged — collection is gated on `persona.mediaInput`.
- Tested end-to-end against the live Xiaomi endpoint (image URL/base64, multi-image, wav + ogg/opus audio, video). `bun test` 272 pass, typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for image, video, and audio attachments in supported AI chats, with automatic prompt attachment handling when enabled for the selected persona.
  * Introduced a new **MiMo** persona (trigger added) with tailored behavior and the ability to use attachments.
* **Bug Fixes**
  * Improved attachment reliability by retrying in text-only mode if multimodal generation fails.
  * Enhanced user-facing notices for attachment acceptance, rejections, and load failures.
* **Chores**
  * Updated request routing/token accounting and expanded context limits for the MiMo model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->