### PR TITLE
feat[ai]: /ai view pagination + search; attached-image editing via generate_image

### DIFF
--- a/classes/handlers/keywordsBehaviorHandler.ts
+++ b/classes/handlers/keywordsBehaviorHandler.ts
@@ -118,29 +118,55 @@ const scriptHandlers = {
 
     const { blocks: pdfBlocks, notices: pdfNotices } = await extractPdfsFromMessage(message);
 
-    // Media (image/video/audio) attachments — persona-gated, openrouter-only.
-    // Base64 buffers live in mediaParts for the duration of this generation
+    // Media (image/video/audio) attachments. Two consumers:
+    //  - vision input (mediaParts → the chat model's user turn): persona-gated
+    //    (mediaInput), openrouter-only;
+    //  - image editing (imageEditParts → the generate_image tool as edit
+    //    sources): any persona with imageGen enabled, images only.
+    // Base64 buffers live in these arrays for the duration of this generation
     // and are never persisted; only text placeholders enter the prompt/history.
     let mediaParts: any[] = [];
+    let imageEditParts: any[] = [];
     let mediaPlaceholders: string[] = [];
+    let editOnlyPlaceholders: string[] = [];
     const mediaNotices: string[] = [];
     let mediaSlotHeld = false;
-    if (persona.mediaInput && persona.provider === 'openrouter'
-      && hasQualifyingMedia(message, contextMsg)) {
+    const visionCapable = !!persona.mediaInput && persona.provider === 'openrouter';
+    const imageGenEnabled = hasMemory;
+    const shouldCollectMedia = (visionCapable && hasQualifyingMedia(message, contextMsg))
+      || (imageGenEnabled && hasQualifyingMedia(message, contextMsg, true));
+    if (shouldCollectMedia) {
       if (!tryAcquireMediaSlot()) {
         mediaNotices.push('⚠ Too many attachment-reading requests in flight right now — answering without your attachments. Try again in a moment.');
       } else {
         mediaSlotHeld = true;
         try {
-          const collected = await collectMediaFromMessage(message, contextMsg);
-          mediaParts = collected.parts;
-          mediaPlaceholders = collected.placeholders;
+          // Non-vision personas only ever need the images (for editing).
+          const collected = await collectMediaFromMessage(message, contextMsg, !visionCapable);
+          imageEditParts = collected.parts.filter((p: any) => p?.type === 'image_url');
+          if (visionCapable) {
+            mediaParts = collected.parts;
+            mediaPlaceholders = collected.placeholders;
+          } else {
+            // The chat model can't see these — placeholders tell it the images
+            // exist so it can offer/perform edits via generate_image. Only a
+            // single attached image is editable (tool hard cap), so with
+            // several the placeholders stay plain and the system note tells
+            // the model to refuse edits.
+            editOnlyPlaceholders = imageEditParts.length === 1
+              ? collected.placeholders.map(
+                (p) => `${p} (you cannot view this image, but your generate_image tool can edit it)`,
+              )
+              : collected.placeholders.map((p) => `${p} (you cannot view this image)`);
+          }
           mediaNotices.push(...collected.notices);
         } catch (mediaErr) {
           logError('AiChat: media collection failed, proceeding without attachments:', mediaErr);
           mediaNotices.push('⚠ Couldn\'t process your attachments — answering without them.');
           mediaParts = [];
+          imageEditParts = [];
           mediaPlaceholders = [];
+          editOnlyPlaceholders = [];
         }
       }
     }
@@ -151,7 +177,8 @@ const scriptHandlers = {
         .catch((e) => { logError('Attachment notice reply failed:', e); });
     }
     const pdfPrefix = pdfBlocks.length > 0 ? `${pdfBlocks.join('\n\n')}\n\n` : '';
-    const mediaSuffix = mediaPlaceholders.length > 0 ? `\n${mediaPlaceholders.join('\n')}` : '';
+    const allPlaceholders = [...mediaPlaceholders, ...editOnlyPlaceholders];
+    const mediaSuffix = allPlaceholders.length > 0 ? `\n${allPlaceholders.join('\n')}` : '';
 
     let prompt = '';
 
@@ -221,9 +248,10 @@ const scriptHandlers = {
         mediaParts: withMedia ? mediaParts : [],
         providerRouting: persona.providerRouting,
         // Image generation is Discord-only (delivery rides this webhook); the
-        // rate limit is keyed to the requesting Discord user.
+        // rate limit is keyed to the requesting Discord user. Attached images
+        // ride along as edit sources for the generate_image tool.
         imageGen: hasMemory
-          ? { userId: message.author.id, db: (message.client as any).db }
+          ? { userId: message.author.id, db: (message.client as any).db, imageParts: imageEditParts }
           : undefined,
       });
 
@@ -239,9 +267,10 @@ const scriptHandlers = {
         mediaDropped = true;
         genResult = await generateOnce(false);
       } finally {
-        // Buffers are only referenced by mediaParts; free the slot as soon as
-        // the provider round-trip is over.
+        // Buffers are only referenced by these arrays; free the slot as soon
+        // as the provider round-trip is over.
         mediaParts = [];
+        imageEditParts = [];
         if (mediaSlotHeld) {
           releaseMediaSlot();
           mediaSlotHeld = false;

--- a/classes/handlers/keywordsBehaviorHandler.ts
+++ b/classes/handlers/keywordsBehaviorHandler.ts
@@ -4,7 +4,7 @@ import {
 } from 'discord.js';
 import { log, logError } from '../../utils/log';
 import { resolvePersona, generateContent, generateTitleForHistory } from '../../utils/ai';
-import { IMAGE_GEN_TOOL_NAME } from '../../utils/imageGen';
+import { IMAGE_GEN_TOOL_NAME, IMAGE_EDIT_MAX_SOURCES } from '../../utils/imageGen';
 import { trimHistoryToFit } from '../../utils/tokenizer';
 import { extractPdfsFromMessage } from '../../utils/pdf';
 import {
@@ -153,7 +153,7 @@ const scriptHandlers = {
             // single attached image is editable (tool hard cap), so with
             // several the placeholders stay plain and the system note tells
             // the model to refuse edits.
-            editOnlyPlaceholders = imageEditParts.length === 1
+            editOnlyPlaceholders = imageEditParts.length <= IMAGE_EDIT_MAX_SOURCES
               ? collected.placeholders.map(
                 (p) => `${p} (you cannot view this image, but your generate_image tool can edit it)`,
               )

--- a/commands/ai_view.ts
+++ b/commands/ai_view.ts
@@ -1,62 +1,143 @@
-import { EmbedBuilder } from 'discord.js';
+import * as Discord from 'discord.js';
 import { Command } from './classes/Command';
 import { logError } from '../utils/log';
-import { getPersonaInvokeLabel } from '../utils/ai';
+import { getPersonaInvokeLabel, getPersonaModelName } from '../utils/ai';
+
+const SESSIONS_PER_PAGE = 10;
+const PAGINATION_TIMEOUT_MS = 60000;
+const MAX_SEARCH_CHARS = 100;
 
 class AiView extends Command {
   constructor(client: any) {
-    super(client, 'view', 'View all your AI chat sessions', [], {
+    super(client, 'view', 'View all your AI chat sessions', [
+      {
+        name: 'search',
+        description: 'Filter sessions by title, AI name/trigger, or model (e.g. "mimo", "deepseek")',
+        type: 3,
+        required: false,
+      },
+    ], {
       isSubcommandOf: 'ai',
       blame: 'xei',
     });
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  buildEmbed(sessions: any[], page: number, maxPage: number, search: string): Discord.EmbedBuilder {
+    const start = page * SESSIONS_PER_PAGE;
+    const rows = sessions.slice(start, start + SESSIONS_PER_PAGE).map((s: any) => {
+      const status = s.active === 1 ? '🟢 Active' : '⚫ Inactive';
+      const messageCount = Number.isFinite(Number(s.messageCount)) ? Number(s.messageCount) : 0;
+      const messageLabel = messageCount === 1 ? 'message' : 'messages';
+      const date = new Date(s.createdAt).toLocaleDateString('en-GB', {
+        year: 'numeric', month: 'short', day: 'numeric',
+      });
+      const ai = getPersonaInvokeLabel(s.personaName);
+      return `**[${s.sessionId}]** ${s.title || s.personaName} · ${status} · ${messageCount} ${messageLabel} · Created ${date} · ${ai}`;
+    });
+
+    const filterNote = search ? ` · Filter: "${search}"` : '';
+    return new Discord.EmbedBuilder()
+      .setColor('#5865F2')
+      .setTitle('🤖 Your AI Chat Sessions')
+      .setDescription(rows.join('\n'))
+      .setFooter({
+        text: `Page ${page + 1}/${maxPage + 1} · ${sessions.length} session${sessions.length === 1 ? '' : 's'}${filterNote}`
+          + ' · Use /ai chatnew, /ai chatswitch, /ai chatdelete, or /ai retitle.',
+      });
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  buildButtons(page: number, maxPage: number, disableAll = false): Discord.ActionRowBuilder<Discord.ButtonBuilder> {
+    return new Discord.ActionRowBuilder<Discord.ButtonBuilder>()
+      .addComponents(
+        new Discord.ButtonBuilder()
+          .setCustomId('prev_page')
+          .setLabel('⬅️ Back')
+          .setStyle(Discord.ButtonStyle.Primary)
+          .setDisabled(disableAll || page === 0),
+        new Discord.ButtonBuilder()
+          .setCustomId('next_page')
+          .setLabel('Next ➡️')
+          .setStyle(Discord.ButtonStyle.Primary)
+          .setDisabled(disableAll || page === maxPage),
+      );
+  }
+
   async run(interaction: any): Promise<void> {
     const userId = interaction.user.id;
+    const search = String(interaction.options.getString('search') || '')
+      .trim().toLowerCase().slice(0, MAX_SEARCH_CHARS);
 
     try {
       // Only Discord-source sessions — web-created (source='web') chats from
       // the /games/ai-slop UI deliberately live in their own world and would
       // be confusing to surface here (they share no memory with the bot).
-      const sessions = await this.client.db.aiChat.getUserDiscordSessions(userId);
+      const allSessions = await this.client.db.aiChat.getUserDiscordSessions(userId);
+
+      // Search matches the session title, persona name, invoke trigger
+      // (e.g. "DS"), configured model id (e.g. "deepseek/deepseek-v4-flash"),
+      // or the numeric session id.
+      const sessions = search
+        ? allSessions.filter((s: any) => [
+          s.title || '',
+          s.personaName || '',
+          getPersonaInvokeLabel(s.personaName),
+          getPersonaModelName(s.personaName),
+          String(s.sessionId),
+        ].join(' ').toLowerCase().includes(search))
+        : allSessions;
 
       if (sessions.length === 0) {
+        const description = allSessions.length === 0
+          ? "You don't have any sessions yet. Mention an AI (e.g. `@grok`) to start one!"
+          : `No sessions match \`${search}\`. Try a persona name (e.g. "mimo"), a model (e.g. "deepseek"), or part of a title.`;
         await interaction.editReply({
           embeds: [
-            new EmbedBuilder()
+            new Discord.EmbedBuilder()
               .setColor('#5865F2')
               .setTitle('🤖 Your AI Chat Sessions')
-              .setDescription("You don't have any sessions yet. Mention an AI (e.g. `@grok`) to start one!"),
+              .setDescription(description),
           ],
         });
         return;
       }
 
-      const displaySessions = sessions.slice(0, 25);
-      const overflow = sessions.length - displaySessions.length;
+      let currentPage = 0;
+      const maxPage = Math.ceil(sessions.length / SESSIONS_PER_PAGE) - 1;
 
-      const rows = displaySessions.map((s: any) => {
-        const status = s.active === 1 ? '🟢 Active' : '⚫ Inactive';
-        const messageCount = Number.isFinite(Number(s.messageCount)) ? Number(s.messageCount) : 0;
-        const messageLabel = messageCount === 1 ? 'message' : 'messages';
-        const date = new Date(s.createdAt).toLocaleDateString('en-GB', {
-          year: 'numeric', month: 'short', day: 'numeric',
-        });
-        const ai = getPersonaInvokeLabel(s.personaName);
-        return `**[${s.sessionId}]** ${s.title || s.personaName} · ${status} · ${messageCount} ${messageLabel} · Created ${date} · ${ai}`;
+      // Single page — no buttons, no collector.
+      if (maxPage === 0) {
+        await interaction.editReply({ embeds: [this.buildEmbed(sessions, 0, 0, search)] });
+        return;
+      }
+
+      const message = await interaction.editReply({
+        embeds: [this.buildEmbed(sessions, currentPage, maxPage, search)],
+        components: [this.buildButtons(currentPage, maxPage)],
       });
 
-      const description = rows.join('\n')
-        + (overflow > 0 ? `\n\n*…and ${overflow} more session(s) not shown.*` : '');
+      const collector = message.createMessageComponentCollector({
+        time: PAGINATION_TIMEOUT_MS,
+        filter: (i: any) => i.user.id === userId,
+      });
 
-      await interaction.editReply({
-        embeds: [
-          new EmbedBuilder()
-            .setColor('#5865F2')
-            .setTitle('🤖 Your AI Chat Sessions')
-            .setDescription(description)
-            .setFooter({ text: 'Use /ai chatnew, /ai chatswitch, /ai chatdelete, or /ai retitle.' }),
-        ],
+      collector.on('collect', async (i: any) => {
+        if (i.customId === 'prev_page' && currentPage > 0) {
+          currentPage -= 1;
+        } else if (i.customId === 'next_page' && currentPage < maxPage) {
+          currentPage += 1;
+        }
+        await i.update({
+          embeds: [this.buildEmbed(sessions, currentPage, maxPage, search)],
+          components: [this.buildButtons(currentPage, maxPage)],
+        });
+      });
+
+      collector.on('end', async () => {
+        await message.edit({
+          components: [this.buildButtons(currentPage, maxPage, true)],
+        }).catch(() => { /* message may have been deleted */ });
       });
     } catch (err) {
       logError('AiView error:', err);

--- a/utils/ai.ts
+++ b/utils/ai.ts
@@ -8,6 +8,7 @@ import { listSearchTools, listSearchToolsGemini, callSearchTool } from './mcp';
 import {
   IMAGE_GEN_TOOL_NAME,
   IMAGE_GEN_DAILY_LIMIT,
+  IMAGE_EDIT_MAX_SOURCES,
   IMAGE_GEN_FALLBACK_MODEL,
   imageGenToolDef,
   imageGenGeminiDecl,
@@ -66,10 +67,10 @@ function buildImageGenNote(imageGen?: ImageGenContext): string {
   if (!imageGen) return '';
   let note = `\n\nYou have a ${IMAGE_GEN_TOOL_NAME} tool. Call it ONLY when the user explicitly asks you to generate, create, draw, or edit an image. The image is attached to your reply automatically — never claim you cannot generate images, and never invent image links. Limit: ${IMAGE_GEN_DAILY_LIMIT} generations per user per 24 hours.`;
   const attachedCount = imageGen.imageParts?.length ?? 0;
-  if (attachedCount === 1) {
-    note += ` The user's current message has 1 attached image; if they ask you to edit, modify, restyle, or transform it, call ${IMAGE_GEN_TOOL_NAME} with use_attached_images=true and a prompt describing the desired change.`;
-  } else if (attachedCount > 1) {
-    note += ` The user's current message has ${attachedCount} attached images, but ${IMAGE_GEN_TOOL_NAME} accepts only ONE attached image per edit. If the user asks for an edit, do NOT call the tool — politely tell them to send a message with exactly one image attached.`;
+  if (attachedCount > 0 && attachedCount <= IMAGE_EDIT_MAX_SOURCES) {
+    note += ` The user's current message has ${attachedCount} attached image${attachedCount === 1 ? '' : 's'}; if they ask you to edit, modify, restyle, or transform ${attachedCount === 1 ? 'it' : 'them'}, call ${IMAGE_GEN_TOOL_NAME} with use_attached_images=true and a prompt describing the desired change.`;
+  } else if (attachedCount > IMAGE_EDIT_MAX_SOURCES) {
+    note += ` The user's current message has ${attachedCount} attached images, but ${IMAGE_GEN_TOOL_NAME} accepts only ${IMAGE_EDIT_MAX_SOURCES} attached image${IMAGE_EDIT_MAX_SOURCES === 1 ? '' : 's'} per edit. If the user asks for an edit, do NOT call the tool — politely tell them to send a message with at most ${IMAGE_EDIT_MAX_SOURCES} image${IMAGE_EDIT_MAX_SOURCES === 1 ? '' : 's'} attached.`;
   }
   return note;
 }

--- a/utils/ai.ts
+++ b/utils/ai.ts
@@ -60,6 +60,20 @@ export interface ToolCallRecord {
 const MAX_TOOL_ITERATIONS = 5;
 const MAX_TITLE_CHARS = 80;
 
+/** System-prompt note advertising the generate_image tool (and, when the
+ * triggering message carried images, the attached-image edit path). */
+function buildImageGenNote(imageGen?: ImageGenContext): string {
+  if (!imageGen) return '';
+  let note = `\n\nYou have a ${IMAGE_GEN_TOOL_NAME} tool. Call it ONLY when the user explicitly asks you to generate, create, draw, or edit an image. The image is attached to your reply automatically — never claim you cannot generate images, and never invent image links. Limit: ${IMAGE_GEN_DAILY_LIMIT} generations per user per 24 hours.`;
+  const attachedCount = imageGen.imageParts?.length ?? 0;
+  if (attachedCount === 1) {
+    note += ` The user's current message has 1 attached image; if they ask you to edit, modify, restyle, or transform it, call ${IMAGE_GEN_TOOL_NAME} with use_attached_images=true and a prompt describing the desired change.`;
+  } else if (attachedCount > 1) {
+    note += ` The user's current message has ${attachedCount} attached images, but ${IMAGE_GEN_TOOL_NAME} accepts only ONE attached image per edit. If the user asks for an edit, do NOT call the tool — politely tell them to send a message with exactly one image attached.`;
+  }
+  return note;
+}
+
 /**
  * Some open models (Qwen/Hermes/DeepSeek lineage) emit tool calls as plain text
  * — e.g. `<tool_call><function=web_search><parameter=query>…` — instead of via the
@@ -217,6 +231,13 @@ function getPersonaInvokeLabel(personaName: string): string {
   return String(trigger).replace(/^@/, '').toUpperCase();
 }
 
+/** Model id configured for a persona (empty string when the persona is unknown). */
+function getPersonaModelName(personaName: string): string {
+  const personas: Persona[] = personasConfig.personas || [];
+  const found = personas.find((p) => p.name.toLowerCase() === String(personaName).toLowerCase());
+  return found?.model || '';
+}
+
 /**
  * Generates content (text and/or images) from the specified AI provider and model.
  */
@@ -275,9 +296,7 @@ ${systemPrompt || ''}
     if (imageGen) {
       toolDefs = [...toolDefs, imageGenToolDef()];
     }
-    const imageGenNote = imageGen
-      ? `\n\nYou have a ${IMAGE_GEN_TOOL_NAME} tool. Call it ONLY when the user explicitly asks you to generate, create, or draw an image. The image is attached to your reply automatically — never claim you cannot generate images, and never invent image links. Limit: ${IMAGE_GEN_DAILY_LIMIT} generations per user per 24 hours.`
-      : '';
+    const imageGenNote = buildImageGenNote(imageGen);
     const useTools = toolDefs.length > 0;
     const toolNote = searchToolNote + imageGenNote;
 
@@ -461,9 +480,7 @@ ${systemPrompt || ''}
       if (geminiTools.length === 0) geminiTools = [{ functionDeclarations: [] }];
       geminiTools[0].functionDeclarations.push(imageGenGeminiDecl());
     }
-    const imageGenNote = imageGen && !isImageModel
-      ? `\n\nYou have a ${IMAGE_GEN_TOOL_NAME} tool. Call it ONLY when the user explicitly asks you to generate, create, or draw an image. The image is attached to your reply automatically — never claim you cannot generate images, and never invent image links. Limit: ${IMAGE_GEN_DAILY_LIMIT} generations per user per 24 hours.`
-      : '';
+    const imageGenNote = !isImageModel ? buildImageGenNote(imageGen) : '';
     const useTools = geminiTools.length > 0;
     const toolNote = searchToolNote + imageGenNote;
 
@@ -783,4 +800,5 @@ export {
   getOpenRouterClient,
   getPersonaByName,
   getPersonaInvokeLabel,
+  getPersonaModelName,
 };

--- a/utils/aiMedia.ts
+++ b/utils/aiMedia.ts
@@ -108,10 +108,18 @@ function fmtMB(bytes: number): string {
  * Cheap pre-check: does this message (or the replied-to message) carry at
  * least one attachment collectMediaFromMessage would actually process?
  * Used by callers to avoid burning a concurrency slot on e.g. a PDF-only
- * message.
+ * message. With `imagesOnly`, only image attachments qualify (the imageGen
+ * edit-source path — video/audio are irrelevant there).
  */
-export function hasQualifyingMedia(message: Message, contextMsg: Message | null = null): boolean {
-  const check = (msg: Message) => [...msg.attachments.values()].some((att) => classify(att) !== null);
+export function hasQualifyingMedia(
+  message: Message,
+  contextMsg: Message | null = null,
+  imagesOnly = false,
+): boolean {
+  const check = (msg: Message) => [...msg.attachments.values()].some((att) => {
+    const cls = classify(att);
+    return cls !== null && (!imagesOnly || cls.kind === 'image');
+  });
   return check(message) || (contextMsg ? check(contextMsg) : false);
 }
 
@@ -139,11 +147,14 @@ async function downloadAttachment(att: Attachment, cap: number): Promise<Buffer 
  * Gathers media from `message` first, then from the replied-to message (so a
  * "@mi what's in this?" reply to a voice message / image works). Enforces
  * per-type counts, per-file and total byte budgets; everything over a cap is
- * skipped with a notice rather than failing the request.
+ * skipped with a notice rather than failing the request. With `imagesOnly`,
+ * video/audio attachments are silently ignored (imageGen edit-source path for
+ * personas whose chat model has no media input).
  */
 export async function collectMediaFromMessage(
   message: Message,
   contextMsg: Message | null = null,
+  imagesOnly = false,
 ): Promise<MediaCollectionResult> {
   const parts: any[] = [];
   const placeholders: string[] = [];
@@ -168,6 +179,8 @@ export async function collectMediaFromMessage(
         skippedUnsupported += 1;
         continue;
       }
+      // imagesOnly: non-image media simply isn't relevant, not "unsupported".
+      if (imagesOnly && cls.kind !== 'image') continue;
       candidates.push({
         att, kind: cls.kind, mime: cls.mime, fromReply,
       });
@@ -226,7 +239,7 @@ export async function collectMediaFromMessage(
       notices.push(`⚠ Only the first ${maxCounts[kind]} ${kind}${maxCounts[kind] === 1 ? '' : 's'} per request ${maxCounts[kind] === 1 ? 'is' : 'are'} processed — skipped ${skippedOverCount[kind]} extra.`);
     }
   }
-  if (skippedUnsupported > 0 && parts.length === 0 && candidates.length === 0) {
+  if (!imagesOnly && skippedUnsupported > 0 && parts.length === 0 && candidates.length === 0) {
     notices.push('⚠ Attachment type not supported — I can read images (png/jpg/webp/gif/bmp), video (mp4/webm/mov) and audio (ogg/mp3/wav/flac/m4a).');
   }
 

--- a/utils/imageGen.ts
+++ b/utils/imageGen.ts
@@ -3,6 +3,10 @@ import { log, logError } from './log';
 
 export const IMAGE_GEN_TOOL_NAME = 'generate_image';
 export const IMAGE_GEN_DAILY_LIMIT = 5;
+/** Hard cap on attached-image edit sources per tool call — guards against
+ * bursty spending (N images × N tool iterations) and matches the Imgen
+ * model's single-composite output anyway. */
+export const IMAGE_EDIT_MAX_SOURCES = 1;
 export const IMAGE_GEN_FALLBACK_MODEL = 'google/gemini-3.1-flash-lite-image';
 
 const IMAGE_GEN_TIMEOUT_MS = 60_000;
@@ -10,16 +14,28 @@ const MAX_PROMPT_CHARS = 2_000;
 // Discord upload cap on non-boosted servers.
 const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
 
-const TOOL_DESCRIPTION = 'Generate an image from a text prompt. Use ONLY when the user explicitly asks you to '
-  + 'generate, create, or draw an image/picture — never for ordinary questions. The generated image is attached '
-  + 'to your reply automatically; do not claim you cannot generate images, and do not write links or placeholders '
-  + `for it. Users are limited to ${IMAGE_GEN_DAILY_LIMIT} generations per 24 hours.`;
+const TOOL_DESCRIPTION = 'Generate an image from a text prompt, or edit the single image the user attached. Use ONLY '
+  + 'when the user explicitly asks you to generate, create, draw, or edit an image/picture — never for ordinary '
+  + 'questions. The generated image is attached to your reply automatically; do not claim you cannot generate '
+  + 'images, and do not write links or placeholders for it. '
+  + `Users are limited to ${IMAGE_GEN_DAILY_LIMIT} generations per 24 hours.`;
+
+const USE_ATTACHED_DESCRIPTION = 'Set to true to use the image attached to the user\'s current message as the '
+  + 'base for an edit/transformation (the prompt then describes the desired change). Only valid when the current '
+  + 'message has EXACTLY ONE image attachment — calls are rejected when the message has none or several; in the '
+  + 'multi-image case, refuse the edit and ask the user to attach a single image.';
 
 export interface ImageGenContext {
   /** Discord user id of the requester (rate-limit key). */
   userId: string;
   /** Shared Database instance (db.imageGen). */
   db: any;
+  /**
+   * OpenRouter image_url content parts from the user's attached images
+   * (base64 data URLs, see utils/aiMedia.ts). When present, the model may set
+   * use_attached_images to edit them instead of generating from scratch.
+   */
+  imageParts?: any[];
 }
 
 export interface ImageGenAttachment {
@@ -47,7 +63,11 @@ export function imageGenToolDef(): ImageGenToolDef {
         properties: {
           prompt: {
             type: 'string',
-            description: 'A detailed description of the image to generate.',
+            description: 'A detailed description of the image to generate, or of the edit to apply.',
+          },
+          use_attached_images: {
+            type: 'boolean',
+            description: USE_ATTACHED_DESCRIPTION,
           },
         },
         required: ['prompt'],
@@ -65,7 +85,11 @@ export function imageGenGeminiDecl(): { name: string; description: string; param
       properties: {
         prompt: {
           type: 'STRING',
-          description: 'A detailed description of the image to generate.',
+          description: 'A detailed description of the image to generate, or of the edit to apply.',
+        },
+        use_attached_images: {
+          type: 'BOOLEAN',
+          description: USE_ATTACHED_DESCRIPTION,
         },
       },
       required: ['prompt'],
@@ -100,6 +124,27 @@ export async function runImageGeneration(opts: {
   }
   const prompt = rawPrompt.trim().slice(0, MAX_PROMPT_CHARS);
 
+  // Attached-image editing: only honored when the caller actually collected
+  // image parts from the triggering message. Checked before quota reservation
+  // so a bad call doesn't burn a generation slot.
+  const useAttached = opts.args?.use_attached_images === true;
+  const imageParts = Array.isArray(ctx.imageParts) ? ctx.imageParts : [];
+  if (useAttached && imageParts.length === 0) {
+    return {
+      ok: false,
+      error: 'Error: the current message has no usable attached images to edit. Generate from the prompt alone, '
+        + 'or tell the user to attach the image to the message that asks for the edit.',
+    };
+  }
+  if (useAttached && imageParts.length > IMAGE_EDIT_MAX_SOURCES) {
+    return {
+      ok: false,
+      error: `Error: only ${IMAGE_EDIT_MAX_SOURCES} attached image can be edited per request, but the user attached `
+        + `${imageParts.length}. Do NOT retry — refuse the edit and tell the user to send a message with exactly one `
+        + 'image attached.',
+    };
+  }
+
   // Atomically count + insert the quota row (fail closed: DB errors block generation).
   let reservationId: number | null = null;
   try {
@@ -123,14 +168,20 @@ export async function runImageGeneration(opts: {
     });
   };
 
-  log(`[imagegen] user ${ctx.userId} generating: ${prompt.slice(0, 120)}`);
+  log(`[imagegen] user ${ctx.userId} generating${useAttached ? ` (editing ${imageParts.length} attached image${imageParts.length === 1 ? '' : 's'})` : ''}: ${prompt.slice(0, 120)}`);
+
+  // For edits the request carries the source images as multimodal content
+  // parts alongside the instruction text (base64 data URLs, never persisted).
+  const userContent = useAttached
+    ? [{ type: 'text', text: prompt }, ...imageParts]
+    : prompt;
 
   let dataUrl = '';
   try {
     const completion: any = await withTimeout(
       openrouter.chat.completions.create({
         model,
-        messages: [{ role: 'user', content: prompt }],
+        messages: [{ role: 'user', content: userContent }],
         modalities,
       } as any),
       IMAGE_GEN_TIMEOUT_MS,
@@ -160,7 +211,8 @@ export async function runImageGeneration(opts: {
   return {
     ok: true,
     attachment: { attachment: buffer, name: `imgen-${Date.now()}.${ext}` },
-    resultText: `Image generated successfully from prompt "${prompt.slice(0, 200)}". It is attached to your reply `
-      + 'automatically — do not write a link, markdown image, or placeholder for it; just describe it briefly.',
+    resultText: `Image ${useAttached ? 'edited' : 'generated'} successfully from prompt "${prompt.slice(0, 200)}". `
+      + 'It is attached to your reply automatically — do not write a link, markdown image, or placeholder for it; '
+      + 'just describe it briefly.',
   };
 }

--- a/utils/imageGen.ts
+++ b/utils/imageGen.ts
@@ -22,8 +22,8 @@ const TOOL_DESCRIPTION = 'Generate an image from a text prompt, or edit the sing
 
 const USE_ATTACHED_DESCRIPTION = 'Set to true to use the image attached to the user\'s current message as the '
   + 'base for an edit/transformation (the prompt then describes the desired change). Only valid when the current '
-  + 'message has EXACTLY ONE image attachment — calls are rejected when the message has none or several; in the '
-  + 'multi-image case, refuse the edit and ask the user to attach a single image.';
+  + `message has EXACTLY ${IMAGE_EDIT_MAX_SOURCES} image attachment(s) — calls are rejected when the message has `
+  + 'none or more than that; in the multi-image case, refuse the edit and ask the user to attach a single image.';
 
 export interface ImageGenContext {
   /** Discord user id of the requester (rate-limit key). */


### PR DESCRIPTION
Closes #201, closes #202.

## What changed

### `/ai view` pagination + search (#202)
- Button pagination in the `leaderboardMixin` style: 10 sessions/page, prev/next buttons, 60s collector (disabled on expiry), single-page results skip buttons entirely. Collector is filtered to the invoking user since the reply is public.
- New optional `search` param filters sessions by title, persona name, invoke trigger (e.g. `DS`), configured model id (e.g. `deepseek/deepseek-v4-flash`), or numeric session id. Backed by a new `getPersonaModelName()` helper in `utils/ai.ts`.

### Attached-image editing via `generate_image` (#201)
- `ImageGenContext` gains `imageParts`; the `generate_image` tool gains a `use_attached_images` boolean. When set, the user's attached image is sent to the Imgen model (`google/gemini-3.1-flash-lite-image`) alongside the edit prompt as a base64 content part — never persisted to history.
- Edit-source collection runs for **any** imageGen-enabled persona (Deepseek, Grok, …), not just `mediaInput` ones; vision input to the chat model stays gated to `mediaInput` personas exactly as before. Non-vision personas get a prompt placeholder telling them the image exists and is editable.
- `collectMediaFromMessage`/`hasQualifyingMedia` gain an `imagesOnly` mode so non-vision personas never download video/audio.
- **Hard cap: ONE edit source per tool call** (`IMAGE_EDIT_MAX_SOURCES`). Multi-image calls are rejected locally — before quota reservation, before any API call — so bursty multi-edit requests cost zero generations. The system note tells models with >1 attached image to refuse edits up front; the tool description/param reinforce it.
- Bad calls (`use_attached_images` with no images) also fail before quota reservation. Edits share the existing 5/24h quota; same media byte caps and concurrency slots apply.

## Live validation (real OpenRouter runs)
- `google/gemini-3.1-flash-lite-image` accepts image input: red square + white marker → correct blue-background edit, marker preserved (verified visually).
- Deepseek (non-vision, placeholder-only) calls the tool with `use_attached_images: true` and relays the user's edit wording; MiMo (vision) does the same with a richer prompt since it sees the source.
- With 2 attached images, both models refuse without calling the tool and ask the user to send one image per message; the tool-level rejection was verified to never touch the quota reservation.
- Multi-image input to the Imgen model returns a single composite image, matching the existing `images[0]` handling.

## Reviewer notes
- Edit sources are ephemeral: follow-up "now make it green" without re-attaching gets a clean tool error telling the model to ask for the image again.
- An image in the message plus one in the replied-to message counts as 2 → denied by design.
- `typecheck`, eslint, and all 272 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The AI session viewer now supports searching, pagination, and richer session details for easier browsing.
  * Image generation can now edit a single attached image when supported.

* **Bug Fixes**
  * Improved media handling so image-only requests ignore non-image attachments more reliably.
  * Better response handling for mixed media requests, with clearer behavior when attachments can’t be used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->