### PR TITLE
feat: Claude-style fixed-window AI rate limit with reset timestamp

### DIFF
--- a/commands/ai_usage.ts
+++ b/commands/ai_usage.ts
@@ -1,7 +1,7 @@
 import * as Discord from 'discord.js';
 import { Command } from './classes/Command';
 import { DAILY_LIMIT, WEEKLY_LIMIT } from '../utils/ai';
-import { formatResetTimestamp } from '../utils/discordRateLimit';
+import { getResetLine } from '../utils/discordRateLimit';
 
 function makeProgressBar(value: number, total: number, size = 15): string {
   const percentage = Math.min(Math.max(value / total, 0), 1);
@@ -36,10 +36,7 @@ class AiUsageSubcommand extends Command {
         ? `🛑 **Rate Limited** (${status.reason === 'daily' ? 'Daily' : 'Weekly'} limit exceeded)`
         : '✅ **Active** (within limits)';
 
-      const resetAt = status.limited && status.reason
-        ? await this.client.db.aiUsage.getResetAt(userId, status.reason)
-        : null;
-      const resetLine = resetAt ? `\n**Resets:** ${formatResetTimestamp(resetAt)}` : '';
+      const resetLine = await getResetLine(this.client.db, userId, status);
 
       const embed = new Discord.EmbedBuilder()
         .setColor('#0099ff')

--- a/commands/ai_usage.ts
+++ b/commands/ai_usage.ts
@@ -34,12 +34,12 @@ class AiUsageSubcommand extends Command {
 
       const statusText = status.limited
         ? `🛑 **Rate Limited** (${status.reason === 'daily' ? 'Daily' : 'Weekly'} limit exceeded)`
-        : '✅ **Active** (Pool is cool)';
+        : '✅ **Active** (within limits)';
 
       const resetAt = status.limited && status.reason
         ? await this.client.db.aiUsage.getResetAt(userId, status.reason)
         : null;
-      const resetLine = resetAt ? `\n**Cools Down:** ${formatResetTimestamp(resetAt)}` : '';
+      const resetLine = resetAt ? `\n**Resets:** ${formatResetTimestamp(resetAt)}` : '';
 
       const embed = new Discord.EmbedBuilder()
         .setColor('#0099ff')

--- a/commands/ai_usage.ts
+++ b/commands/ai_usage.ts
@@ -1,6 +1,7 @@
 import * as Discord from 'discord.js';
 import { Command } from './classes/Command';
 import { DAILY_LIMIT, WEEKLY_LIMIT } from '../utils/ai';
+import { formatResetTimestamp } from '../utils/discordRateLimit';
 
 function makeProgressBar(value: number, total: number, size = 15): string {
   const percentage = Math.min(Math.max(value / total, 0), 1);
@@ -15,7 +16,6 @@ class AiUsageSubcommand extends Command {
   constructor(client: any) {
     super(client, 'usage', 'View your AI token usage and limits', [], {
       isSubcommandOf: 'ai',
-      ephemeral: true,
       blame: 'xei',
     });
   }
@@ -36,6 +36,11 @@ class AiUsageSubcommand extends Command {
         ? `🛑 **Rate Limited** (${status.reason === 'daily' ? 'Daily' : 'Weekly'} limit exceeded)`
         : '✅ **Active** (Pool is cool)';
 
+      const resetAt = status.limited && status.reason
+        ? await this.client.db.aiUsage.getResetAt(userId, status.reason)
+        : null;
+      const resetLine = resetAt ? `\n**Cools Down:** ${formatResetTimestamp(resetAt)}` : '';
+
       const embed = new Discord.EmbedBuilder()
         .setColor('#0099ff')
         .setTitle('🤖 Your AI Token Usage')
@@ -49,7 +54,7 @@ ${dailyBar}
 ${weeklyUsage.toLocaleString()} / ${WEEKLY_LIMIT.toLocaleString()} tokens
 ${weeklyBar}
 
-**Status:** ${statusText}
+**Status:** ${statusText}${resetLine}
         `)
         .setFooter({ text: 'Note: AI roleplay cost is shared among active users in the chat.' })
         .setTimestamp();

--- a/commands/profile.ts
+++ b/commands/profile.ts
@@ -7,7 +7,7 @@ import {
   getNuggiePokeMultiplier, getNuggieNuggieMultiplier,
 } from '../utils/ascensionupgrades';
 import { DAILY_LIMIT, WEEKLY_LIMIT } from '../utils/ai';
-import { formatResetTimestamp } from '../utils/discordRateLimit';
+import { getResetLine } from '../utils/discordRateLimit';
 import {
   getMultiplierAmountInfo,
   getMultiplierChanceInfo,
@@ -336,10 +336,7 @@ ${getNuggieNuggieMultiplierInfo(user.nuggieNuggieMultiplierLevel, INFO_LEVEL.THI
       ? `🛑 **Rate Limited** (${status.reason === 'daily' ? 'Daily' : 'Weekly'} limit exceeded)`
       : '✅ **Active** (within limits)';
 
-    const resetAt = status.limited && status.reason
-      ? await this.client.db.aiUsage.getResetAt(userId, status.reason)
-      : null;
-    const resetLine = resetAt ? `\n**Resets:** ${formatResetTimestamp(resetAt)}` : '';
+    const resetLine = await getResetLine(this.client.db, userId, status);
 
     return new Discord.EmbedBuilder()
       .setColor('#0099ff')

--- a/commands/profile.ts
+++ b/commands/profile.ts
@@ -7,6 +7,7 @@ import {
   getNuggiePokeMultiplier, getNuggieNuggieMultiplier,
 } from '../utils/ascensionupgrades';
 import { DAILY_LIMIT, WEEKLY_LIMIT } from '../utils/ai';
+import { formatResetTimestamp } from '../utils/discordRateLimit';
 import {
   getMultiplierAmountInfo,
   getMultiplierChanceInfo,
@@ -335,6 +336,11 @@ ${getNuggieNuggieMultiplierInfo(user.nuggieNuggieMultiplierLevel, INFO_LEVEL.THI
       ? `🛑 **Rate Limited** (${status.reason === 'daily' ? 'Daily' : 'Weekly'} limit exceeded)`
       : '✅ **Active** (Pool is cool)';
 
+    const resetAt = status.limited && status.reason
+      ? await this.client.db.aiUsage.getResetAt(userId, status.reason)
+      : null;
+    const resetLine = resetAt ? `\n**Cools Down:** ${formatResetTimestamp(resetAt)}` : '';
+
     return new Discord.EmbedBuilder()
       .setColor('#0099ff')
       .setTitle(`${username}'s Profile`)
@@ -343,7 +349,7 @@ ${getNuggieNuggieMultiplierInfo(user.nuggieNuggieMultiplierLevel, INFO_LEVEL.THI
 ## AI Usage
 **Daily Usage (24h):** ${dailyUsage.toLocaleString()} / ${DAILY_LIMIT.toLocaleString()} tokens
 **Weekly Usage (7d):** ${weeklyUsage.toLocaleString()} / ${WEEKLY_LIMIT.toLocaleString()} tokens
-**Status:** ${statusText}
+**Status:** ${statusText}${resetLine}
       `)
       .setTimestamp();
   }

--- a/commands/profile.ts
+++ b/commands/profile.ts
@@ -334,12 +334,12 @@ ${getNuggieNuggieMultiplierInfo(user.nuggieNuggieMultiplierLevel, INFO_LEVEL.THI
     ]);
     const statusText = status.limited
       ? `🛑 **Rate Limited** (${status.reason === 'daily' ? 'Daily' : 'Weekly'} limit exceeded)`
-      : '✅ **Active** (Pool is cool)';
+      : '✅ **Active** (within limits)';
 
     const resetAt = status.limited && status.reason
       ? await this.client.db.aiUsage.getResetAt(userId, status.reason)
       : null;
-    const resetLine = resetAt ? `\n**Cools Down:** ${formatResetTimestamp(resetAt)}` : '';
+    const resetLine = resetAt ? `\n**Resets:** ${formatResetTimestamp(resetAt)}` : '';
 
     return new Discord.EmbedBuilder()
       .setColor('#0099ff')

--- a/database/models/AiUsageModel.ts
+++ b/database/models/AiUsageModel.ts
@@ -3,6 +3,14 @@ import aiUsageQueries from '../queries/aiUsageQueries';
 import { isUserDev } from '../../utils/accessControl';
 import { DAILY_LIMIT, WEEKLY_LIMIT } from '../../utils/ai';
 
+type WindowType = 'daily' | 'weekly';
+
+/** SQLite datetime modifiers per window: `pos` extends a window, `neg` tests if it's still open. */
+const WINDOW_INTERVALS: Record<WindowType, { pos: string; neg: string }> = {
+  daily: { pos: '+1 day', neg: '-1 day' },
+  weekly: { pos: '+7 days', neg: '-7 days' },
+};
+
 class AiUsageModel {
   private db: Database;
 
@@ -20,62 +28,57 @@ class AiUsageModel {
     // Ensure user exists in User table
     await this.db.user.getUser(userId);
 
-    const result = await this.db.executeQuery(aiUsageQueries.ADD_USAGE, [
-      userId,
-      model,
-      promptTokens,
-      completionTokens,
-      cost,
-    ]);
+    const total = promptTokens + completionTokens;
 
-    if (!result || result.changes === 0) {
-      throw new Error('Failed to record AI usage in the database');
+    // Log the call (audit) and fold its tokens into both fixed windows atomically.
+    await this.db.executeTransaction((rawDb) => {
+      const logResult = rawDb.query(aiUsageQueries.ADD_USAGE)
+        .run(userId, model, promptTokens, completionTokens, cost);
+      if (!logResult || logResult.changes === 0) {
+        throw new Error('Failed to record AI usage in the database');
+      }
+      (Object.keys(WINDOW_INTERVALS) as WindowType[]).forEach((type) => {
+        const { pos } = WINDOW_INTERVALS[type];
+        rawDb.query(aiUsageQueries.UPSERT_WINDOW).run(userId, type, total, pos, pos);
+      });
+    });
+  }
+
+  /** Tokens used in the current fixed window (0 once it has lapsed) and when it resets. */
+  private async getWindow(userId: string, type: WindowType): Promise<{ tokens: number; resetAt: Date | null }> {
+    const { pos, neg } = WINDOW_INTERVALS[type];
+    const row = await this.db.executeSelectQuery(aiUsageQueries.GET_WINDOW, [neg, neg, pos, userId, type]);
+    const tokens = typeof row?.tokens === 'number' ? row.tokens : 0;
+
+    let resetAt: Date | null = null;
+    if (row?.resetAt) {
+      // SQLite datetime() returns UTC "YYYY-MM-DD HH:MM:SS"; make it ISO-parseable.
+      const date = new Date(`${String(row.resetAt).replace(' ', 'T')}Z`);
+      if (!Number.isNaN(date.getTime())) resetAt = date;
     }
+    return { tokens, resetAt };
   }
 
   async getDailyUsage(userId: string): Promise<number> {
-    const row = await this.db.executeSelectQuery(aiUsageQueries.GET_DAILY_USAGE, [userId]);
-    if (row === null) {
-      throw new Error('Database query failed while fetching daily usage');
-    }
-    return row.total ?? 0;
+    return (await this.getWindow(userId, 'daily')).tokens;
   }
 
   async getWeeklyUsage(userId: string): Promise<number> {
-    const row = await this.db.executeSelectQuery(aiUsageQueries.GET_WEEKLY_USAGE, [userId]);
-    if (row === null) {
-      throw new Error('Database query failed while fetching weekly usage');
-    }
-    return row.total ?? 0;
+    return (await this.getWindow(userId, 'weekly')).tokens;
   }
 
   /**
-   * When a rolling-window limit will clear for a user. Usage is a trailing sum
-   * (24h / 7d), so the limit lifts as the oldest entries age out — this returns
-   * the moment the windowed sum first drops back below the limit, or `null` if
-   * the user is not currently over that limit.
+   * When the given fixed window resets (its start + interval), or `null` when no
+   * window is currently open. Under a fixed window a rate-limited user stays
+   * limited until exactly this instant, when the counter clears wholesale.
    */
-  async getResetAt(userId: string, reason: 'daily' | 'weekly'): Promise<Date | null> {
-    const usage = reason === 'daily'
-      ? await this.getDailyUsage(userId)
-      : await this.getWeeklyUsage(userId);
-    const limit = reason === 'daily' ? DAILY_LIMIT : WEEKLY_LIMIT;
-    if (usage < limit) return null;
-
-    const query = reason === 'daily'
-      ? aiUsageQueries.GET_DAILY_RESET_AT
-      : aiUsageQueries.GET_WEEKLY_RESET_AT;
-    const row = await this.db.executeSelectQuery(query, [userId, usage - limit]);
-    if (!row?.resetAt) return null;
-
-    // SQLite datetime() returns UTC "YYYY-MM-DD HH:MM:SS"; make it ISO-parseable.
-    const date = new Date(`${String(row.resetAt).replace(' ', 'T')}Z`);
-    return Number.isNaN(date.getTime()) ? null : date;
+  async getResetAt(userId: string, reason: WindowType): Promise<Date | null> {
+    return (await this.getWindow(userId, reason)).resetAt;
   }
 
   async checkRateLimit(userId: string): Promise<{
     limited: boolean;
-    reason?: 'daily' | 'weekly';
+    reason?: WindowType;
     usage?: number;
     limit?: number;
   }> {

--- a/database/models/AiUsageModel.ts
+++ b/database/models/AiUsageModel.ts
@@ -49,6 +49,30 @@ class AiUsageModel {
     return row.total ?? 0;
   }
 
+  /**
+   * When a rolling-window limit will clear for a user. Usage is a trailing sum
+   * (24h / 7d), so the limit lifts as the oldest entries age out — this returns
+   * the moment the windowed sum first drops back below the limit, or `null` if
+   * the user is not currently over that limit.
+   */
+  async getResetAt(userId: string, reason: 'daily' | 'weekly'): Promise<Date | null> {
+    const usage = reason === 'daily'
+      ? await this.getDailyUsage(userId)
+      : await this.getWeeklyUsage(userId);
+    const limit = reason === 'daily' ? DAILY_LIMIT : WEEKLY_LIMIT;
+    if (usage < limit) return null;
+
+    const query = reason === 'daily'
+      ? aiUsageQueries.GET_DAILY_RESET_AT
+      : aiUsageQueries.GET_WEEKLY_RESET_AT;
+    const row = await this.db.executeSelectQuery(query, [userId, usage - limit]);
+    if (!row?.resetAt) return null;
+
+    // SQLite datetime() returns UTC "YYYY-MM-DD HH:MM:SS"; make it ISO-parseable.
+    const date = new Date(`${String(row.resetAt).replace(' ', 'T')}Z`);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
   async checkRateLimit(userId: string): Promise<{
     limited: boolean;
     reason?: 'daily' | 'weekly';

--- a/database/queries/aiUsageQueries.ts
+++ b/database/queries/aiUsageQueries.ts
@@ -1,43 +1,41 @@
 const aiUsageQueries = {
+  // Immutable per-call audit log (per-model tokens + cost). Enforcement no longer
+  // reads this — it uses the AiRateLimitWindow counter below — but it's kept for
+  // history/cost accounting.
   ADD_USAGE: `
     INSERT INTO AiUsage (user_id, model, tokens_prompt, tokens_completion, cost)
     VALUES (?, ?, ?, ?, ?)
   `,
-  GET_DAILY_USAGE: `
-    SELECT COALESCE(SUM(tokens_prompt + tokens_completion), 0) AS total
-    FROM AiUsage
-    WHERE user_id = ? AND created_at > datetime('now', '-1 day')
+  // Fixed-window (Claude-style) rate-limit counter. A window opens on the first
+  // message after the previous one lapsed and resets wholesale one interval later.
+  // On conflict: if the stored window has lapsed (now >= window_start + interval),
+  // open a fresh window at `now` seeded with this call's tokens; otherwise keep the
+  // anchor and accumulate. `?` order: user_id, window_type, tokens, interval, interval
+  // (interval e.g. '+1 day' / '+7 days'). 'now' is fixed within a statement, so all
+  // three references agree.
+  UPSERT_WINDOW: `
+    INSERT INTO AiRateLimitWindow (user_id, window_type, window_start, tokens)
+    VALUES (?, ?, datetime('now'), ?)
+    ON CONFLICT(user_id, window_type) DO UPDATE SET
+      tokens = CASE
+        WHEN datetime('now') >= datetime(window_start, ?) THEN excluded.tokens
+        ELSE tokens + excluded.tokens
+      END,
+      window_start = CASE
+        WHEN datetime('now') >= datetime(window_start, ?) THEN excluded.window_start
+        ELSE window_start
+      END
   `,
-  GET_WEEKLY_USAGE: `
-    SELECT COALESCE(SUM(tokens_prompt + tokens_completion), 0) AS total
-    FROM AiUsage
-    WHERE user_id = ? AND created_at > datetime('now', '-7 days')
-  `,
-  // Rolling-window reset time: usage is a trailing sum, so the limit lifts as the
-  // oldest entries age out. Walking entries oldest→newest, `running` is the
-  // cumulative tokens dropped once that entry exits the window; the limit clears
-  // when enough have dropped that the remainder falls under it — i.e. when the
-  // cumulative exceeds the excess (usage - limit, passed as `?`). The first such
-  // entry's timestamp + the window length is the moment the pool cools down.
-  GET_DAILY_RESET_AT: `
-    SELECT datetime(MIN(created_at), '+1 day') AS reset_at
-    FROM (
-      SELECT created_at,
-        SUM(tokens_prompt + tokens_completion) OVER (ORDER BY created_at) AS running
-      FROM AiUsage
-      WHERE user_id = ? AND created_at > datetime('now', '-1 day')
-    )
-    WHERE running > ?
-  `,
-  GET_WEEKLY_RESET_AT: `
-    SELECT datetime(MIN(created_at), '+7 days') AS reset_at
-    FROM (
-      SELECT created_at,
-        SUM(tokens_prompt + tokens_completion) OVER (ORDER BY created_at) AS running
-      FROM AiUsage
-      WHERE user_id = ? AND created_at > datetime('now', '-7 days')
-    )
-    WHERE running > ?
+  // Current-window tokens (0 once the window has lapsed) and the reset instant
+  // (window_start + interval, NULL when lapsed). A missing row means no window yet.
+  // `?` order: negInterval, negInterval, posInterval, user_id, window_type
+  // (negInterval e.g. '-1 day' / '-7 days'; posInterval '+1 day' / '+7 days').
+  GET_WINDOW: `
+    SELECT
+      CASE WHEN window_start > datetime('now', ?) THEN tokens ELSE 0 END AS tokens,
+      CASE WHEN window_start > datetime('now', ?) THEN datetime(window_start, ?) ELSE NULL END AS reset_at
+    FROM AiRateLimitWindow
+    WHERE user_id = ? AND window_type = ?
   `,
   CREATE_INDEX_USER_CREATED: `
     CREATE INDEX IF NOT EXISTS idx_aiusage_user_created ON AiUsage (user_id, created_at)

--- a/database/queries/aiUsageQueries.ts
+++ b/database/queries/aiUsageQueries.ts
@@ -13,6 +13,32 @@ const aiUsageQueries = {
     FROM AiUsage
     WHERE user_id = ? AND created_at > datetime('now', '-7 days')
   `,
+  // Rolling-window reset time: usage is a trailing sum, so the limit lifts as the
+  // oldest entries age out. Walking entries oldest→newest, `running` is the
+  // cumulative tokens dropped once that entry exits the window; the limit clears
+  // when enough have dropped that the remainder falls under it — i.e. when the
+  // cumulative exceeds the excess (usage - limit, passed as `?`). The first such
+  // entry's timestamp + the window length is the moment the pool cools down.
+  GET_DAILY_RESET_AT: `
+    SELECT datetime(MIN(created_at), '+1 day') AS reset_at
+    FROM (
+      SELECT created_at,
+        SUM(tokens_prompt + tokens_completion) OVER (ORDER BY created_at) AS running
+      FROM AiUsage
+      WHERE user_id = ? AND created_at > datetime('now', '-1 day')
+    )
+    WHERE running > ?
+  `,
+  GET_WEEKLY_RESET_AT: `
+    SELECT datetime(MIN(created_at), '+7 days') AS reset_at
+    FROM (
+      SELECT created_at,
+        SUM(tokens_prompt + tokens_completion) OVER (ORDER BY created_at) AS running
+      FROM AiUsage
+      WHERE user_id = ? AND created_at > datetime('now', '-7 days')
+    )
+    WHERE running > ?
+  `,
   CREATE_INDEX_USER_CREATED: `
     CREATE INDEX IF NOT EXISTS idx_aiusage_user_created ON AiUsage (user_id, created_at)
   `,

--- a/database/tables/aiRateLimitWindowTable.ts
+++ b/database/tables/aiRateLimitWindowTable.ts
@@ -1,0 +1,38 @@
+import type { TableDefinition } from '../types';
+
+export interface AiRateLimitWindowRow {
+  id: number;
+  user_id: string;
+  /** 'daily' | 'weekly' — one fixed window per type per user. */
+  window_type: string;
+  /** SQLite datetime (UTC) when the current window opened (its first message). */
+  window_start: string;
+  /** Tokens accumulated in the current window. */
+  tokens: number;
+}
+
+/**
+ * Backs the fixed-window (Claude-style) AI rate limit: a window opens on the
+ * first message after the previous one lapsed and resets wholesale one interval
+ * later, so a stored counter — not a trailing sum of the AiUsage log — drives
+ * enforcement. One row per (user, window_type); the AiUsage table remains the
+ * immutable per-call audit log.
+ */
+const aiRateLimitWindowTable: TableDefinition = {
+  name: 'AiRateLimitWindow',
+  columns: [
+    { name: 'id', type: 'INTEGER PRIMARY KEY AUTOINCREMENT' },
+    { name: 'user_id', type: 'TEXT NOT NULL' },
+    { name: 'window_type', type: 'TEXT NOT NULL' },
+    { name: 'window_start', type: 'TIMESTAMP NOT NULL' },
+    { name: 'tokens', type: 'INTEGER NOT NULL DEFAULT 0' },
+  ],
+  primaryKey: ['id'],
+  specialConstraints: [],
+  constraints: [
+    // Enables the ON CONFLICT upsert in UPSERT_WINDOW.
+    'UNIQUE (user_id, window_type)',
+  ],
+};
+
+export default aiRateLimitWindowTable;

--- a/database/tables/index.ts
+++ b/database/tables/index.ts
@@ -1,5 +1,6 @@
 import aiChatHistoryTable from './aiChatHistoryTable';
 import aiChatSessionTable from './aiChatSessionTable';
+import aiRateLimitWindowTable from './aiRateLimitWindowTable';
 import aiUsageTable from './aiUsageTable';
 import babyTable from './babyTable';
 import battleshipsMatchTable from './battleshipsMatchTable';
@@ -27,6 +28,7 @@ import webSessionTable from './webSessionTable';
 export {
   aiChatHistoryTable,
   aiChatSessionTable,
+  aiRateLimitWindowTable,
   aiUsageTable,
   babyTable,
   battleshipsMatchTable,
@@ -54,6 +56,7 @@ export {
 
 export type { AiChatHistoryRow } from './aiChatHistoryTable';
 export type { AiChatSessionRow } from './aiChatSessionTable';
+export type { AiRateLimitWindowRow } from './aiRateLimitWindowTable';
 export type { AiUsageRow } from './aiUsageTable';
 export type { BabyRow } from './babyTable';
 export type { BattleshipsMatchRow } from './battleshipsMatchTable';

--- a/tests/database/aiUsage.test.ts
+++ b/tests/database/aiUsage.test.ts
@@ -138,6 +138,58 @@ describe('AiUsageModel', () => {
     expect(status.limit).toBe(WEEKLY_LIMIT);
   });
 
+  test('getResetAt returns null when under the limit', async () => {
+    await aiUsageModel.addUsage('u1', 'test-model', 1000, 1000);
+    expect(await aiUsageModel.getResetAt('u1', 'daily')).toBeNull();
+    expect(await aiUsageModel.getResetAt('u1', 'weekly')).toBeNull();
+  });
+
+  test('getResetAt (daily) clears when the oldest over-budget entry ages out', async () => {
+    // 20h ago: 200k. Once this drops out (at 20h-ago + 24h = ~4h from now),
+    // the remaining 100k is under the 250k daily limit.
+    await db.executeQuery(`
+      INSERT INTO AiUsage (user_id, model, tokens_prompt, tokens_completion, cost, created_at)
+      VALUES (?, ?, ?, ?, ?, datetime('now', '-20 hours'))
+    `, ['u1', 'test-model', 200000, 0, 0]);
+    // 5h ago: 100k (stays in the window past the reset).
+    await db.executeQuery(`
+      INSERT INTO AiUsage (user_id, model, tokens_prompt, tokens_completion, cost, created_at)
+      VALUES (?, ?, ?, ?, ?, datetime('now', '-5 hours'))
+    `, ['u1', 'test-model', 100000, 0, 0]);
+
+    expect(await aiUsageModel.getDailyUsage('u1')).toBe(300000);
+
+    const resetAt = await aiUsageModel.getResetAt('u1', 'daily');
+    expect(resetAt).not.toBeNull();
+    // Expected ≈ now + 4h (20h-ago entry + 24h window).
+    const expected = Date.now() + 4 * 60 * 60 * 1000;
+    expect(Math.abs((resetAt as Date).getTime() - expected)).toBeLessThan(2 * 60 * 1000);
+  });
+
+  test('getResetAt (weekly) clears when the oldest over-budget entry ages out', async () => {
+    // Spread 1.05M across the week without tripping the daily limit; weekly is
+    // over by 50k, so the limit lifts once the oldest (6d-ago) entry drops out
+    // at 6d-ago + 7d = ~1 day from now.
+    for (const [ago, tokens] of [
+      ['-6 days', 200000], ['-5 days', 200000], ['-4 days', 200000],
+      ['-3 days', 200000], ['-2 days', 150000], ['-30 hours', 100000],
+    ] as const) {
+      // eslint-disable-next-line no-await-in-loop
+      await db.executeQuery(`
+        INSERT INTO AiUsage (user_id, model, tokens_prompt, tokens_completion, cost, created_at)
+        VALUES (?, ?, ?, ?, ?, datetime('now', ?))
+      `, ['u1', 'test-model', tokens, 0, 0, ago]);
+    }
+
+    expect(await aiUsageModel.getWeeklyUsage('u1')).toBe(1050000);
+
+    const resetAt = await aiUsageModel.getResetAt('u1', 'weekly');
+    expect(resetAt).not.toBeNull();
+    // Expected ≈ now + 1 day (6d-ago entry + 7d window).
+    const expected = Date.now() + 24 * 60 * 60 * 1000;
+    expect(Math.abs((resetAt as Date).getTime() - expected)).toBeLessThan(2 * 60 * 1000);
+  });
+
   test('bypasses rate limit checks for developers', async () => {
     const devId = process.env.ALLOWED_USERS?.split(',')[0];
     if (!devId) {

--- a/tests/database/aiUsage.test.ts
+++ b/tests/database/aiUsage.test.ts
@@ -5,6 +5,19 @@ import Database from '../../database/Database';
 import type AiUsageModel from '../../database/models/AiUsageModel';
 import { DAILY_LIMIT, WEEKLY_LIMIT } from '../../utils/ai';
 
+// Back-dates a user's fixed window so it reads as lapsed — the test-time
+// equivalent of the window's interval elapsing.
+async function lapseWindow(db: Database, userId: string, type: 'daily' | 'weekly') {
+  const ago = type === 'daily' ? '-25 hours' : '-8 days';
+  await db.executeQuery(
+    `
+      UPDATE AiRateLimitWindow SET window_start = datetime('now', ?)
+      WHERE user_id = ? AND window_type = ?
+    `,
+    [ago, userId, type],
+  );
+}
+
 describe('AiUsageModel', () => {
   let db: Database;
   let aiUsageModel: AiUsageModel;
@@ -22,6 +35,7 @@ describe('AiUsageModel', () => {
 
   beforeEach(async () => {
     await db.executeQuery('DELETE FROM AiUsage');
+    await db.executeQuery('DELETE FROM AiRateLimitWindow');
     await db.executeQuery('DELETE FROM User');
   });
 
@@ -32,7 +46,7 @@ describe('AiUsageModel', () => {
     expect(limitStatus.limited).toBe(false);
   });
 
-  test('accumulates daily and weekly usage correctly', async () => {
+  test('accumulates usage within a window', async () => {
     await aiUsageModel.addUsage('u1', 'test-model', 1000, 2000);
     await aiUsageModel.addUsage('u1', 'test-model2', 500, 1500);
 
@@ -48,44 +62,26 @@ describe('AiUsageModel', () => {
     expect(await aiUsageModel.getDailyUsage('u2')).toBe(1000);
   });
 
-  test('excludes daily entries older than 24 hours but includes in weekly', async () => {
-    // 25 hours ago
-    await db.executeQuery(`
-      INSERT INTO AiUsage (user_id, model, tokens_prompt, tokens_completion, cost, created_at)
-      VALUES (?, ?, ?, ?, ?, datetime('now', '-25 hours'))
-    `, ['u1', 'test-model', 10000, 10000, 0]);
+  test('clears the daily window wholesale once it lapses, weekly keeps rolling', async () => {
+    await aiUsageModel.addUsage('u1', 'test-model', 100000, 0);
+    expect(await aiUsageModel.getDailyUsage('u1')).toBe(100000);
+    expect(await aiUsageModel.getWeeklyUsage('u1')).toBe(100000);
 
-    // 2 hours ago
-    await aiUsageModel.addUsage('u1', 'test-model', 2000, 3000);
+    await lapseWindow(db, 'u1', 'daily');
+    expect(await aiUsageModel.getDailyUsage('u1')).toBe(0); // daily reset to zero
+    expect(await aiUsageModel.getWeeklyUsage('u1')).toBe(100000); // weekly still open
 
-    expect(await aiUsageModel.getDailyUsage('u1')).toBe(5000);
-    expect(await aiUsageModel.getWeeklyUsage('u1')).toBe(25000);
+    // The next call opens a fresh daily window rather than resuming the old total.
+    await aiUsageModel.addUsage('u1', 'test-model', 50000, 0);
+    expect(await aiUsageModel.getDailyUsage('u1')).toBe(50000);
+    expect(await aiUsageModel.getWeeklyUsage('u1')).toBe(150000);
   });
 
-  test('excludes weekly entries older than 7 days', async () => {
-    // 8 days ago
-    await db.executeQuery(`
-      INSERT INTO AiUsage (user_id, model, tokens_prompt, tokens_completion, cost, created_at)
-      VALUES (?, ?, ?, ?, ?, datetime('now', '-8 days'))
-    `, ['u1', 'test-model', 50000, 50000, 0]);
-
-    // 3 days ago
-    await db.executeQuery(`
-      INSERT INTO AiUsage (user_id, model, tokens_prompt, tokens_completion, cost, created_at)
-      VALUES (?, ?, ?, ?, ?, datetime('now', '-3 days'))
-    `, ['u1', 'test-model', 20000, 20000, 0]);
-
-    expect(await aiUsageModel.getDailyUsage('u1')).toBe(0);
-    expect(await aiUsageModel.getWeeklyUsage('u1')).toBe(40000);
-  });
-
-  test('triggers daily rate limit when budget exceeded', async () => {
-    // Under limit
+  test('triggers daily rate limit when the window budget is exceeded', async () => {
     await aiUsageModel.addUsage('u1', 'test-model', DAILY_LIMIT - 5000, 0);
     let status = await aiUsageModel.checkRateLimit('u1');
     expect(status.limited).toBe(false);
 
-    // Over limit
     await aiUsageModel.addUsage('u1', 'test-model', 10000, 0);
     status = await aiUsageModel.checkRateLimit('u1');
     expect(status.limited).toBe(true);
@@ -93,100 +89,56 @@ describe('AiUsageModel', () => {
     expect(status.limit).toBe(DAILY_LIMIT);
   });
 
-  test('triggers weekly rate limit when budget exceeded', async () => {
-    // Simulate usage across past 6 days, staying below the 250k daily limit on each day
-    // Day 1 (6 days ago): 200k
-    await db.executeQuery(`
-      INSERT INTO AiUsage (user_id, model, tokens_prompt, tokens_completion, cost, created_at)
-      VALUES (?, ?, ?, ?, ?, datetime('now', '-6 days'))
-    `, ['u1', 'test-model', 200000, 0, 0]);
+  test('daily rate limit clears once the window resets', async () => {
+    await aiUsageModel.addUsage('u1', 'test-model', DAILY_LIMIT, 0);
+    expect((await aiUsageModel.checkRateLimit('u1')).limited).toBe(true);
 
-    // Day 2 (5 days ago): 200k
-    await db.executeQuery(`
-      INSERT INTO AiUsage (user_id, model, tokens_prompt, tokens_completion, cost, created_at)
-      VALUES (?, ?, ?, ?, ?, datetime('now', '-5 days'))
-    `, ['u1', 'test-model', 200000, 0, 0]);
+    await lapseWindow(db, 'u1', 'daily');
+    const status = await aiUsageModel.checkRateLimit('u1');
+    expect(status.limited).toBe(false); // daily cleared; weekly (250k) still under 1M
+  });
 
-    // Day 3 (4 days ago): 200k
-    await db.executeQuery(`
-      INSERT INTO AiUsage (user_id, model, tokens_prompt, tokens_completion, cost, created_at)
-      VALUES (?, ?, ?, ?, ?, datetime('now', '-4 days'))
-    `, ['u1', 'test-model', 200000, 0, 0]);
+  test('weekly rate limit trips independently while daily keeps resetting', async () => {
+    // Five 200k "days": daily is lapsed between each so it never exceeds 250k,
+    // but the weekly window keeps accumulating to 1,000,000.
+    for (let i = 0; i < 5; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await aiUsageModel.addUsage('u1', 'test-model', 200000, 0);
+      // eslint-disable-next-line no-await-in-loop
+      await lapseWindow(db, 'u1', 'daily');
+    }
 
-    // Day 4 (3 days ago): 200k
-    await db.executeQuery(`
-      INSERT INTO AiUsage (user_id, model, tokens_prompt, tokens_completion, cost, created_at)
-      VALUES (?, ?, ?, ?, ?, datetime('now', '-3 days'))
-    `, ['u1', 'test-model', 200000, 0, 0]);
+    expect(await aiUsageModel.getWeeklyUsage('u1')).toBe(1000000);
+    expect(await aiUsageModel.getDailyUsage('u1')).toBe(0);
 
-    // Day 5 (2 days ago): 150k
-    await db.executeQuery(`
-      INSERT INTO AiUsage (user_id, model, tokens_prompt, tokens_completion, cost, created_at)
-      VALUES (?, ?, ?, ?, ?, datetime('now', '-2 days'))
-    `, ['u1', 'test-model', 150000, 0, 0]);
-
-    // Day 6 (30 hours ago): 100k
-    await db.executeQuery(`
-      INSERT INTO AiUsage (user_id, model, tokens_prompt, tokens_completion, cost, created_at)
-      VALUES (?, ?, ?, ?, ?, datetime('now', '-30 hours'))
-    `, ['u1', 'test-model', 100000, 0, 0]);
-
-    // Total so far = 1,050,000. Daily usage = 0.
     const status = await aiUsageModel.checkRateLimit('u1');
     expect(status.limited).toBe(true);
     expect(status.reason).toBe('weekly');
     expect(status.limit).toBe(WEEKLY_LIMIT);
   });
 
-  test('getResetAt returns null when under the limit', async () => {
-    await aiUsageModel.addUsage('u1', 'test-model', 1000, 1000);
+  test('getResetAt is null when no window is open', async () => {
     expect(await aiUsageModel.getResetAt('u1', 'daily')).toBeNull();
     expect(await aiUsageModel.getResetAt('u1', 'weekly')).toBeNull();
+
+    await aiUsageModel.addUsage('u1', 'test-model', 1000, 0);
+    await lapseWindow(db, 'u1', 'daily');
+    expect(await aiUsageModel.getResetAt('u1', 'daily')).toBeNull();
   });
 
-  test('getResetAt (daily) clears when the oldest over-budget entry ages out', async () => {
-    // 20h ago: 200k. Once this drops out (at 20h-ago + 24h = ~4h from now),
-    // the remaining 100k is under the 250k daily limit.
-    await db.executeQuery(`
-      INSERT INTO AiUsage (user_id, model, tokens_prompt, tokens_completion, cost, created_at)
-      VALUES (?, ?, ?, ?, ?, datetime('now', '-20 hours'))
-    `, ['u1', 'test-model', 200000, 0, 0]);
-    // 5h ago: 100k (stays in the window past the reset).
-    await db.executeQuery(`
-      INSERT INTO AiUsage (user_id, model, tokens_prompt, tokens_completion, cost, created_at)
-      VALUES (?, ?, ?, ?, ?, datetime('now', '-5 hours'))
-    `, ['u1', 'test-model', 100000, 0, 0]);
-
-    expect(await aiUsageModel.getDailyUsage('u1')).toBe(300000);
-
+  test('getResetAt (daily) is the window start + 24h', async () => {
+    await aiUsageModel.addUsage('u1', 'test-model', DAILY_LIMIT, 0);
     const resetAt = await aiUsageModel.getResetAt('u1', 'daily');
     expect(resetAt).not.toBeNull();
-    // Expected ≈ now + 4h (20h-ago entry + 24h window).
-    const expected = Date.now() + 4 * 60 * 60 * 1000;
+    const expected = Date.now() + 24 * 60 * 60 * 1000;
     expect(Math.abs((resetAt as Date).getTime() - expected)).toBeLessThan(2 * 60 * 1000);
   });
 
-  test('getResetAt (weekly) clears when the oldest over-budget entry ages out', async () => {
-    // Spread 1.05M across the week without tripping the daily limit; weekly is
-    // over by 50k, so the limit lifts once the oldest (6d-ago) entry drops out
-    // at 6d-ago + 7d = ~1 day from now.
-    for (const [ago, tokens] of [
-      ['-6 days', 200000], ['-5 days', 200000], ['-4 days', 200000],
-      ['-3 days', 200000], ['-2 days', 150000], ['-30 hours', 100000],
-    ] as const) {
-      // eslint-disable-next-line no-await-in-loop
-      await db.executeQuery(`
-        INSERT INTO AiUsage (user_id, model, tokens_prompt, tokens_completion, cost, created_at)
-        VALUES (?, ?, ?, ?, ?, datetime('now', ?))
-      `, ['u1', 'test-model', tokens, 0, 0, ago]);
-    }
-
-    expect(await aiUsageModel.getWeeklyUsage('u1')).toBe(1050000);
-
+  test('getResetAt (weekly) is the window start + 7d', async () => {
+    await aiUsageModel.addUsage('u1', 'test-model', 500000, 0);
     const resetAt = await aiUsageModel.getResetAt('u1', 'weekly');
     expect(resetAt).not.toBeNull();
-    // Expected ≈ now + 1 day (6d-ago entry + 7d window).
-    const expected = Date.now() + 24 * 60 * 60 * 1000;
+    const expected = Date.now() + 7 * 24 * 60 * 60 * 1000;
     expect(Math.abs((resetAt as Date).getTime() - expected)).toBeLessThan(2 * 60 * 1000);
   });
 

--- a/utils/discordRateLimit.ts
+++ b/utils/discordRateLimit.ts
@@ -22,14 +22,14 @@ export async function getRateLimitErrorMessage(userId: string, db: Database): Pr
   const limitLabel = reachedDaily ? 'Daily' : 'Weekly';
   const usageVal = reachedDaily ? dailyUsage : weeklyUsage;
   const limitVal = reachedDaily ? DAILY_LIMIT : WEEKLY_LIMIT;
-  const windowLabel = reachedDaily ? '24 hours' : '7 days';
+  const windowLabel = reachedDaily ? '24-hour' : '7-day';
 
   const resetAt = await db.aiUsage.getResetAt(userId, reason);
-  const cooldownNote = resetAt
-    ? `Your pool cools down enough to use again ${formatResetTimestamp(resetAt)}.`
-    : 'Please wait for your token pool to cool down.';
+  const resetNote = resetAt
+    ? `Your limit resets ${formatResetTimestamp(resetAt)}.`
+    : 'Please wait for your limit to reset.';
 
-  return `⚠️ **${limitLabel} AI Rate Limit Reached**\nYou have consumed **${usageVal.toLocaleString()}** / **${limitVal.toLocaleString()}** tokens in the last ${windowLabel}. ${cooldownNote}`;
+  return `⚠️ **${limitLabel} AI Rate Limit Reached**\nYou've used **${usageVal.toLocaleString()}** / **${limitVal.toLocaleString()}** tokens in the current ${windowLabel} window. ${resetNote}`;
 }
 
 export async function handleRateLimitError(

--- a/utils/discordRateLimit.ts
+++ b/utils/discordRateLimit.ts
@@ -11,6 +11,21 @@ export function formatResetTimestamp(resetAt: Date): string {
   return `<t:${unix}:t> (<t:${unix}:R>)`;
 }
 
+/**
+ * The trailing "**Resets:** <t…>" embed line for a rate-limited user (empty
+ * string when not limited or the window has already lapsed). Shared by the
+ * `/ai usage` and `/profile` embeds so the wording stays in sync.
+ */
+export async function getResetLine(
+  db: Database,
+  userId: string,
+  status: { limited: boolean; reason?: 'daily' | 'weekly' },
+): Promise<string> {
+  if (!status.limited || !status.reason) return '';
+  const resetAt = await db.aiUsage.getResetAt(userId, status.reason);
+  return resetAt ? `\n**Resets:** ${formatResetTimestamp(resetAt)}` : '';
+}
+
 export async function getRateLimitErrorMessage(userId: string, db: Database): Promise<string> {
   const [dailyUsage, weeklyUsage] = await Promise.all([
     db.aiUsage.getDailyUsage(userId),

--- a/utils/discordRateLimit.ts
+++ b/utils/discordRateLimit.ts
@@ -2,16 +2,34 @@ import type { ChatInputCommandInteraction } from 'discord.js';
 import type Database from '../database/Database';
 import { DAILY_LIMIT, WEEKLY_LIMIT } from './ai';
 
+/**
+ * Renders a rate-limit reset time as a Discord short-time + relative stamp,
+ * e.g. "3:04 PM (in about 2 hours)" — resolved to each viewer's local clock.
+ */
+export function formatResetTimestamp(resetAt: Date): string {
+  const unix = Math.floor(resetAt.getTime() / 1000);
+  return `<t:${unix}:t> (<t:${unix}:R>)`;
+}
+
 export async function getRateLimitErrorMessage(userId: string, db: Database): Promise<string> {
-  const dailyUsage = await db.aiUsage.getDailyUsage(userId);
-  const weeklyUsage = await db.aiUsage.getWeeklyUsage(userId);
+  const [dailyUsage, weeklyUsage] = await Promise.all([
+    db.aiUsage.getDailyUsage(userId),
+    db.aiUsage.getWeeklyUsage(userId),
+  ]);
   const reachedDaily = dailyUsage >= DAILY_LIMIT;
 
+  const reason: 'daily' | 'weekly' = reachedDaily ? 'daily' : 'weekly';
   const limitLabel = reachedDaily ? 'Daily' : 'Weekly';
   const usageVal = reachedDaily ? dailyUsage : weeklyUsage;
   const limitVal = reachedDaily ? DAILY_LIMIT : WEEKLY_LIMIT;
+  const windowLabel = reachedDaily ? '24 hours' : '7 days';
 
-  return `⚠️ **${limitLabel} AI Rate Limit Reached**\nYou have consumed **${usageVal.toLocaleString()}** / **${limitVal.toLocaleString()}** tokens in the last ${reachedDaily ? '24 hours' : '7 days'}. Please wait for your token pool to cool down.`;
+  const resetAt = await db.aiUsage.getResetAt(userId, reason);
+  const cooldownNote = resetAt
+    ? `Your pool cools down enough to use again ${formatResetTimestamp(resetAt)}.`
+    : 'Please wait for your token pool to cool down.';
+
+  return `⚠️ **${limitLabel} AI Rate Limit Reached**\nYou have consumed **${usageVal.toLocaleString()}** / **${limitVal.toLocaleString()}** tokens in the last ${windowLabel}. ${cooldownNote}`;
 }
 
 export async function handleRateLimitError(


### PR DESCRIPTION
## What & why

AI rate limiting moves from a **rolling** trailing-sum window to a **fixed** window (Claude-style): your first message opens the window, usage accumulates against the cap, and at `window_start + interval` the counter **resets wholesale to zero**. The next message opens a fresh window.

This makes the reset a single fixed timestamp — easy to reason about and to display — and is surfaced on all three Discord surfaces: the **rate-limit notice**, **`/ai usage`**, and the **`/profile` AI-usage embed**, as a Discord short-time + relative stamp (`<t:…:t> (<t:…:R>)`, each viewer's local clock).

> ⚠️ **Daily AI Rate Limit Reached**
> You've used **350,000** / **250,000** tokens in the current 24-hour window. Your limit resets `<t:…:t>` (`<t:…:R>`).

Both limits are kept as independent fixed windows: **250k / 24h** and **1M / 7d**, each anchored to its own first message (weekly still bites: 250k×7 > 1M).

## How it works
- **`database/tables/aiRateLimitWindowTable.ts`** — new `AiRateLimitWindow`: one row per `(user_id, window_type)` holding `window_start` + accumulated `tokens`, `UNIQUE(user_id, window_type)`.
- **`aiUsageQueries.ts`** — `UPSERT_WINDOW` (atomic `ON CONFLICT`: if the stored window lapsed → re-anchor to `now` and reseed with this call's tokens, else accumulate) and `GET_WINDOW` (returns current tokens, `0` once lapsed, plus the reset instant).
- **`AiUsageModel.ts`** — `addUsage` folds each call's tokens into **both** windows inside a transaction alongside the `AiUsage` audit-log insert. `getDailyUsage`/`getWeeklyUsage` read the counter; `getResetAt(userId, reason)` returns `window_start + interval` (`null` when lapsed). `checkRateLimit` is unchanged in shape, now fed by the counter.
- **`AiUsage` log is untouched** — still the immutable per-call audit/cost trail; enforcement just no longer trailing-sums it.
- **`discordRateLimit.ts` / `ai_usage.ts` / `profile.ts`** — reworded to "resets" + the fixed timestamp; `/ai usage` made **public** (dropped `ephemeral`) per request.

## Migration note
`AiRateLimitWindow` starts empty on deploy (created via the usual `CREATE TABLE IF NOT EXISTS`), so **every user's window resets once** — a clean slate — the first time they use AI after this ships. No backfill from the historical log.

## Not touched
Website usage surfaces (`ai-slop-api.ts`, `/me`) — they read the same `getDailyUsage`/`getWeeklyUsage`, so they now show the fixed-window counts automatically; Discord `<t:>` stamps don't render there, so no reset timestamp on the web.

## Verification
Full suite `bun test` (300/300), `bun run typecheck`, `eslint` all clean. End-to-end against a temp DB: 100k → accumulates; +250k → trips at 350k/250k daily; `getResetAt` = exactly `now + 24h`; after back-dating `window_start` past the interval the daily counter clears to 0 and enforcement lifts while weekly (350k) stays under 1M.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer AI usage status messages with reset timing when limits are reached.
  * Introduced visible cooldown/reset timestamps in AI usage responses.
* **Bug Fixes**
  * Improved AI usage tracking to use fixed daily and weekly windows for more accurate limit behavior.
  * Status messages now better distinguish between daily and weekly limit hits.
* **Tests**
  * Updated coverage for window resets and reset-time reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->