### PR TITLE
🇪🇸 🇪🇸 🇪🇸 RODRI'S ON FIRE 🔥🔥🔥 

### DIFF
--- a/classes/footballScheduler.ts
+++ b/classes/footballScheduler.ts
@@ -1,6 +1,6 @@
 import { EmbedBuilder } from 'discord.js';
 import { log, logError } from '../utils/log';
-import { getFootballChannelIds } from '../utils/footballChannels';
+import { getFootballChannelIds, isFootballEnabled } from '../utils/footballChannels';
 import {
   buildFullTimeEmbed,
   buildPreMatchEmbed,
@@ -57,6 +57,8 @@ class FootballScheduler {
 
   async checkMatches(): Promise<void> {
     try {
+      if (!(await isFootballEnabled(this.client.db))) return;
+
       const channelIds = await getFootballChannelIds(this.client.db);
       if (channelIds.length === 0) return;
 

--- a/commands/classes/Command.ts
+++ b/commands/classes/Command.ts
@@ -39,7 +39,8 @@ class Command {
   }
 
   async execute(interaction: any): Promise<void> {
-    if (await this.client.db.globalConfig.getGlobalConfig('banned') === 'true') {
+    const banned = await this.client.db.globalConfig.getGlobalConfig('banned');
+    if (banned === '1' || banned === 'true') {
       if (!isDev(interaction)) {
         log('ehe banned');
         const embed = new EmbedBuilder()

--- a/commands/globalconfig_get.ts
+++ b/commands/globalconfig_get.ts
@@ -1,53 +1,26 @@
 import { EmbedBuilder } from 'discord.js';
 import { DevCommand } from './classes/DevCommand';
+import { formatGlobalConfigOverview } from '../utils/globalConfig';
 
 class GlobalConfigGet extends DevCommand {
   constructor(client: any) {
-    super(client, 'get', 'Get a global config value', [
-      {
-        name: 'key',
-        description: 'config key (ALL to get all)',
-        type: 3,
-        required: true,
-      },
-    ], { isSubcommandOf: 'globalconfig', blame: 'ei' });
+    super(client, 'get', 'List all documented global config values', [], {
+      isSubcommandOf: 'globalconfig',
+      blame: 'ei',
+    });
   }
 
   async run(interaction: any): Promise<void> {
-    const key = interaction.options.getString('key');
-    if (key === 'ALL') {
-      const all = await this.client.db.globalConfig.getAllGlobalConfig();
-      if (all.length === 0) {
-        await interaction.editReply({
-          embeds: [
-            new EmbedBuilder()
-              .setTitle('No Global Config Values')
-              .setDescription('No global config values found')
-              .setColor('#00AA00'),
-          ],
-        });
-        return;
-      }
+    const rows = await this.client.db.globalConfig.getAllGlobalConfig();
 
-      await interaction.editReply({
-        embeds: [
-          new EmbedBuilder()
-            .setTitle('All Global Config Values')
-            .setDescription(all.map((row: any) => `**${row.key}**: ${row.value}`).join('\n'))
-            .setColor('#00AA00'),
-        ],
-      });
-    } else {
-      const value = await this.client.db.globalConfig.getGlobalConfig(key);
-      await interaction.editReply({
-        embeds: [
-          new EmbedBuilder()
-            .setTitle(`Global Config: ${key}`)
-            .setDescription(`Value: ${value}`)
-            .setColor('#00AA00'),
-        ],
-      });
-    }
+    await interaction.editReply({
+      embeds: [
+        new EmbedBuilder()
+          .setTitle('Global config')
+          .setDescription(formatGlobalConfigOverview(rows))
+          .setColor('#00AA00'),
+      ],
+    });
   }
 }
 

--- a/commands/globalconfig_set.ts
+++ b/commands/globalconfig_set.ts
@@ -1,17 +1,25 @@
 import { DevCommand } from './classes/DevCommand';
+import {
+  SETTABLE_GLOBAL_VALUE_KEYS,
+  validateGlobalConfigValue,
+} from '../utils/globalConfig';
 
 class GlobalConfigSet extends DevCommand {
   constructor(client: any) {
     super(client, 'set', 'Set a global config value', [
       {
         name: 'key',
-        description: 'config key',
+        description: 'Config key',
         type: 3,
         required: true,
+        choices: SETTABLE_GLOBAL_VALUE_KEYS.map((entry) => ({
+          name: entry.key,
+          value: entry.key,
+        })),
       },
       {
         name: 'value',
-        description: 'config value',
+        description: 'Config value',
         type: 3,
         required: true,
       },
@@ -20,9 +28,15 @@ class GlobalConfigSet extends DevCommand {
 
   async run(interaction: any): Promise<void> {
     const key = interaction.options.getString('key');
-    const value = interaction.options.getString('value');
+    const value = interaction.options.getString('value').trim();
+    const validationError = validateGlobalConfigValue(key, value);
+    if (validationError) {
+      await interaction.editReply(validationError);
+      return;
+    }
+
     await this.client.db.globalConfig.setGlobalConfig(key, value);
-    await interaction.editReply(`${key} set to ${value}`);
+    await interaction.editReply(`\`${key}\` set to \`${value}\`.`);
   }
 }
 

--- a/tests/footballChannels.test.ts
+++ b/tests/footballChannels.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test';
+import { FOOTBALL_ENABLED_CONFIG_KEY, isFootballEnabled } from '../utils/footballChannels';
+
+function mockDb(value: string | null) {
+  return {
+    globalConfig: {
+      getGlobalConfig: async (key: string) => {
+        expect(key).toBe(FOOTBALL_ENABLED_CONFIG_KEY);
+        return value;
+      },
+    },
+  };
+}
+
+describe('isFootballEnabled', () => {
+  test('defaults to enabled when unset', async () => {
+    expect(await isFootballEnabled(mockDb(null))).toBe(true);
+    expect(await isFootballEnabled(mockDb(''))).toBe(true);
+  });
+
+  test('treats 0/false as disabled', async () => {
+    expect(await isFootballEnabled(mockDb('0'))).toBe(false);
+    expect(await isFootballEnabled(mockDb('false'))).toBe(false);
+    expect(await isFootballEnabled(mockDb('FALSE'))).toBe(false);
+  });
+
+  test('treats 1/true as enabled', async () => {
+    expect(await isFootballEnabled(mockDb('1'))).toBe(true);
+    expect(await isFootballEnabled(mockDb('true'))).toBe(true);
+  });
+});

--- a/tests/utils/globalConfig.test.ts
+++ b/tests/utils/globalConfig.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  formatGlobalConfigOverview,
+  GLOBAL_CONFIG_KEYS,
+  validateGlobalConfigValue,
+} from '../../utils/globalConfig';
+
+describe('globalConfig utils', () => {
+  describe('validateGlobalConfigValue', () => {
+    test('accepts football 0/1', () => {
+      expect(validateGlobalConfigValue(GLOBAL_CONFIG_KEYS.FOOTBALL, '0')).toBeNull();
+      expect(validateGlobalConfigValue(GLOBAL_CONFIG_KEYS.FOOTBALL, '1')).toBeNull();
+      expect(validateGlobalConfigValue(GLOBAL_CONFIG_KEYS.FOOTBALL, '2')).not.toBeNull();
+    });
+
+    test('accepts banned 0/1', () => {
+      expect(validateGlobalConfigValue(GLOBAL_CONFIG_KEYS.BANNED, '0')).toBeNull();
+      expect(validateGlobalConfigValue(GLOBAL_CONFIG_KEYS.BANNED, '1')).toBeNull();
+      expect(validateGlobalConfigValue(GLOBAL_CONFIG_KEYS.BANNED, 'true')).not.toBeNull();
+    });
+
+    test('rejects list keys and unknown keys', () => {
+      expect(validateGlobalConfigValue(GLOBAL_CONFIG_KEYS.FOOTBALL_CHANNELS, '1')).not.toBeNull();
+      expect(validateGlobalConfigValue('unknown_key', '1')).not.toBeNull();
+    });
+  });
+
+  describe('formatGlobalConfigOverview', () => {
+    test('shows defaults for unset values and formats set lists', () => {
+      const overview = formatGlobalConfigOverview([
+        { key: 'football', value: '0' },
+        { key: 'birthday_channels', value: '111,222' },
+        { key: 'allowed_servers', value: '999' },
+        { key: 'custom_legacy', value: 'keep-me' },
+      ]);
+
+      expect(overview).toContain('football: 0');
+      expect(overview).toContain('banned: None (default: 0)');
+      expect(overview).toContain('season: None (default: normal)');
+      expect(overview).toContain('birthday_channels: <#111>, <#222>');
+      expect(overview).toContain('football_channels: None (default: none)');
+      expect(overview).toContain('allowed_servers: `999`');
+      expect(overview).toContain('custom_legacy: keep-me');
+    });
+
+    test('shows defaults when nothing is configured', () => {
+      const overview = formatGlobalConfigOverview([]);
+      expect(overview).toContain('football: None (default: 1)');
+      expect(overview).toContain('birthday_channels: None (default: none)');
+      expect(overview).toContain('allowed_servers: None (default: none)');
+    });
+  });
+});

--- a/utils/footballChannels.ts
+++ b/utils/footballChannels.ts
@@ -1,10 +1,22 @@
 import { parseChannelIds } from './parseChannelIds';
 
 export const FOOTBALL_CHANNELS_CONFIG_KEY = 'football_channels';
+/** Global kill-switch: `0` = off, `1` = on. Unset defaults to on. */
+export const FOOTBALL_ENABLED_CONFIG_KEY = 'football';
 
-export async function getFootballChannelIds(
-  db: { globalConfig: { getGlobalConfig: (key: string) => Promise<string | null> } },
-): Promise<string[]> {
+type GlobalConfigReader = {
+  globalConfig: { getGlobalConfig: (key: string) => Promise<string | null> };
+};
+
+export async function isFootballEnabled(db: GlobalConfigReader): Promise<boolean> {
+  const raw = await db.globalConfig.getGlobalConfig(FOOTBALL_ENABLED_CONFIG_KEY);
+  if (raw === null || raw === undefined || raw === '') return true;
+  if (raw === '0' || raw.toLowerCase() === 'false') return false;
+  if (raw === '1' || raw.toLowerCase() === 'true') return true;
+  return true;
+}
+
+export async function getFootballChannelIds(db: GlobalConfigReader): Promise<string[]> {
   const dbChannels = await db.globalConfig.getGlobalConfig(FOOTBALL_CHANNELS_CONFIG_KEY);
   return parseChannelIds(dbChannels ?? process.env.FOOTBALL_CHANNELS);
 }

--- a/utils/footballChannels.ts
+++ b/utils/footballChannels.ts
@@ -1,8 +1,9 @@
 import { parseChannelIds } from './parseChannelIds';
+import { GLOBAL_CONFIG_KEYS } from './globalConfig';
 
-export const FOOTBALL_CHANNELS_CONFIG_KEY = 'football_channels';
+export const FOOTBALL_CHANNELS_CONFIG_KEY = GLOBAL_CONFIG_KEYS.FOOTBALL_CHANNELS;
 /** Global kill-switch: `0` = off, `1` = on. Unset defaults to on. */
-export const FOOTBALL_ENABLED_CONFIG_KEY = 'football';
+export const FOOTBALL_ENABLED_CONFIG_KEY = GLOBAL_CONFIG_KEYS.FOOTBALL;
 
 type GlobalConfigReader = {
   globalConfig: { getGlobalConfig: (key: string) => Promise<string | null> };

--- a/utils/globalConfig.ts
+++ b/utils/globalConfig.ts
@@ -1,0 +1,160 @@
+import { parseChannelIds } from './parseChannelIds';
+
+export const GLOBAL_CONFIG_KEYS = {
+  FOOTBALL: 'football',
+  BANNED: 'banned',
+  SEASON: 'season',
+  ALLOWED_SERVERS: 'allowed_servers',
+  BIRTHDAY_CHANNELS: 'birthday_channels',
+  FOOTBALL_CHANNELS: 'football_channels',
+} as const;
+
+export const GLOBAL_CHANNEL_LIST_KEYS = [
+  GLOBAL_CONFIG_KEYS.BIRTHDAY_CHANNELS,
+  GLOBAL_CONFIG_KEYS.FOOTBALL_CHANNELS,
+] as const;
+
+export const GLOBAL_SERVER_LIST_KEYS = [
+  GLOBAL_CONFIG_KEYS.ALLOWED_SERVERS,
+] as const;
+
+export type GlobalChannelListKey = typeof GLOBAL_CHANNEL_LIST_KEYS[number];
+export type GlobalServerListKey = typeof GLOBAL_SERVER_LIST_KEYS[number];
+export type DocumentedGlobalConfigKey = typeof GLOBAL_CONFIG_KEYS[keyof typeof GLOBAL_CONFIG_KEYS];
+
+export const DOCUMENTED_GLOBAL_CONFIG_KEYS: {
+  key: DocumentedGlobalConfigKey;
+  description: string;
+  defaultValue: string;
+}[] = [
+  {
+    key: GLOBAL_CONFIG_KEYS.FOOTBALL,
+    description: 'World Cup announcement scheduler. 0 = off, 1 = on',
+    defaultValue: '1',
+  },
+  {
+    key: GLOBAL_CONFIG_KEYS.BANNED,
+    description: 'Emergency command kill-switch. 0 = off, 1 = on (blocks non-dev commands)',
+    defaultValue: '0',
+  },
+  {
+    key: GLOBAL_CONFIG_KEYS.SEASON,
+    description: 'Seasonal mode for claim/slots (e.g. normal, christmas)',
+    defaultValue: 'normal',
+  },
+  {
+    key: GLOBAL_CONFIG_KEYS.ALLOWED_SERVERS,
+    description: 'Guild IDs where the bot is allowed to run',
+    defaultValue: 'none',
+  },
+  {
+    key: GLOBAL_CONFIG_KEYS.BIRTHDAY_CHANNELS,
+    description: 'Channels that receive birthday announcements',
+    defaultValue: 'none',
+  },
+  {
+    key: GLOBAL_CONFIG_KEYS.FOOTBALL_CHANNELS,
+    description: 'Channels that receive World Cup match announcements',
+    defaultValue: 'none',
+  },
+];
+
+/** Keys managed via `/globalconfig set` (not list keys managed by register commands). */
+export const SETTABLE_GLOBAL_VALUE_KEYS = DOCUMENTED_GLOBAL_CONFIG_KEYS.filter(
+  (entry) => !(GLOBAL_CHANNEL_LIST_KEYS as readonly string[]).includes(entry.key)
+    && !(GLOBAL_SERVER_LIST_KEYS as readonly string[]).includes(entry.key),
+);
+
+const BOOLEAN_VALUE_KEYS = new Set<string>([
+  GLOBAL_CONFIG_KEYS.FOOTBALL,
+  GLOBAL_CONFIG_KEYS.BANNED,
+]);
+
+const DOCUMENTED_KEY_SET = new Set<string>(DOCUMENTED_GLOBAL_CONFIG_KEYS.map((entry) => entry.key));
+
+function formatUnsetDisplay(defaultValue: string): string {
+  return `None (default: ${defaultValue})`;
+}
+
+function documentedDefault(key: DocumentedGlobalConfigKey): string {
+  return DOCUMENTED_GLOBAL_CONFIG_KEYS.find((entry) => entry.key === key)!.defaultValue;
+}
+
+export function isDocumentedGlobalConfigKey(key: string): key is DocumentedGlobalConfigKey {
+  return DOCUMENTED_KEY_SET.has(key);
+}
+
+export function validateGlobalConfigValue(key: string, value: string): string | null {
+  if (!SETTABLE_GLOBAL_VALUE_KEYS.some((entry) => entry.key === key)) {
+    return `Unknown key. Supported keys: ${SETTABLE_GLOBAL_VALUE_KEYS.map((entry) => entry.key).join(', ')}`;
+  }
+
+  if (BOOLEAN_VALUE_KEYS.has(key)) {
+    if (value !== '0' && value !== '1') {
+      return `${key} must be 0 or 1`;
+    }
+    return null;
+  }
+
+  if (key === GLOBAL_CONFIG_KEYS.SEASON) {
+    if (!value.trim()) return `${key} must not be empty`;
+    return null;
+  }
+
+  return null;
+}
+
+export function formatGlobalChannelListValue(
+  key: GlobalChannelListKey,
+  raw: string | null | undefined,
+): string {
+  if (!raw?.trim()) return formatUnsetDisplay(documentedDefault(key));
+  const ids = parseChannelIds(raw);
+  return ids.length > 0
+    ? ids.map((id) => `<#${id}>`).join(', ')
+    : formatUnsetDisplay(documentedDefault(key));
+}
+
+export function formatGlobalServerListValue(
+  key: GlobalServerListKey,
+  raw: string | null | undefined,
+): string {
+  if (!raw?.trim()) return formatUnsetDisplay(documentedDefault(key));
+  const ids = parseChannelIds(raw);
+  return ids.length > 0
+    ? ids.map((id) => `\`${id}\``).join(', ')
+    : formatUnsetDisplay(documentedDefault(key));
+}
+
+export function formatGlobalConfigOverview(rows: { key: string; value: string }[]): string {
+  const valueByKey = new Map(rows.map((row) => [row.key, row.value]));
+  const lines: string[] = [];
+
+  lines.push('**Values**');
+  SETTABLE_GLOBAL_VALUE_KEYS.forEach((entry) => {
+    const raw = valueByKey.get(entry.key);
+    const display = raw?.trim() ? raw : formatUnsetDisplay(entry.defaultValue);
+    lines.push(`${entry.key}: ${display}`);
+  });
+
+  lines.push('', '**Channel lists**');
+  GLOBAL_CHANNEL_LIST_KEYS.forEach((listKey) => {
+    lines.push(`${listKey}: ${formatGlobalChannelListValue(listKey, valueByKey.get(listKey))}`);
+  });
+
+  lines.push('', '**Server lists**');
+  GLOBAL_SERVER_LIST_KEYS.forEach((listKey) => {
+    lines.push(`${listKey}: ${formatGlobalServerListValue(listKey, valueByKey.get(listKey))}`);
+  });
+
+  const documentedKeys = new Set<string>(DOCUMENTED_GLOBAL_CONFIG_KEYS.map((entry) => entry.key));
+  const extras = rows.filter((row) => !documentedKeys.has(row.key));
+  if (extras.length > 0) {
+    lines.push('', '**Other**');
+    extras.forEach((row) => {
+      lines.push(`${row.key}: ${row.value}`);
+    });
+  }
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
now that WC is over, adding an option to turn off football live api calls, and made global configs more consistent 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an enable/disable setting for football scheduling, with football enabled by default.
  * Updated `globalconfig get` to display all documented configuration values.
  * Added validation and selectable options for `globalconfig set`.
  * Added clearer formatting for configuration values, including channel and server lists.
  * The banned setting now recognizes both `1` and `true`.

* **Bug Fixes**
  * Football scheduling now stops when disabled.
  * Improved handling of unset and case-insensitive configuration values.

* **Tests**
  * Added coverage for football settings and global configuration validation and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->