### PR TITLE
feat: implement daily and weekly token-based AI rate limiting

### DIFF
--- a/classes/handlers/keywordsBehaviorHandler.ts
+++ b/classes/handlers/keywordsBehaviorHandler.ts
@@ -3,7 +3,13 @@ import {
   type TextChannel,
 } from 'discord.js';
 import { log, logError } from '../../utils/log';
-import { resolvePersona, generateContent, generateTitleForHistory } from '../../utils/ai';
+import {
+  resolvePersona,
+  generateContent,
+  generateTitleForHistory,
+  DAILY_LIMIT,
+  WEEKLY_LIMIT,
+} from '../../utils/ai';
 import { IMAGE_GEN_TOOL_NAME, IMAGE_EDIT_MAX_SOURCES } from '../../utils/imageGen';
 import { MUSIC_GEN_TOOL_NAME, MUSIC_GUIDE_TOOL_NAME } from '../../utils/musicGen';
 import { trimHistoryToFit } from '../../utils/tokenizer';
@@ -240,6 +246,8 @@ const scriptHandlers = {
       let webhook = webhooks.find((wh: any) => wh.name === WEBHOOK_NAME && wh.token);
 
       const generateOnce = (withMedia: boolean) => generateContent({
+        db: (message.client as any).db,
+        userId: message.author.id,
         provider: persona.provider,
         model: persona.model,
         systemPrompt: persona.systemPrompt ?? '',
@@ -463,10 +471,25 @@ const scriptHandlers = {
           logError('AiChat: Failed to save history:', saveErr);
         }
       }
-    } catch (err) {
+    } catch (err: any) {
       if (mediaSlotHeld) {
         releaseMediaSlot();
         mediaSlotHeld = false;
+      }
+      if (err?.message === 'RATE_LIMIT_EXCEEDED') {
+        const db = (message.client as any).db;
+        const dailyUsage = await db.aiUsage.getDailyUsage(message.author.id);
+        const weeklyUsage = await db.aiUsage.getWeeklyUsage(message.author.id);
+        const reachedDaily = dailyUsage >= DAILY_LIMIT;
+
+        const limitLabel = reachedDaily ? 'Daily' : 'Weekly';
+        const usageVal = reachedDaily ? dailyUsage : weeklyUsage;
+        const limitVal = reachedDaily ? DAILY_LIMIT : WEEKLY_LIMIT;
+
+        await message.reply(
+          `⚠️ **${limitLabel} AI Rate Limit Reached**\nYou have consumed **${usageVal.toLocaleString()}** / **${limitVal.toLocaleString()}** tokens in the last ${reachedDaily ? '24 hours' : '7 days'}. Please wait for your token pool to cool down.`,
+        );
+        return;
       }
       logError('AI unified handler error', err);
       await message.reply(

--- a/classes/handlers/keywordsBehaviorHandler.ts
+++ b/classes/handlers/keywordsBehaviorHandler.ts
@@ -7,9 +7,8 @@ import {
   resolvePersona,
   generateContent,
   generateTitleForHistory,
-  DAILY_LIMIT,
-  WEEKLY_LIMIT,
 } from '../../utils/ai';
+import { getRateLimitErrorMessage } from '../../utils/discordRateLimit';
 import { IMAGE_GEN_TOOL_NAME, IMAGE_EDIT_MAX_SOURCES } from '../../utils/imageGen';
 import { MUSIC_GEN_TOOL_NAME, MUSIC_GUIDE_TOOL_NAME } from '../../utils/musicGen';
 import { trimHistoryToFit } from '../../utils/tokenizer';
@@ -273,7 +272,8 @@ const scriptHandlers = {
       let mediaDropped = false;
       try {
         genResult = await generateOnce(mediaParts.length > 0);
-      } catch (genErr) {
+      } catch (genErr: any) {
+        if (genErr?.message === 'RATE_LIMIT_EXCEEDED') throw genErr;
         // A provider rejecting the media (bad codec, too long, …) shouldn't eat
         // the whole reply — drop attachments and answer text-only.
         if (mediaParts.length === 0) throw genErr;
@@ -478,17 +478,8 @@ const scriptHandlers = {
       }
       if (err?.message === 'RATE_LIMIT_EXCEEDED') {
         const db = (message.client as any).db;
-        const dailyUsage = await db.aiUsage.getDailyUsage(message.author.id);
-        const weeklyUsage = await db.aiUsage.getWeeklyUsage(message.author.id);
-        const reachedDaily = dailyUsage >= DAILY_LIMIT;
-
-        const limitLabel = reachedDaily ? 'Daily' : 'Weekly';
-        const usageVal = reachedDaily ? dailyUsage : weeklyUsage;
-        const limitVal = reachedDaily ? DAILY_LIMIT : WEEKLY_LIMIT;
-
-        await message.reply(
-          `⚠️ **${limitLabel} AI Rate Limit Reached**\nYou have consumed **${usageVal.toLocaleString()}** / **${limitVal.toLocaleString()}** tokens in the last ${reachedDaily ? '24 hours' : '7 days'}. Please wait for your token pool to cool down.`,
-        );
+        const content = await getRateLimitErrorMessage(message.author.id, db);
+        await message.reply(content);
         return;
       }
       logError('AI unified handler error', err);

--- a/commands/ai_usage.ts
+++ b/commands/ai_usage.ts
@@ -15,13 +15,12 @@ class AiUsageSubcommand extends Command {
   constructor(client: any) {
     super(client, 'usage', 'View your AI token usage and limits', [], {
       isSubcommandOf: 'ai',
+      ephemeral: true,
       blame: 'xei',
     });
   }
 
   async run(interaction: Discord.ChatInputCommandInteraction) {
-    await interaction.deferReply({ ephemeral: true });
-
     try {
       const userId = interaction.user.id;
       const [dailyUsage, weeklyUsage, status] = await Promise.all([

--- a/commands/ai_usage.ts
+++ b/commands/ai_usage.ts
@@ -1,0 +1,67 @@
+import * as Discord from 'discord.js';
+import { Command } from './classes/Command';
+import { DAILY_LIMIT, WEEKLY_LIMIT } from '../utils/ai';
+
+function makeProgressBar(value: number, total: number, size = 15): string {
+  const percentage = Math.min(Math.max(value / total, 0), 1);
+  const filledLength = Math.round(percentage * size);
+  const emptyLength = size - filledLength;
+  const bar = '█'.repeat(filledLength) + '░'.repeat(emptyLength);
+  const pctText = Math.round(percentage * 100);
+  return `\`[${bar}]\` **${pctText}%**`;
+}
+
+class AiUsageSubcommand extends Command {
+  constructor(client: any) {
+    super(client, 'usage', 'View your AI token usage and limits', [], {
+      isSubcommandOf: 'ai',
+      blame: 'xei',
+    });
+  }
+
+  async run(interaction: Discord.ChatInputCommandInteraction) {
+    await interaction.deferReply({ ephemeral: true });
+
+    try {
+      const userId = interaction.user.id;
+      const [dailyUsage, weeklyUsage, status] = await Promise.all([
+        this.client.db.aiUsage.getDailyUsage(userId),
+        this.client.db.aiUsage.getWeeklyUsage(userId),
+        this.client.db.aiUsage.checkRateLimit(userId),
+      ]);
+
+      const dailyBar = makeProgressBar(dailyUsage, DAILY_LIMIT);
+      const weeklyBar = makeProgressBar(weeklyUsage, WEEKLY_LIMIT);
+
+      const statusText = status.limited
+        ? `🛑 **Rate Limited** (${status.reason === 'daily' ? 'Daily' : 'Weekly'} limit exceeded)`
+        : '✅ **Active** (Pool is cool)';
+
+      const embed = new Discord.EmbedBuilder()
+        .setColor('#0099ff')
+        .setTitle('🤖 Your AI Token Usage')
+        .setThumbnail(interaction.user.displayAvatarURL({ size: 256 }))
+        .setDescription(`
+**Daily Usage (24h):**
+${dailyUsage.toLocaleString()} / ${DAILY_LIMIT.toLocaleString()} tokens
+${dailyBar}
+
+**Weekly Usage (7d):**
+${weeklyUsage.toLocaleString()} / ${WEEKLY_LIMIT.toLocaleString()} tokens
+${weeklyBar}
+
+**Status:** ${statusText}
+        `)
+        .setFooter({ text: 'Note: AI roleplay cost is shared among active users in the chat.' })
+        .setTimestamp();
+
+      await interaction.editReply({ embeds: [embed] });
+    } catch {
+      await interaction.editReply({
+        content: '❌ Failed to fetch your AI usage stats. Please try again later.',
+      });
+    }
+  }
+}
+
+export default AiUsageSubcommand;

--- a/commands/askSilverwolfAI.ts
+++ b/commands/askSilverwolfAI.ts
@@ -3,6 +3,7 @@ import { Command } from './classes/Command';
 import { log, logError } from '../utils/log';
 import { getPersonaByName, generateContent, generateTitleForHistory } from '../utils/ai';
 import { trimHistoryToFit } from '../utils/tokenizer';
+import { handleRateLimitError } from '../utils/discordRateLimit';
 
 const PERSONA_NAME = 'Silverwolf';
 
@@ -123,19 +124,7 @@ class AskSilverwolfAI extends Command {
       }
     } catch (error: any) {
       if (error?.message === 'RATE_LIMIT_EXCEEDED') {
-        const dailyUsage = await this.client.db.aiUsage.getDailyUsage(interaction.user.id);
-        const weeklyUsage = await this.client.db.aiUsage.getWeeklyUsage(interaction.user.id);
-        const dailyLimit = 250000;
-        const weeklyLimit = 1000000;
-        const reachedDaily = dailyUsage >= dailyLimit;
-
-        const limitLabel = reachedDaily ? 'Daily' : 'Weekly';
-        const usageVal = reachedDaily ? dailyUsage : weeklyUsage;
-        const limitVal = reachedDaily ? dailyLimit : weeklyLimit;
-
-        await interaction.editReply({
-          content: `⚠️ **${limitLabel} AI Rate Limit Reached**\nYou have consumed **${usageVal.toLocaleString()}** / **${limitVal.toLocaleString()}** tokens in the last ${reachedDaily ? '24 hours' : '7 days'}. Please wait for your token pool to cool down.`,
-        });
+        await handleRateLimitError(interaction, this.client.db);
         return;
       }
       logError('Error generating text:', error);

--- a/commands/askSilverwolfAI.ts
+++ b/commands/askSilverwolfAI.ts
@@ -59,6 +59,8 @@ class AskSilverwolfAI extends Command {
       );
 
       const { text, toolCalls } = await generateContent({
+        db: this.client.db,
+        userId: interaction.user.id,
         provider: persona.provider,
         model: persona.model,
         systemPrompt: persona.systemPrompt ?? '',
@@ -119,7 +121,23 @@ class AskSilverwolfAI extends Command {
             logError('AiChat: Failed to generate session title:', titleErr);
           });
       }
-    } catch (error) {
+    } catch (error: any) {
+      if (error?.message === 'RATE_LIMIT_EXCEEDED') {
+        const dailyUsage = await this.client.db.aiUsage.getDailyUsage(interaction.user.id);
+        const weeklyUsage = await this.client.db.aiUsage.getWeeklyUsage(interaction.user.id);
+        const dailyLimit = 250000;
+        const weeklyLimit = 1000000;
+        const reachedDaily = dailyUsage >= dailyLimit;
+
+        const limitLabel = reachedDaily ? 'Daily' : 'Weekly';
+        const usageVal = reachedDaily ? dailyUsage : weeklyUsage;
+        const limitVal = reachedDaily ? dailyLimit : weeklyLimit;
+
+        await interaction.editReply({
+          content: `⚠️ **${limitLabel} AI Rate Limit Reached**\nYou have consumed **${usageVal.toLocaleString()}** / **${limitVal.toLocaleString()}** tokens in the last ${reachedDaily ? '24 hours' : '7 days'}. Please wait for your token pool to cool down.`,
+        });
+        return;
+      }
       logError('Error generating text:', error);
       await interaction.editReply({ content: 'Failed to retrieve response from the AI. Please try again later.' });
     }

--- a/commands/commandgroups/ai.ts
+++ b/commands/commandgroups/ai.ts
@@ -3,7 +3,7 @@ import { CommandGroup } from '../classes/commandGroup';
 export default class Ai extends CommandGroup {
   constructor(client: any) {
     super(client, 'ai', 'Manage your AI chat sessions', [
-      'view', 'chatnew', 'chatswitch', 'chatdelete', 'retitle',
+      'view', 'chatnew', 'chatswitch', 'chatdelete', 'retitle', 'usage',
       'rp-create-char', 'rp-details', 'rp-edit', 'rp-spawn', 'rp-remove', 'rp-setasset',
       'rp-lorebook-add', 'rp-lorebook-remove', 'rp-lorebook-view',
       'rp-persona-add', 'rp-persona-remove',

--- a/commands/profile.ts
+++ b/commands/profile.ts
@@ -107,6 +107,7 @@ class Profile extends Command {
         { label: 'Gambling', value: 'gambling' },
         { label: 'Others', value: 'others' },
         { label: 'Pokemons', value: 'pokemons' },
+        { label: 'AI Usage', value: 'ai_usage' },
       ]);
 
     const actionRow = new Discord.ActionRowBuilder().addComponents(categorySelect);
@@ -152,6 +153,9 @@ class Profile extends Command {
           break;
         case 'pokemons':
           detailsEmbed = this.createPokemonsEmbed(pokemonList, username, avatarURL);
+          break;
+        case 'ai_usage':
+          detailsEmbed = await this.createAiUsageEmbed(interaction.user.id, username, avatarURL);
           break;
         default:
           break;
@@ -317,6 +321,27 @@ ${getNuggieNuggieMultiplierInfo(user.nuggieNuggieMultiplierLevel, INFO_LEVEL.THI
       .setTitle(`${username}'s Profile`)
       .setThumbnail(avatarURL)
       .setDescription(`**Pokemons:** \`\`\`${pokemonList}\`\`\``)
+      .setTimestamp();
+  }
+
+  async createAiUsageEmbed(userId: string, username: string, avatarURL: string) {
+    const dailyUsage = await this.client.db.aiUsage.getDailyUsage(userId);
+    const weeklyUsage = await this.client.db.aiUsage.getWeeklyUsage(userId);
+    const status = await this.client.db.aiUsage.checkRateLimit(userId);
+    const statusText = status.limited
+      ? `🛑 **Rate Limited** (${status.reason === 'daily' ? 'Daily' : 'Weekly'} limit exceeded)`
+      : '✅ **Active** (Pool is cool)';
+
+    return new Discord.EmbedBuilder()
+      .setColor('#0099ff')
+      .setTitle(`${username}'s Profile`)
+      .setThumbnail(avatarURL)
+      .setDescription(`
+## AI Usage
+**Daily Usage (24h):** ${dailyUsage.toLocaleString()} / 250,000 tokens
+**Weekly Usage (7d):** ${weeklyUsage.toLocaleString()} / 1,000,000 tokens
+**Status:** ${statusText}
+      `)
       .setTimestamp();
   }
 }

--- a/commands/profile.ts
+++ b/commands/profile.ts
@@ -6,6 +6,7 @@ import {
   getNuggieFlatMultiplier, getNuggieStreakMultiplier, getNuggieCreditsMultiplier,
   getNuggiePokeMultiplier, getNuggieNuggieMultiplier,
 } from '../utils/ascensionupgrades';
+import { DAILY_LIMIT, WEEKLY_LIMIT } from '../utils/ai';
 import {
   getMultiplierAmountInfo,
   getMultiplierChanceInfo,
@@ -155,7 +156,7 @@ class Profile extends Command {
           detailsEmbed = this.createPokemonsEmbed(pokemonList, username, avatarURL);
           break;
         case 'ai_usage':
-          detailsEmbed = await this.createAiUsageEmbed(interaction.user.id, username, avatarURL);
+          detailsEmbed = await this.createAiUsageEmbed(user.id, username, avatarURL);
           break;
         default:
           break;
@@ -325,9 +326,11 @@ ${getNuggieNuggieMultiplierInfo(user.nuggieNuggieMultiplierLevel, INFO_LEVEL.THI
   }
 
   async createAiUsageEmbed(userId: string, username: string, avatarURL: string) {
-    const dailyUsage = await this.client.db.aiUsage.getDailyUsage(userId);
-    const weeklyUsage = await this.client.db.aiUsage.getWeeklyUsage(userId);
-    const status = await this.client.db.aiUsage.checkRateLimit(userId);
+    const [dailyUsage, weeklyUsage, status] = await Promise.all([
+      this.client.db.aiUsage.getDailyUsage(userId),
+      this.client.db.aiUsage.getWeeklyUsage(userId),
+      this.client.db.aiUsage.checkRateLimit(userId),
+    ]);
     const statusText = status.limited
       ? `🛑 **Rate Limited** (${status.reason === 'daily' ? 'Daily' : 'Weekly'} limit exceeded)`
       : '✅ **Active** (Pool is cool)';
@@ -338,8 +341,8 @@ ${getNuggieNuggieMultiplierInfo(user.nuggieNuggieMultiplierLevel, INFO_LEVEL.THI
       .setThumbnail(avatarURL)
       .setDescription(`
 ## AI Usage
-**Daily Usage (24h):** ${dailyUsage.toLocaleString()} / 250,000 tokens
-**Weekly Usage (7d):** ${weeklyUsage.toLocaleString()} / 1,000,000 tokens
+**Daily Usage (24h):** ${dailyUsage.toLocaleString()} / ${DAILY_LIMIT.toLocaleString()} tokens
+**Weekly Usage (7d):** ${weeklyUsage.toLocaleString()} / ${WEEKLY_LIMIT.toLocaleString()} tokens
 **Status:** ${statusText}
       `)
       .setTimestamp();

--- a/commands/summary_count.ts
+++ b/commands/summary_count.ts
@@ -2,6 +2,7 @@ import { EmbedBuilder } from 'discord.js';
 import { Command } from './classes/Command';
 import { generateContent, getPersonaByName } from '../utils/ai';
 import { log, logError } from '../utils/log';
+import { handleRateLimitError } from '../utils/discordRateLimit';
 import { fetchMessagesByCount } from '../utils/fetch';
 
 function splitForEmbed(text: string, max = 4096): string[] {
@@ -69,19 +70,7 @@ class Summary extends Command {
       log(`Generated summary: ${summary.text}`);
     } catch (error: any) {
       if (error?.message === 'RATE_LIMIT_EXCEEDED') {
-        const dailyUsage = await this.client.db.aiUsage.getDailyUsage(interaction.user.id);
-        const weeklyUsage = await this.client.db.aiUsage.getWeeklyUsage(interaction.user.id);
-        const dailyLimit = 250000;
-        const weeklyLimit = 1000000;
-        const reachedDaily = dailyUsage >= dailyLimit;
-
-        const limitLabel = reachedDaily ? 'Daily' : 'Weekly';
-        const usageVal = reachedDaily ? dailyUsage : weeklyUsage;
-        const limitVal = reachedDaily ? dailyLimit : weeklyLimit;
-
-        await interaction.editReply({
-          content: `⚠️ **${limitLabel} AI Rate Limit Reached**\nYou have consumed **${usageVal.toLocaleString()}** / **${limitVal.toLocaleString()}** tokens in the last ${reachedDaily ? '24 hours' : '7 days'}. Please wait for your token pool to cool down.`,
-        });
+        await handleRateLimitError(interaction, this.client.db);
         return;
       }
       logError('Failed to generate summary:', error);

--- a/commands/summary_count.ts
+++ b/commands/summary_count.ts
@@ -59,13 +59,31 @@ class Summary extends Command {
     let summary: any;
     try {
       summary = await generateContent({
+        db: this.client.db,
+        userId: interaction.user.id,
         provider: persona.provider,
         model: persona.model,
         systemPrompt: persona.systemPrompt ?? '',
         prompt: content,
       });
       log(`Generated summary: ${summary.text}`);
-    } catch (error) {
+    } catch (error: any) {
+      if (error?.message === 'RATE_LIMIT_EXCEEDED') {
+        const dailyUsage = await this.client.db.aiUsage.getDailyUsage(interaction.user.id);
+        const weeklyUsage = await this.client.db.aiUsage.getWeeklyUsage(interaction.user.id);
+        const dailyLimit = 250000;
+        const weeklyLimit = 1000000;
+        const reachedDaily = dailyUsage >= dailyLimit;
+
+        const limitLabel = reachedDaily ? 'Daily' : 'Weekly';
+        const usageVal = reachedDaily ? dailyUsage : weeklyUsage;
+        const limitVal = reachedDaily ? dailyLimit : weeklyLimit;
+
+        await interaction.editReply({
+          content: `⚠️ **${limitLabel} AI Rate Limit Reached**\nYou have consumed **${usageVal.toLocaleString()}** / **${limitVal.toLocaleString()}** tokens in the last ${reachedDaily ? '24 hours' : '7 days'}. Please wait for your token pool to cool down.`,
+        });
+        return;
+      }
       logError('Failed to generate summary:', error);
       await interaction.editReply('Failed to generate summary. Please try again later.');
       return;

--- a/commands/summary_time.ts
+++ b/commands/summary_time.ts
@@ -2,6 +2,7 @@ import { EmbedBuilder } from 'discord.js';
 import { Command } from './classes/Command';
 import { generateContent, getPersonaByName } from '../utils/ai';
 import { log, logError } from '../utils/log';
+import { handleRateLimitError } from '../utils/discordRateLimit';
 import { fetchMessagesByTime } from '../utils/fetch';
 
 function splitForEmbed(text: string, max = 4096): string[] {
@@ -83,19 +84,7 @@ class Summary extends Command {
       log(`Generated summary: ${summary.text}`);
     } catch (error: any) {
       if (error?.message === 'RATE_LIMIT_EXCEEDED') {
-        const dailyUsage = await this.client.db.aiUsage.getDailyUsage(interaction.user.id);
-        const weeklyUsage = await this.client.db.aiUsage.getWeeklyUsage(interaction.user.id);
-        const dailyLimit = 250000;
-        const weeklyLimit = 1000000;
-        const reachedDaily = dailyUsage >= dailyLimit;
-
-        const limitLabel = reachedDaily ? 'Daily' : 'Weekly';
-        const usageVal = reachedDaily ? dailyUsage : weeklyUsage;
-        const limitVal = reachedDaily ? dailyLimit : weeklyLimit;
-
-        await interaction.editReply({
-          content: `⚠️ **${limitLabel} AI Rate Limit Reached**\nYou have consumed **${usageVal.toLocaleString()}** / **${limitVal.toLocaleString()}** tokens in the last ${reachedDaily ? '24 hours' : '7 days'}. Please wait for your token pool to cool down.`,
-        });
+        await handleRateLimitError(interaction, this.client.db);
         return;
       }
       logError('Failed to generate summary:', error);

--- a/commands/summary_time.ts
+++ b/commands/summary_time.ts
@@ -73,13 +73,31 @@ class Summary extends Command {
     let summary: any;
     try {
       summary = await generateContent({
+        db: this.client.db,
+        userId: interaction.user.id,
         provider: persona.provider,
         model: persona.model,
         systemPrompt: persona.systemPrompt ?? '',
         prompt: content,
       });
       log(`Generated summary: ${summary.text}`);
-    } catch (error) {
+    } catch (error: any) {
+      if (error?.message === 'RATE_LIMIT_EXCEEDED') {
+        const dailyUsage = await this.client.db.aiUsage.getDailyUsage(interaction.user.id);
+        const weeklyUsage = await this.client.db.aiUsage.getWeeklyUsage(interaction.user.id);
+        const dailyLimit = 250000;
+        const weeklyLimit = 1000000;
+        const reachedDaily = dailyUsage >= dailyLimit;
+
+        const limitLabel = reachedDaily ? 'Daily' : 'Weekly';
+        const usageVal = reachedDaily ? dailyUsage : weeklyUsage;
+        const limitVal = reachedDaily ? dailyLimit : weeklyLimit;
+
+        await interaction.editReply({
+          content: `⚠️ **${limitLabel} AI Rate Limit Reached**\nYou have consumed **${usageVal.toLocaleString()}** / **${limitVal.toLocaleString()}** tokens in the last ${reachedDaily ? '24 hours' : '7 days'}. Please wait for your token pool to cool down.`,
+        });
+        return;
+      }
       logError('Failed to generate summary:', error);
       await interaction.editReply('Failed to generate summary. Please try again later.');
       return;

--- a/database/Database.ts
+++ b/database/Database.ts
@@ -7,12 +7,14 @@ import imageGenQueries from './queries/imageGenQueries';
 import musicGenQueries from './queries/musicGenQueries';
 import battleshipsMatchQueries from './queries/battleshipsMatchQueries';
 import rpQueries from './queries/rpQueries';
+import aiUsageQueries from './queries/aiUsageQueries';
 import * as modelClasses from './models';
 import type { TableDefinition, QueryResult } from './types';
 import type UserModel from './models/UserModel';
 import type BabyModel from './models/BabyModel';
 import type BattleshipsMatchModel from './models/BattleshipsMatchModel';
 import type AiChatModel from './models/AiChatModel';
+import type AiUsageModel from './models/AiUsageModel';
 import type PokemonModel from './models/PokemonModel';
 import type MarriageModel from './models/MarriageModel';
 import type CommandConfigModel from './models/CommandConfigModel';
@@ -190,6 +192,9 @@ class Database {
     this.db.run(rpQueries.CREATE_INDEX_CHAR_NAME);
     this.db.run(rpQueries.CREATE_INDEX_CHAR_CREATOR);
 
+    // AI Usage tracking
+    this.db.run(aiUsageQueries.CREATE_INDEX_USER_CREATED);
+
     // Migrate legacy ServerRoles into ServerConfig when opening an older database.
     this.migrateLegacyServerRolesIfNeeded();
 
@@ -334,6 +339,7 @@ class Database {
   async dumpGameUID(): Promise<string> { return this.dumpTable('GameUID', ['user_id']); }
 
   get aiChat(): AiChatModel { return this.models.AiChatModel; }
+  get aiUsage(): AiUsageModel { return this.models.AiUsageModel; }
   get birthdayReminder(): BirthdayReminderModel { return this.models.BirthdayReminderModel; }
   get footballMatchAnnouncement(): FootballMatchAnnouncementModel { return this.models.FootballMatchAnnouncementModel; }
   get baby(): BabyModel { return this.models.BabyModel; }

--- a/database/models/AiUsageModel.ts
+++ b/database/models/AiUsageModel.ts
@@ -1,0 +1,73 @@
+import type Database from '../Database';
+import aiUsageQueries from '../queries/aiUsageQueries';
+import { isUserDev } from '../../utils/accessControl';
+
+export const DAILY_LIMIT = 250000; // 250,000 tokens
+export const WEEKLY_LIMIT = 1000000; // 1,000,000 tokens (exactly 4 daily limits)
+
+class AiUsageModel {
+  private db: Database;
+
+  constructor(db: Database) {
+    this.db = db;
+  }
+
+  async addUsage(
+    userId: string,
+    model: string,
+    promptTokens: number,
+    completionTokens: number,
+    cost = 0,
+  ): Promise<void> {
+    // Ensure user exists in User table
+    await this.db.user.getUser(userId);
+
+    await this.db.executeQuery(aiUsageQueries.ADD_USAGE, [
+      userId,
+      model,
+      promptTokens,
+      completionTokens,
+      cost,
+    ]);
+  }
+
+  async getDailyUsage(userId: string): Promise<number> {
+    const row = await this.db.executeSelectQuery(aiUsageQueries.GET_DAILY_USAGE, [userId]);
+    return row?.total ?? 0;
+  }
+
+  async getWeeklyUsage(userId: string): Promise<number> {
+    const row = await this.db.executeSelectQuery(aiUsageQueries.GET_WEEKLY_USAGE, [userId]);
+    return row?.total ?? 0;
+  }
+
+  async checkRateLimit(userId: string): Promise<{
+    limited: boolean;
+    reason?: 'daily' | 'weekly';
+    usage?: number;
+    limit?: number;
+  }> {
+    if (isUserDev(userId)) {
+      return { limited: false };
+    }
+
+    const dailyUsage = await this.getDailyUsage(userId);
+    if (dailyUsage >= DAILY_LIMIT) {
+      return { limited: true, reason: 'daily', usage: dailyUsage, limit: DAILY_LIMIT };
+    }
+
+    const weeklyUsage = await this.getWeeklyUsage(userId);
+    if (weeklyUsage >= WEEKLY_LIMIT) {
+      return { limited: true, reason: 'weekly', usage: weeklyUsage, limit: WEEKLY_LIMIT };
+    }
+
+    return { limited: false };
+  }
+
+  async isRateLimited(userId: string): Promise<boolean> {
+    const status = await this.checkRateLimit(userId);
+    return status.limited;
+  }
+}
+
+export default AiUsageModel;

--- a/database/models/AiUsageModel.ts
+++ b/database/models/AiUsageModel.ts
@@ -38,7 +38,7 @@ class AiUsageModel {
     if (row === null) {
       throw new Error('Database query failed while fetching daily usage');
     }
-    return row.total;
+    return row.total ?? 0;
   }
 
   async getWeeklyUsage(userId: string): Promise<number> {
@@ -46,7 +46,7 @@ class AiUsageModel {
     if (row === null) {
       throw new Error('Database query failed while fetching weekly usage');
     }
-    return row.total;
+    return row.total ?? 0;
   }
 
   async checkRateLimit(userId: string): Promise<{

--- a/database/models/AiUsageModel.ts
+++ b/database/models/AiUsageModel.ts
@@ -1,9 +1,7 @@
 import type Database from '../Database';
 import aiUsageQueries from '../queries/aiUsageQueries';
 import { isUserDev } from '../../utils/accessControl';
-
-export const DAILY_LIMIT = 250000; // 250,000 tokens
-export const WEEKLY_LIMIT = 1000000; // 1,000,000 tokens (exactly 4 daily limits)
+import { DAILY_LIMIT, WEEKLY_LIMIT } from '../../utils/ai';
 
 class AiUsageModel {
   private db: Database;
@@ -22,23 +20,33 @@ class AiUsageModel {
     // Ensure user exists in User table
     await this.db.user.getUser(userId);
 
-    await this.db.executeQuery(aiUsageQueries.ADD_USAGE, [
+    const result = await this.db.executeQuery(aiUsageQueries.ADD_USAGE, [
       userId,
       model,
       promptTokens,
       completionTokens,
       cost,
     ]);
+
+    if (!result || result.changes === 0) {
+      throw new Error('Failed to record AI usage in the database');
+    }
   }
 
   async getDailyUsage(userId: string): Promise<number> {
     const row = await this.db.executeSelectQuery(aiUsageQueries.GET_DAILY_USAGE, [userId]);
-    return row?.total ?? 0;
+    if (row === null) {
+      throw new Error('Database query failed while fetching daily usage');
+    }
+    return row.total;
   }
 
   async getWeeklyUsage(userId: string): Promise<number> {
     const row = await this.db.executeSelectQuery(aiUsageQueries.GET_WEEKLY_USAGE, [userId]);
-    return row?.total ?? 0;
+    if (row === null) {
+      throw new Error('Database query failed while fetching weekly usage');
+    }
+    return row.total;
   }
 
   async checkRateLimit(userId: string): Promise<{
@@ -53,12 +61,16 @@ class AiUsageModel {
 
     const dailyUsage = await this.getDailyUsage(userId);
     if (dailyUsage >= DAILY_LIMIT) {
-      return { limited: true, reason: 'daily', usage: dailyUsage, limit: DAILY_LIMIT };
+      return {
+        limited: true, reason: 'daily', usage: dailyUsage, limit: DAILY_LIMIT,
+      };
     }
 
     const weeklyUsage = await this.getWeeklyUsage(userId);
     if (weeklyUsage >= WEEKLY_LIMIT) {
-      return { limited: true, reason: 'weekly', usage: weeklyUsage, limit: WEEKLY_LIMIT };
+      return {
+        limited: true, reason: 'weekly', usage: weeklyUsage, limit: WEEKLY_LIMIT,
+      };
     }
 
     return { limited: false };

--- a/database/models/RpModel.ts
+++ b/database/models/RpModel.ts
@@ -361,6 +361,11 @@ class RpModel {
     return row?.count ?? 0;
   }
 
+  async getLastHumanSpeaker(spawnId: number): Promise<string | null> {
+    const row = await this.db.executeSelectQuery(rpQueries.GET_LAST_HUMAN_SPEAKER, [spawnId]);
+    return row?.speakerId ?? null;
+  }
+
   async deleteHistoryBySpawn(spawnId: number): Promise<void> {
     await this.db.executeQuery(rpQueries.DELETE_HISTORY_BY_SPAWN, [spawnId]);
   }

--- a/database/models/index.ts
+++ b/database/models/index.ts
@@ -1,4 +1,5 @@
 import AiChatModel from './AiChatModel';
+import AiUsageModel from './AiUsageModel';
 import BabyModel from './BabyModel';
 import BattleshipsMatchModel from './BattleshipsMatchModel';
 import BirthdayReminderModel from './BirthdayReminderModel';
@@ -19,6 +20,7 @@ import WebSessionModel from './WebSessionModel';
 
 export {
   AiChatModel,
+  AiUsageModel,
   BabyModel,
   BattleshipsMatchModel,
   BirthdayReminderModel,

--- a/database/queries/aiUsageQueries.ts
+++ b/database/queries/aiUsageQueries.ts
@@ -1,0 +1,21 @@
+const aiUsageQueries = {
+  ADD_USAGE: `
+    INSERT INTO AiUsage (user_id, model, tokens_prompt, tokens_completion, cost)
+    VALUES (?, ?, ?, ?, ?)
+  `,
+  GET_DAILY_USAGE: `
+    SELECT COALESCE(SUM(tokens_prompt + tokens_completion), 0) AS total
+    FROM AiUsage
+    WHERE user_id = ? AND created_at > datetime('now', '-1 day')
+  `,
+  GET_WEEKLY_USAGE: `
+    SELECT COALESCE(SUM(tokens_prompt + tokens_completion), 0) AS total
+    FROM AiUsage
+    WHERE user_id = ? AND created_at > datetime('now', '-7 days')
+  `,
+  CREATE_INDEX_USER_CREATED: `
+    CREATE INDEX IF NOT EXISTS idx_aiusage_user_created ON AiUsage (user_id, created_at)
+  `,
+};
+
+export default aiUsageQueries;

--- a/database/queries/rpQueries.ts
+++ b/database/queries/rpQueries.ts
@@ -132,6 +132,11 @@ const rpQueries = {
         AND id > COALESCE((SELECT MAX(id) FROM RpHistory WHERE spawn_id = ? AND role = 'model'), 0)
     ) AS has
   `,
+  GET_LAST_HUMAN_SPEAKER: `
+    SELECT speaker_id FROM RpHistory
+    WHERE spawn_id = ? AND role = 'user' AND from_bot = 0
+    ORDER BY id DESC LIMIT 1
+  `,
   COUNT_HISTORY: 'SELECT COUNT(*) AS count FROM RpHistory WHERE spawn_id = ?',
   // Whole-table footprint (row count + total message bytes) for /memstats diagnostics.
   // CAST to BLOB so LENGTH counts bytes, not characters. Full scan is acceptable: the

--- a/database/tables/aiUsageTable.ts
+++ b/database/tables/aiUsageTable.ts
@@ -1,0 +1,29 @@
+import type { TableDefinition } from '../types';
+
+export interface AiUsageRow {
+  id: number;
+  user_id: string;
+  model: string;
+  tokens_prompt: number;
+  tokens_completion: number;
+  cost: number;
+  created_at: string;
+}
+
+const aiUsageTable: TableDefinition = {
+  name: 'AiUsage',
+  columns: [
+    { name: 'id', type: 'INTEGER PRIMARY KEY AUTOINCREMENT' },
+    { name: 'user_id', type: 'TEXT NOT NULL' },
+    { name: 'model', type: 'TEXT NOT NULL' },
+    { name: 'tokens_prompt', type: 'INTEGER NOT NULL' },
+    { name: 'tokens_completion', type: 'INTEGER NOT NULL' },
+    { name: 'cost', type: 'REAL NOT NULL DEFAULT 0' },
+    { name: 'created_at', type: 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP' },
+  ],
+  primaryKey: ['id'],
+  specialConstraints: [],
+  constraints: [],
+};
+
+export default aiUsageTable;

--- a/database/tables/index.ts
+++ b/database/tables/index.ts
@@ -1,5 +1,6 @@
 import aiChatHistoryTable from './aiChatHistoryTable';
 import aiChatSessionTable from './aiChatSessionTable';
+import aiUsageTable from './aiUsageTable';
 import babyTable from './babyTable';
 import battleshipsMatchTable from './battleshipsMatchTable';
 import birthdayReminderTable from './birthdayReminderTable';
@@ -26,6 +27,7 @@ import webSessionTable from './webSessionTable';
 export {
   aiChatHistoryTable,
   aiChatSessionTable,
+  aiUsageTable,
   babyTable,
   battleshipsMatchTable,
   birthdayReminderTable,
@@ -52,6 +54,7 @@ export {
 
 export type { AiChatHistoryRow } from './aiChatHistoryTable';
 export type { AiChatSessionRow } from './aiChatSessionTable';
+export type { AiUsageRow } from './aiUsageTable';
 export type { BabyRow } from './babyTable';
 export type { BattleshipsMatchRow } from './battleshipsMatchTable';
 export type { BirthdayReminderRow } from './birthdayReminderTable';

--- a/site_src/pages/home.ts
+++ b/site_src/pages/home.ts
@@ -31,6 +31,8 @@ export interface DashboardProfile {
   marriageBenefits: number;
   poopStats: Record<string, any> | null;
   poopProfile: Record<string, any> | null;
+  aiUsageDaily: number;
+  aiUsageWeekly: number;
 }
 
 const styles = raw(`
@@ -297,6 +299,35 @@ export function HomePage(opts: {
           <div class="me-card">
             <div class="label">Heavenly Nuggies</div>
             <div class="value">${numSpan(stats.heavenlyNuggies ?? 0)}</div>
+          </div>
+        </div>
+      </div>
+    </details>
+
+    <details>
+      <summary>AI Usage</summary>
+      <div class="details-content">
+        <div class="me-grid">
+          <div class="me-card">
+            <div class="label">Daily Usage (24h)</div>
+            <div class="value">${numSpan(profile.aiUsageDaily)}</div>
+            <div class="label" style="margin-top:0.25rem">of 250,000 tokens</div>
+          </div>
+          <div class="me-card">
+            <div class="label">Weekly Usage (7d)</div>
+            <div class="value">${numSpan(profile.aiUsageWeekly)}</div>
+            <div class="label" style="margin-top:0.25rem">of 1,000,000 tokens</div>
+          </div>
+          <div class="me-card">
+            <div class="label">Status</div>
+            <div class="value" style="font-size: 1.5rem; font-weight: 600;">
+              ${profile.aiUsageDaily >= 250000 || profile.aiUsageWeekly >= 1000000 
+                ? html`<span style="color: #ef4444;">Rate Limited</span>` 
+                : html`<span style="color: #10b981;">Active</span>`}
+            </div>
+            <div class="label" style="margin-top:0.25rem">
+              ${profile.aiUsageDaily >= 250000 ? 'Daily limit exceeded' : (profile.aiUsageWeekly >= 1000000 ? 'Weekly limit exceeded' : 'Token pool is cool')}
+            </div>
           </div>
         </div>
       </div>

--- a/site_src/pages/home.ts
+++ b/site_src/pages/home.ts
@@ -2,6 +2,7 @@ import { html, raw } from 'hono/html';
 import type { HtmlEscapedString } from 'hono/utils/html';
 import { Layout } from '../components/layout';
 import type { NavUser } from '../components/navbar';
+import { DAILY_LIMIT, WEEKLY_LIMIT } from '../../utils/ai';
 import { numSpan, numSpanSuffix } from '../format';
 import { getMaxLevel, getBekiCooldown } from '../../utils/upgrades';
 import {
@@ -274,6 +275,21 @@ export function HomePage(opts: {
   const commonPoopType = poopStats?.commonType ?? 'N/A';
   const commonPoopColour = poopStats?.commonColour ?? 'N/A';
 
+  const reachedDaily = profile.aiUsageDaily >= DAILY_LIMIT;
+  const reachedWeekly = profile.aiUsageWeekly >= WEEKLY_LIMIT;
+  const isAiRateLimited = reachedDaily || reachedWeekly;
+
+  const aiStatusLabel = isAiRateLimited
+    ? html`<span style="color: #ef4444;">Rate Limited</span>`
+    : html`<span style="color: #10b981;">Active</span>`;
+
+  let aiStatusDetail = 'Token pool is cool';
+  if (reachedDaily) {
+    aiStatusDetail = 'Daily limit exceeded';
+  } else if (reachedWeekly) {
+    aiStatusDetail = 'Weekly limit exceeded';
+  }
+
   const body = html`
     ${styles}
     <div class="me-header">
@@ -311,22 +327,20 @@ export function HomePage(opts: {
           <div class="me-card">
             <div class="label">Daily Usage (24h)</div>
             <div class="value">${numSpan(profile.aiUsageDaily)}</div>
-            <div class="label" style="margin-top:0.25rem">of 250,000 tokens</div>
+            <div class="label" style="margin-top:0.25rem">of ${DAILY_LIMIT.toLocaleString()} tokens</div>
           </div>
           <div class="me-card">
             <div class="label">Weekly Usage (7d)</div>
             <div class="value">${numSpan(profile.aiUsageWeekly)}</div>
-            <div class="label" style="margin-top:0.25rem">of 1,000,000 tokens</div>
+            <div class="label" style="margin-top:0.25rem">of ${WEEKLY_LIMIT.toLocaleString()} tokens</div>
           </div>
           <div class="me-card">
             <div class="label">Status</div>
             <div class="value" style="font-size: 1.5rem; font-weight: 600;">
-              ${profile.aiUsageDaily >= 250000 || profile.aiUsageWeekly >= 1000000 
-                ? html`<span style="color: #ef4444;">Rate Limited</span>` 
-                : html`<span style="color: #10b981;">Active</span>`}
+              ${aiStatusLabel}
             </div>
             <div class="label" style="margin-top:0.25rem">
-              ${profile.aiUsageDaily >= 250000 ? 'Daily limit exceeded' : (profile.aiUsageWeekly >= 1000000 ? 'Weekly limit exceeded' : 'Token pool is cool')}
+              ${aiStatusDetail}
             </div>
           </div>
         </div>

--- a/site_src/routes/ai-slop-api.ts
+++ b/site_src/routes/ai-slop-api.ts
@@ -162,6 +162,8 @@ export function registerAiSlopApiRoutes(app: Hono<AppEnv>, silverwolf: Silverwol
       }
 
       const result = await generateContent({
+        db: silverwolf.db,
+        userId: auth.discordId,
         provider: persona.provider,
         model: persona.model,
         systemPrompt: persona.systemPrompt ?? '',
@@ -213,7 +215,17 @@ export function registerAiSlopApiRoutes(app: Hono<AppEnv>, silverwolf: Silverwol
           title,
         },
       });
-    } catch (err) {
+    } catch (err: any) {
+      if (err?.message === 'RATE_LIMIT_EXCEEDED') {
+        const dailyUsage = await silverwolf.db.aiUsage.getDailyUsage(auth.discordId);
+        const weeklyUsage = await silverwolf.db.aiUsage.getWeeklyUsage(auth.discordId);
+        const reachedDaily = dailyUsage >= 250000;
+        return c.json({
+          ok: false,
+          error: 'rate_limited' as const,
+          reason: reachedDaily ? ('daily' as const) : ('weekly' as const),
+        }, 429);
+      }
       logError('[ai-slop] send failed:', err);
       // If this was a brand-new session and the AI call failed without producing
       // any history, leave the empty session in place rather than rolling back —

--- a/site_src/routes/ai-slop-api.ts
+++ b/site_src/routes/ai-slop-api.ts
@@ -7,6 +7,7 @@ import {
   generateTitleForHistory,
   getPersonaByName,
   type Persona,
+  DAILY_LIMIT,
 } from '../../utils/ai';
 import { trimHistoryToFit } from '../../utils/tokenizer';
 import { type AppEnv, authedGameRequest, readGameBody } from '../shared';
@@ -219,11 +220,13 @@ export function registerAiSlopApiRoutes(app: Hono<AppEnv>, silverwolf: Silverwol
       if (err?.message === 'RATE_LIMIT_EXCEEDED') {
         const dailyUsage = await silverwolf.db.aiUsage.getDailyUsage(auth.discordId);
         const weeklyUsage = await silverwolf.db.aiUsage.getWeeklyUsage(auth.discordId);
-        const reachedDaily = dailyUsage >= 250000;
+        const reachedDaily = dailyUsage >= DAILY_LIMIT;
         return c.json({
           ok: false,
           error: 'rate_limited' as const,
           reason: reachedDaily ? ('daily' as const) : ('weekly' as const),
+          dailyUsage,
+          weeklyUsage,
         }, 429);
       }
       logError('[ai-slop] send failed:', err);

--- a/site_src/routes/pages.ts
+++ b/site_src/routes/pages.ts
@@ -44,7 +44,8 @@ export function registerPageRoutes(app: Hono<AppEnv>, silverwolf: Silverwolf) {
     try {
       const getDailyUsageSafe = async () => {
         try {
-          return await silverwolf.db.aiUsage.getDailyUsage(user.discordId);
+          const usage = await silverwolf.db.aiUsage.getDailyUsage(user.discordId);
+          return usage ?? 0;
         } catch (e) {
           logError('Dashboard failed to load daily AI usage:', e);
           return 0;
@@ -53,7 +54,8 @@ export function registerPageRoutes(app: Hono<AppEnv>, silverwolf: Silverwolf) {
 
       const getWeeklyUsageSafe = async () => {
         try {
-          return await silverwolf.db.aiUsage.getWeeklyUsage(user.discordId);
+          const usage = await silverwolf.db.aiUsage.getWeeklyUsage(user.discordId);
+          return usage ?? 0;
         } catch (e) {
           logError('Dashboard failed to load weekly AI usage:', e);
           return 0;

--- a/site_src/routes/pages.ts
+++ b/site_src/routes/pages.ts
@@ -42,14 +42,40 @@ export function registerPageRoutes(app: Hono<AppEnv>, silverwolf: Silverwolf) {
     const nonce = c.get('nonce');
     const lv999 = c.req.query('lv') === '999';
     try {
-      const [stats, pokemonCount, marriageBenefits, poopStats, poopProfile, aiUsageDaily, aiUsageWeekly] = await Promise.all([
+      const getDailyUsageSafe = async () => {
+        try {
+          return await silverwolf.db.aiUsage.getDailyUsage(user.discordId);
+        } catch (e) {
+          logError('Dashboard failed to load daily AI usage:', e);
+          return 0;
+        }
+      };
+
+      const getWeeklyUsageSafe = async () => {
+        try {
+          return await silverwolf.db.aiUsage.getWeeklyUsage(user.discordId);
+        } catch (e) {
+          logError('Dashboard failed to load weekly AI usage:', e);
+          return 0;
+        }
+      };
+
+      const [
+        stats,
+        pokemonCount,
+        marriageBenefits,
+        poopStats,
+        poopProfile,
+        aiUsageDaily,
+        aiUsageWeekly,
+      ] = await Promise.all([
         silverwolf.db.user.getUser(user.discordId),
         silverwolf.db.pokemon.getUniquePokemonCount(user.discordId),
         silverwolf.db.marriage.getMarriageBenefits(user.discordId),
         silverwolf.db.poop.getUserStats(user.discordId),
         silverwolf.db.poop.getProfile(user.discordId),
-        silverwolf.db.aiUsage.getDailyUsage(user.discordId),
-        silverwolf.db.aiUsage.getWeeklyUsage(user.discordId),
+        getDailyUsageSafe(),
+        getWeeklyUsageSafe(),
       ]);
 
       const profile: DashboardProfile = {

--- a/site_src/routes/pages.ts
+++ b/site_src/routes/pages.ts
@@ -42,12 +42,14 @@ export function registerPageRoutes(app: Hono<AppEnv>, silverwolf: Silverwolf) {
     const nonce = c.get('nonce');
     const lv999 = c.req.query('lv') === '999';
     try {
-      const [stats, pokemonCount, marriageBenefits, poopStats, poopProfile] = await Promise.all([
+      const [stats, pokemonCount, marriageBenefits, poopStats, poopProfile, aiUsageDaily, aiUsageWeekly] = await Promise.all([
         silverwolf.db.user.getUser(user.discordId),
         silverwolf.db.pokemon.getUniquePokemonCount(user.discordId),
         silverwolf.db.marriage.getMarriageBenefits(user.discordId),
         silverwolf.db.poop.getUserStats(user.discordId),
         silverwolf.db.poop.getProfile(user.discordId),
+        silverwolf.db.aiUsage.getDailyUsage(user.discordId),
+        silverwolf.db.aiUsage.getWeeklyUsage(user.discordId),
       ]);
 
       const profile: DashboardProfile = {
@@ -59,6 +61,8 @@ export function registerPageRoutes(app: Hono<AppEnv>, silverwolf: Silverwolf) {
         marriageBenefits,
         poopStats,
         poopProfile,
+        aiUsageDaily,
+        aiUsageWeekly,
       };
       return c.html(HomePage({
         profile, user: user.nav, nonce, lv999,

--- a/tests/database/aiUsage.test.ts
+++ b/tests/database/aiUsage.test.ts
@@ -1,0 +1,150 @@
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import Database from '../../database/Database';
+import type AiUsageModel from '../../database/models/AiUsageModel';
+import { DAILY_LIMIT, WEEKLY_LIMIT } from '../../database/models/AiUsageModel';
+
+describe('AiUsageModel', () => {
+  let db: Database;
+  let aiUsageModel: AiUsageModel;
+
+  beforeAll(async () => {
+    const timestamp = Date.now();
+    db = new Database(`./tests/temp/testAiUsage-${timestamp}.db`);
+    await db.ready;
+    aiUsageModel = db.aiUsage;
+  });
+
+  afterAll(() => {
+    db.db.close();
+  });
+
+  beforeEach(async () => {
+    await db.executeQuery('DELETE FROM AiUsage');
+    await db.executeQuery('DELETE FROM User');
+  });
+
+  test('starts with zero usage for fresh user', async () => {
+    expect(await aiUsageModel.getDailyUsage('u1')).toBe(0);
+    expect(await aiUsageModel.getWeeklyUsage('u1')).toBe(0);
+    const limitStatus = await aiUsageModel.checkRateLimit('u1');
+    expect(limitStatus.limited).toBe(false);
+  });
+
+  test('accumulates daily and weekly usage correctly', async () => {
+    await aiUsageModel.addUsage('u1', 'test-model', 1000, 2000);
+    await aiUsageModel.addUsage('u1', 'test-model2', 500, 1500);
+
+    expect(await aiUsageModel.getDailyUsage('u1')).toBe(5000);
+    expect(await aiUsageModel.getWeeklyUsage('u1')).toBe(5000);
+  });
+
+  test('separates usage by user', async () => {
+    await aiUsageModel.addUsage('u1', 'test-model', 1000, 2000);
+    await aiUsageModel.addUsage('u2', 'test-model', 500, 500);
+
+    expect(await aiUsageModel.getDailyUsage('u1')).toBe(3000);
+    expect(await aiUsageModel.getDailyUsage('u2')).toBe(1000);
+  });
+
+  test('excludes daily entries older than 24 hours but includes in weekly', async () => {
+    // 25 hours ago
+    await db.executeQuery(`
+      INSERT INTO AiUsage (user_id, model, tokens_prompt, tokens_completion, cost, created_at)
+      VALUES (?, ?, ?, ?, ?, datetime('now', '-25 hours'))
+    `, ['u1', 'test-model', 10000, 10000, 0]);
+
+    // 2 hours ago
+    await aiUsageModel.addUsage('u1', 'test-model', 2000, 3000);
+
+    expect(await aiUsageModel.getDailyUsage('u1')).toBe(5000);
+    expect(await aiUsageModel.getWeeklyUsage('u1')).toBe(25000);
+  });
+
+  test('excludes weekly entries older than 7 days', async () => {
+    // 8 days ago
+    await db.executeQuery(`
+      INSERT INTO AiUsage (user_id, model, tokens_prompt, tokens_completion, cost, created_at)
+      VALUES (?, ?, ?, ?, ?, datetime('now', '-8 days'))
+    `, ['u1', 'test-model', 50000, 50000, 0]);
+
+    // 3 days ago
+    await db.executeQuery(`
+      INSERT INTO AiUsage (user_id, model, tokens_prompt, tokens_completion, cost, created_at)
+      VALUES (?, ?, ?, ?, ?, datetime('now', '-3 days'))
+    `, ['u1', 'test-model', 20000, 20000, 0]);
+
+    expect(await aiUsageModel.getDailyUsage('u1')).toBe(0);
+    expect(await aiUsageModel.getWeeklyUsage('u1')).toBe(40000);
+  });
+
+  test('triggers daily rate limit when budget exceeded', async () => {
+    // Under limit
+    await aiUsageModel.addUsage('u1', 'test-model', DAILY_LIMIT - 5000, 0);
+    let status = await aiUsageModel.checkRateLimit('u1');
+    expect(status.limited).toBe(false);
+
+    // Over limit
+    await aiUsageModel.addUsage('u1', 'test-model', 10000, 0);
+    status = await aiUsageModel.checkRateLimit('u1');
+    expect(status.limited).toBe(true);
+    expect(status.reason).toBe('daily');
+    expect(status.limit).toBe(DAILY_LIMIT);
+  });
+
+  test('triggers weekly rate limit when budget exceeded', async () => {
+    // Simulate usage across past 6 days, staying below the 250k daily limit on each day
+    // Day 1 (6 days ago): 200k
+    await db.executeQuery(`
+      INSERT INTO AiUsage (user_id, model, tokens_prompt, tokens_completion, cost, created_at)
+      VALUES (?, ?, ?, ?, ?, datetime('now', '-6 days'))
+    `, ['u1', 'test-model', 200000, 0, 0]);
+
+    // Day 2 (5 days ago): 200k
+    await db.executeQuery(`
+      INSERT INTO AiUsage (user_id, model, tokens_prompt, tokens_completion, cost, created_at)
+      VALUES (?, ?, ?, ?, ?, datetime('now', '-5 days'))
+    `, ['u1', 'test-model', 200000, 0, 0]);
+
+    // Day 3 (4 days ago): 200k
+    await db.executeQuery(`
+      INSERT INTO AiUsage (user_id, model, tokens_prompt, tokens_completion, cost, created_at)
+      VALUES (?, ?, ?, ?, ?, datetime('now', '-4 days'))
+    `, ['u1', 'test-model', 200000, 0, 0]);
+
+    // Day 4 (3 days ago): 200k
+    await db.executeQuery(`
+      INSERT INTO AiUsage (user_id, model, tokens_prompt, tokens_completion, cost, created_at)
+      VALUES (?, ?, ?, ?, ?, datetime('now', '-3 days'))
+    `, ['u1', 'test-model', 200000, 0, 0]);
+
+    // Day 5 (2 days ago): 150k
+    await db.executeQuery(`
+      INSERT INTO AiUsage (user_id, model, tokens_prompt, tokens_completion, cost, created_at)
+      VALUES (?, ?, ?, ?, ?, datetime('now', '-2 days'))
+    `, ['u1', 'test-model', 150000, 0, 0]);
+
+    // Day 6 (30 hours ago): 100k
+    await db.executeQuery(`
+      INSERT INTO AiUsage (user_id, model, tokens_prompt, tokens_completion, cost, created_at)
+      VALUES (?, ?, ?, ?, ?, datetime('now', '-30 hours'))
+    `, ['u1', 'test-model', 100000, 0, 0]);
+
+    // Total so far = 1,050,000. Daily usage = 0.
+    const status = await aiUsageModel.checkRateLimit('u1');
+    expect(status.limited).toBe(true);
+    expect(status.reason).toBe('weekly');
+    expect(status.limit).toBe(WEEKLY_LIMIT);
+  });
+
+  test('bypasses rate limit checks for developers', async () => {
+    const devId = process.env.ALLOWED_USERS?.split(',')[0];
+    if (!devId) {
+      // Skip if no ALLOWED_USERS configured
+      return;
+    }
+    
+    await aiUsageModel.addUsage(devId, 'test-model', DAILY_LIMIT * 5, 0);
+    const status = await aiUsageModel.checkRateLimit(devId);
+    expect(status.limited).toBe(false);
+  });
+});

--- a/tests/database/aiUsage.test.ts
+++ b/tests/database/aiUsage.test.ts
@@ -1,7 +1,9 @@
-import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import {
+  describe, test, expect, beforeAll, afterAll, beforeEach,
+} from 'bun:test';
 import Database from '../../database/Database';
 import type AiUsageModel from '../../database/models/AiUsageModel';
-import { DAILY_LIMIT, WEEKLY_LIMIT } from '../../database/models/AiUsageModel';
+import { DAILY_LIMIT, WEEKLY_LIMIT } from '../../utils/ai';
 
 describe('AiUsageModel', () => {
   let db: Database;
@@ -142,7 +144,7 @@ describe('AiUsageModel', () => {
       // Skip if no ALLOWED_USERS configured
       return;
     }
-    
+
     await aiUsageModel.addUsage(devId, 'test-model', DAILY_LIMIT * 5, 0);
     const status = await aiUsageModel.checkRateLimit(devId);
     expect(status.limited).toBe(false);

--- a/utils/accessControl.ts
+++ b/utils/accessControl.ts
@@ -34,8 +34,12 @@ function clearCachedAllowedServers(): void {
   cachedAllowedServers = null;
 }
 
+function isUserDev(userId: string): boolean {
+  return ALLOWED_USERS.includes(userId);
+}
+
 function isDev(interaction: ChatInputCommandInteraction): boolean {
-  return ALLOWED_USERS.includes(interaction.user.id);
+  return isUserDev(interaction.user.id);
 }
 
 function isAdmin(interaction: ChatInputCommandInteraction): boolean {
@@ -53,6 +57,7 @@ function isAllowedServer(interaction: ChatInputCommandInteraction): boolean {
 }
 
 export {
+  isUserDev,
   isDev,
   isAdmin,
   isBasement,

--- a/utils/ai.ts
+++ b/utils/ai.ts
@@ -169,6 +169,8 @@ export function formatHistoryEntryForModel(entry: Pick<HistoryEntry, 'role' | 'm
 }
 
 interface GenerateContentOptions {
+  db?: any;
+  userId?: string;
   provider: string;
   model: string;
   systemPrompt: string;
@@ -285,9 +287,19 @@ function getImageGenConfig(): { model: string; modalities: string[] } {
 }
 
 async function generateContent({
-  provider, model, systemPrompt, prompt, history = [], webSearchEnabled = false, imageGen, musicGen,
+  db, userId, provider, model, systemPrompt, prompt, history = [], webSearchEnabled = false, imageGen, musicGen,
   mediaParts = [], providerRouting,
 }: GenerateContentOptions): Promise<GenerateContentResult> {
+  if (db && userId) {
+    const isLimited = await db.aiUsage.isRateLimited(userId);
+    if (isLimited) {
+      throw new Error('RATE_LIMIT_EXCEEDED');
+    }
+  }
+
+  let totalPromptTokens = 0;
+  let totalCompletionTokens = 0;
+
   const now = new Date();
   const nowUTC = formatUtcTimestamp(now);
   const today = now.toISOString().slice(0, 10);
@@ -401,6 +413,13 @@ ${systemPrompt || ''}
       }
 
       const actualPromptTokens = completion.usage?.prompt_tokens;
+      const actualCompletionTokens = completion.usage?.completion_tokens;
+      if (actualPromptTokens) {
+        totalPromptTokens += actualPromptTokens;
+      }
+      if (actualCompletionTokens) {
+        totalCompletionTokens += actualCompletionTokens;
+      }
       if (actualPromptTokens && actualPromptTokens > 0) {
         // Array content (multimodal turns): count the text part, not the media
         // — otherwise calibration learns an inflated multiplier from media turns.
@@ -521,6 +540,9 @@ ${systemPrompt || ''}
     if (!cleanedText && finalText.trim()) {
       cleanedText = 'I gathered search results but ran out of tool calls before I could finish. Try asking again or narrowing the question.';
     }
+    if (db && userId && (totalPromptTokens > 0 || totalCompletionTokens > 0)) {
+      await db.aiUsage.addUsage(userId, model, totalPromptTokens, totalCompletionTokens);
+    }
     return { text: cleanedText, images: generatedImages, toolCalls };
   }
 
@@ -611,6 +633,10 @@ ${systemPrompt || ''}
 
       for (let iter = 0; iter < MAX_TOOL_ITERATIONS + 1; iter += 1) {
         const response = await result.response;
+        if (response.usageMetadata) {
+          totalPromptTokens += response.usageMetadata.promptTokenCount ?? 0;
+          totalCompletionTokens += response.usageMetadata.candidatesTokenCount ?? 0;
+        }
         const fnCalls = typeof response.functionCalls === 'function'
           ? (response.functionCalls() ?? [])
           : [];
@@ -696,6 +722,9 @@ ${systemPrompt || ''}
         result = await chatSession.sendMessage(fnResponses);
       }
 
+      if (db && userId && (totalPromptTokens > 0 || totalCompletionTokens > 0)) {
+        await db.aiUsage.addUsage(userId, model, totalPromptTokens, totalCompletionTokens);
+      }
       return { text: fullText, images: generatedImages, toolCalls };
     }
 
@@ -744,6 +773,18 @@ ${systemPrompt || ''}
           }
         });
       }
+    }
+    try {
+      const finalResponse = await resultObject.response;
+      if (finalResponse.usageMetadata) {
+        totalPromptTokens = finalResponse.usageMetadata.promptTokenCount ?? 0;
+        totalCompletionTokens = finalResponse.usageMetadata.candidatesTokenCount ?? 0;
+      }
+    } catch {
+      // Ignored
+    }
+    if (db && userId && (totalPromptTokens > 0 || totalCompletionTokens > 0)) {
+      await db.aiUsage.addUsage(userId, model, totalPromptTokens, totalCompletionTokens);
     }
     return { text: fullText, images: imageAttachments, toolCalls: [] };
   }

--- a/utils/ai.ts
+++ b/utils/ai.ts
@@ -1,6 +1,7 @@
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { OpenAI } from 'openai';
 import mime from 'mime';
+import type Database from '../database/Database';
 import { logError, logWarning } from './log';
 import { recordUsage } from './tokenCalibration';
 import { countTokensOpenRouterMessages } from './tokenizer';
@@ -168,8 +169,11 @@ export function formatHistoryEntryForModel(entry: Pick<HistoryEntry, 'role' | 'm
   return stripModelTimestampPrefix(entry.message);
 }
 
+export const DAILY_LIMIT = 250000;
+export const WEEKLY_LIMIT = 1000000;
+
 interface GenerateContentOptions {
-  db?: any;
+  db?: Database;
   userId?: string;
   provider: string;
   model: string;
@@ -541,7 +545,11 @@ ${systemPrompt || ''}
       cleanedText = 'I gathered search results but ran out of tool calls before I could finish. Try asking again or narrowing the question.';
     }
     if (db && userId && (totalPromptTokens > 0 || totalCompletionTokens > 0)) {
-      await db.aiUsage.addUsage(userId, model, totalPromptTokens, totalCompletionTokens);
+      try {
+        await db.aiUsage.addUsage(userId, model, totalPromptTokens, totalCompletionTokens);
+      } catch (err) {
+        logError('Failed to record AI usage (OpenRouter):', err);
+      }
     }
     return { text: cleanedText, images: generatedImages, toolCalls };
   }
@@ -723,7 +731,11 @@ ${systemPrompt || ''}
       }
 
       if (db && userId && (totalPromptTokens > 0 || totalCompletionTokens > 0)) {
-        await db.aiUsage.addUsage(userId, model, totalPromptTokens, totalCompletionTokens);
+        try {
+          await db.aiUsage.addUsage(userId, model, totalPromptTokens, totalCompletionTokens);
+        } catch (err) {
+          logError('Failed to record AI usage (Gemini Chat):', err);
+        }
       }
       return { text: fullText, images: generatedImages, toolCalls };
     }
@@ -784,7 +796,11 @@ ${systemPrompt || ''}
       // Ignored
     }
     if (db && userId && (totalPromptTokens > 0 || totalCompletionTokens > 0)) {
-      await db.aiUsage.addUsage(userId, model, totalPromptTokens, totalCompletionTokens);
+      try {
+        await db.aiUsage.addUsage(userId, model, totalPromptTokens, totalCompletionTokens);
+      } catch (err) {
+        logError('Failed to record AI usage (Gemini Image/Fallback):', err);
+      }
     }
     return { text: fullText, images: imageAttachments, toolCalls: [] };
   }

--- a/utils/discordRateLimit.ts
+++ b/utils/discordRateLimit.ts
@@ -1,0 +1,21 @@
+import type { ChatInputCommandInteraction } from 'discord.js';
+import type Database from '../database/Database';
+import { DAILY_LIMIT, WEEKLY_LIMIT } from './ai';
+
+export async function handleRateLimitError(
+  interaction: ChatInputCommandInteraction,
+  db: Database,
+): Promise<void> {
+  const userId = interaction.user.id;
+  const dailyUsage = await db.aiUsage.getDailyUsage(userId);
+  const weeklyUsage = await db.aiUsage.getWeeklyUsage(userId);
+  const reachedDaily = dailyUsage >= DAILY_LIMIT;
+
+  const limitLabel = reachedDaily ? 'Daily' : 'Weekly';
+  const usageVal = reachedDaily ? dailyUsage : weeklyUsage;
+  const limitVal = reachedDaily ? DAILY_LIMIT : WEEKLY_LIMIT;
+
+  await interaction.editReply({
+    content: `⚠️ **${limitLabel} AI Rate Limit Reached**\nYou have consumed **${usageVal.toLocaleString()}** / **${limitVal.toLocaleString()}** tokens in the last ${reachedDaily ? '24 hours' : '7 days'}. Please wait for your token pool to cool down.`,
+  });
+}

--- a/utils/discordRateLimit.ts
+++ b/utils/discordRateLimit.ts
@@ -2,11 +2,7 @@ import type { ChatInputCommandInteraction } from 'discord.js';
 import type Database from '../database/Database';
 import { DAILY_LIMIT, WEEKLY_LIMIT } from './ai';
 
-export async function handleRateLimitError(
-  interaction: ChatInputCommandInteraction,
-  db: Database,
-): Promise<void> {
-  const userId = interaction.user.id;
+export async function getRateLimitErrorMessage(userId: string, db: Database): Promise<string> {
   const dailyUsage = await db.aiUsage.getDailyUsage(userId);
   const weeklyUsage = await db.aiUsage.getWeeklyUsage(userId);
   const reachedDaily = dailyUsage >= DAILY_LIMIT;
@@ -15,7 +11,15 @@ export async function handleRateLimitError(
   const usageVal = reachedDaily ? dailyUsage : weeklyUsage;
   const limitVal = reachedDaily ? DAILY_LIMIT : WEEKLY_LIMIT;
 
+  return `⚠️ **${limitLabel} AI Rate Limit Reached**\nYou have consumed **${usageVal.toLocaleString()}** / **${limitVal.toLocaleString()}** tokens in the last ${reachedDaily ? '24 hours' : '7 days'}. Please wait for your token pool to cool down.`;
+}
+
+export async function handleRateLimitError(
+  interaction: ChatInputCommandInteraction,
+  db: Database,
+): Promise<void> {
+  const content = await getRateLimitErrorMessage(interaction.user.id, db);
   await interaction.editReply({
-    content: `⚠️ **${limitLabel} AI Rate Limit Reached**\nYou have consumed **${usageVal.toLocaleString()}** / **${limitVal.toLocaleString()}** tokens in the last ${reachedDaily ? '24 hours' : '7 days'}. Please wait for your token pool to cool down.`,
+    content,
   });
 }

--- a/utils/rpChat.ts
+++ b/utils/rpChat.ts
@@ -70,6 +70,7 @@ export interface RpSpawnState {
 export interface RpHistoryTurn {
   id: number;
   role: 'user' | 'model';
+  speakerId?: string | null;
   speakerName: string | null;
   message: string;
   fromBot: boolean;
@@ -157,7 +158,10 @@ function estimateTokens(systemPrompt: string, tail: RpHistoryTurn[]): number {
   return countTokensOpenRouterMessages(msgs);
 }
 
-async function callDeepseek(messages: ChatMessage[], maxTokens: number): Promise<string> {
+async function callDeepseek(
+  messages: ChatMessage[],
+  maxTokens: number,
+): Promise<{ text: string; promptTokens: number; completionTokens: number }> {
   if (!process.env.OPENROUTER_API_KEY) {
     throw new Error('OPENROUTER_API_KEY is not set');
   }
@@ -168,7 +172,10 @@ async function callDeepseek(messages: ChatMessage[], maxTokens: number): Promise
     max_tokens: maxTokens + RP_REASONING_HEADROOM,
     reasoning: { enabled: true },
   } as any);
-  return completion.choices?.[0]?.message?.content ?? '';
+  const text = completion.choices?.[0]?.message?.content ?? '';
+  const promptTokens = completion.usage?.prompt_tokens ?? 0;
+  const completionTokens = completion.usage?.completion_tokens ?? 0;
+  return { text, promptTokens, completionTokens };
 }
 
 /** Drops oldest rows until the tail fits the truncation target, keeping the newest. */
@@ -243,10 +250,11 @@ Output ONLY the updated memory wrapped exactly as ${MEMORY_OPEN}...${MEMORY_CLOS
 
   let raw = '';
   try {
-    raw = await callDeepseek(
+    const res = await callDeepseek(
       [{ role: 'system', content: systemPrompt }, { role: 'user', content: userPrompt }],
       4096,
     );
+    raw = res.text;
   } catch (err) {
     logError(`Rp: compaction request failed for spawn ${spawnId}:`, err);
     return { ok: false };
@@ -265,7 +273,7 @@ Output ONLY the updated memory wrapped exactly as ${MEMORY_OPEN}...${MEMORY_CLOS
 
 export type RpReplyResult =
   | { ok: true; text: string }
-  | { ok: false; reason: 'compaction_failed' }
+  | { ok: false; reason: 'compaction_failed' | 'rate_limited' }
   | { ok: false; reason: 'error' };
 
 async function loadTail(db: any, spawnId: number, afterId: number): Promise<RpHistoryTurn[]> {
@@ -273,6 +281,7 @@ async function loadTail(db: any, spawnId: number, afterId: number): Promise<RpHi
   return rows.map((r: any) => ({
     id: r.id,
     role: r.role,
+    speakerId: r.speakerId ?? null,
     speakerName: r.speakerName ?? null,
     message: r.message,
     fromBot: r.fromBot === 1,
@@ -329,6 +338,26 @@ export async function generateRpReply(
     let uptoId = spawn.compactedUptoId ?? 0;
     let tail = await loadTail(db, spawn.spawnId, uptoId);
 
+    // Identify triggering user (last human turn author in tail) and check rate limit
+    let lastUserTurn: RpHistoryTurn | undefined;
+    for (let i = tail.length - 1; i >= 0; i--) {
+      const t = tail[i];
+      if (t.role === 'user' && !t.fromBot) {
+        lastUserTurn = t;
+        break;
+      }
+    }
+    const triggeringUserId = lastUserTurn?.speakerId;
+    if (triggeringUserId) {
+      const isLimited = await db.aiUsage.isRateLimited(triggeringUserId);
+      if (isLimited) {
+        return { ok: false, reason: 'rate_limited' };
+      }
+    }
+
+    let totalPromptTokens = 0;
+    let totalCompletionTokens = 0;
+
     let lorebooks: any[] = [];
     try {
       lorebooks = await db.rp.getLorebooksByChar(character.charId);
@@ -377,7 +406,10 @@ export async function generateRpReply(
         { role: 'system', content: prompt },
         ...tail.map(turnToMessage),
       ];
-      return (await callDeepseek(messages, RP_MAX_OUTPUT)).trim();
+      const res = await callDeepseek(messages, RP_MAX_OUTPUT);
+      totalPromptTokens += res.promptTokens;
+      totalCompletionTokens += res.completionTokens;
+      return res.text.trim();
     };
 
     let text = await generate(systemPrompt);
@@ -422,6 +454,20 @@ export async function generateRpReply(
     }
 
     if (!text) return { ok: false, reason: 'error' };
+
+    // Log AI usage for all active human users involved in the tail
+    const activeUsers = [...new Set(
+      tail
+        .filter((t) => t.role === 'user' && !t.fromBot && t.speakerId)
+        .map((t) => t.speakerId!)
+    )];
+    if (activeUsers.length === 0 && triggeringUserId) {
+      activeUsers.push(triggeringUserId);
+    }
+    for (const userId of activeUsers) {
+      await db.aiUsage.addUsage(userId, RP_MODEL, totalPromptTokens, totalCompletionTokens);
+    }
+
     return { ok: true, text };
   } catch (err) {
     logError(`Rp: generation failed for spawn ${spawn.spawnId}:`, err);

--- a/utils/rpChat.ts
+++ b/utils/rpChat.ts
@@ -340,7 +340,7 @@ export async function generateRpReply(
 
     // Identify triggering user (last human turn author in tail) and check rate limit
     let lastUserTurn: RpHistoryTurn | undefined;
-    for (let i = tail.length - 1; i >= 0; i--) {
+    for (let i = tail.length - 1; i >= 0; i -= 1) {
       const t = tail[i];
       if (t.role === 'user' && !t.fromBot) {
         lastUserTurn = t;
@@ -459,7 +459,7 @@ export async function generateRpReply(
     const activeUsers = [...new Set(
       tail
         .filter((t) => t.role === 'user' && !t.fromBot && t.speakerId)
-        .map((t) => t.speakerId!)
+        .map((t) => t.speakerId!),
     )];
     if (activeUsers.length === 0 && triggeringUserId) {
       activeUsers.push(triggeringUserId);

--- a/utils/rpRuntime.ts
+++ b/utils/rpRuntime.ts
@@ -195,6 +195,13 @@ async function respondAsCharacter(
     // Generation failed — clear the dangling "typing…" before surfacing anything.
     if (typing) await deleteCharacterPlaceholder(typing);
 
+    if (result.reason === 'rate_limited') {
+      const notice = `⚠️ **${row.charName}** cannot respond because the triggering user has exceeded their AI usage limit (daily or weekly).`;
+      if (opts.notify) await opts.notify(notice);
+      else await channel.send({ content: notice, allowedMentions: { parse: [] } }).catch(() => {});
+      return;
+    }
+
     if (result.reason === 'compaction_failed') {
       const notice = `⚠️ **${row.charName}** has run out of context and automatic compaction failed. `
         + 'Mention them again to retry — if it keeps failing the oldest messages will be dropped instead.';
@@ -335,7 +342,16 @@ export async function runProactiveRpTick(client: any): Promise<void> {
     for (const s of list) {
       // eslint-disable-next-line no-await-in-loop
       const hasUnanswered = await db.rp.hasUnansweredHumanTurn(s.spawnId);
-      if (hasUnanswered) candidates.push(s);
+      if (hasUnanswered) {
+        const lastSpeaker = await db.rp.getLastHumanSpeaker(s.spawnId);
+        if (lastSpeaker) {
+          const isLimited = await db.aiUsage.isRateLimited(lastSpeaker);
+          if (isLimited) {
+            continue;
+          }
+        }
+        candidates.push(s);
+      }
     }
     if (candidates.length === 0) continue;
 


### PR DESCRIPTION
Implement a dual daily & weekly token-based rate limiter for text AI calls (daily cap: 250,000 tokens, weekly cap: 1,000,000 tokens).

### Changes
- Created `AiUsage` table, queries, and model class.
- Added rolling sums calculation for daily and weekly windows.
- Integrated rate checks inside `generateContent` for both OpenRouter and Gemini providers.
- Implemented multi-user cost-sharing mechanics inside character roleplay chats.
- Exposed daily/weekly status meters inside `/ask-silverwolf-ai`, `/profile` categories, and Hono web dashboard `/me`.
- Created unit tests verifying all rate limiting scenarios (8/8 tests pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI token usage tracking (daily + weekly) with rate-limit status shown in profile/dashboard and a new collapsible **AI Usage** area.
  * Added an `ai usage` command that displays daily/weekly token usage with progress-style bars.
* **Bug Fixes**
  * Improved “rate limit exceeded” handling across chat commands and the AI slop endpoint, including clearer daily vs weekly cooldown messaging.
  * Updated roleplay rate limiting to use the most recent human speaker and show a dedicated notice when responses are blocked.
* **Tests**
  * Added automated coverage for AI usage aggregation and rate-limit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->