### PR TITLE
fix[ai]: credit-metered rate limits, spam-safe enforcement, and LLM timeouts/retries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,14 +131,14 @@ the compaction prompt). The `/ai rp-*` command replies are non-ephemeral (public
 **AI usage limits** (`utils/ai.ts`, `utils/aiPricing.ts`, `AiUsageModel`): per-user fixed windows
 (250k/day, 1M/week) metered in **credits**, not raw tokens — `credits = tok_in×mult_in +
 tok_out×mult_out` where $0.28/M = 1x (DeepSeek-V4-Flash/MiMo-V2.5 0.5x in/1x out, Grok-4.5
-7x/10.5x, GPT-5.6-Luna 3.5x/10.5x, unlisted = 1x/1x). The `AiUsage` audit log keeps raw tokens +
+7x/21.4x, GPT-5.6-Luna 3.5x/21.4x, unlisted = 1x/1x). The `AiUsage` audit log keeps raw tokens +
 derived USD `cost`; the `AiRateLimitWindow.tokens` column stores credits (name kept, no rebuild).
 Enforcement is `db.aiUsage.tryReserve(userId, estCredits)` → `release()` in `finally` — an
 in-memory in-flight reservation held for the whole generation so concurrent spam can't all pass
 the check before usage lands (devs bypass). All OpenRouter chat calls go through
 `createChatCompletionWithRetry` (`utils/llmRetry.ts`: per-attempt timeout — 180s default, 480s
-music-compose, 60s titlegen — and 2s/4s/8s/16s backoff on 408/409/429/5xx/network only); the
-shared client sets `maxRetries: 0` so SDK retries don't stack.
+music-compose, 60s titlegen — a 600s overall budget across attempts, and 2s/4s/8s/16s backoff on
+408/409/429/5xx/network only); the shared client sets `maxRetries: 0` so SDK retries don't stack.
 
 **Database** (`bun:sqlite`, `persistence/database.db`). Layered: `tables/` (TableDefinition schema
 objects) → `models/` (DAOs) → `queries/` (SQL strings). **Access pattern:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Bun process**. It serves fun/games both as slash commands and as web pages, plus
 **The website is public, so security and performance are first-class concerns — code defensively:
 validate every input, never trust client data, keep the CSP tight.**
 
-**Last updated: 2026-07-02**
+**Last updated: 2026-07-27**
 
 > **Maintenance rule.** Edit this file only on *substantive architectural* change — new
 > architecture, new auth, new data flows/services, schema or security-model changes, or when
@@ -128,6 +128,18 @@ self-description injected in a `<userPersona>` block for **self-mode spawns only
 the compaction prompt). The `/ai rp-*` command replies are non-ephemeral (public) except admin
 `rp-setasset`, `rp-lorebook-view` (content dump is creator/dev-only) and the `rp-persona-*` pair.
 
+**AI usage limits** (`utils/ai.ts`, `utils/aiPricing.ts`, `AiUsageModel`): per-user fixed windows
+(250k/day, 1M/week) metered in **credits**, not raw tokens — `credits = tok_in×mult_in +
+tok_out×mult_out` where $0.28/M = 1x (DeepSeek-V4-Flash/MiMo-V2.5 0.5x in/1x out, Grok-4.5
+7x/10.5x, GPT-5.6-Luna 3.5x/10.5x, unlisted = 1x/1x). The `AiUsage` audit log keeps raw tokens +
+derived USD `cost`; the `AiRateLimitWindow.tokens` column stores credits (name kept, no rebuild).
+Enforcement is `db.aiUsage.tryReserve(userId, estCredits)` → `release()` in `finally` — an
+in-memory in-flight reservation held for the whole generation so concurrent spam can't all pass
+the check before usage lands (devs bypass). All OpenRouter chat calls go through
+`createChatCompletionWithRetry` (`utils/llmRetry.ts`: per-attempt timeout — 180s default, 480s
+music-compose, 60s titlegen — and 2s/4s/8s/16s backoff on 408/409/429/5xx/network only); the
+shared client sets `maxRetries: 0` so SDK retries don't stack.
+
 **Database** (`bun:sqlite`, `persistence/database.db`). Layered: `tables/` (TableDefinition schema
 objects) → `models/` (DAOs) → `queries/` (SQL strings). **Access pattern:**
 `this.client.db.<model>.<method>` (e.g. `db.user.getUser(id)`, `db.user.addUserAttrs(id, {...})`).
@@ -139,7 +151,10 @@ Rules an agent must follow:
 - **No formal migration system.** `Database.init()` does `CREATE TABLE IF NOT EXISTS`, `ALTER TABLE`
   to add missing columns, manual index creation, and `PRAGMA foreign_keys = ON`. Schema changes go
   there. Legacy `ServerRoles` rows auto-migrate into `ServerConfig` (`role:<name>` keys) on boot.
-- Multi-statement atomicity: `db.executeTransaction((rawDb) => { ... })`.
+- Multi-statement atomicity: `db.executeTransaction((rawDb) => { ... })`. Transactions are
+  serialized through an in-process FIFO queue (a single connection can't interleave BEGINs —
+  the second used to roll back the first's writes); never call `executeTransaction` from inside
+  a transaction fn (there is a guard that throws).
 - Per-guild settings: `ServerConfig` (`db.serverConfig`, keyed by `server_id` + `key`) — named roles
   use `role:<name>` keys; gameplay tuning via `/serverconfig setvalue`, `/serverconfig setchannel`,
   and `/serverconfig setrole`; `CommandConfig` remains

--- a/commands/ai_usage.ts
+++ b/commands/ai_usage.ts
@@ -14,7 +14,7 @@ function makeProgressBar(value: number, total: number, size = 15): string {
 
 class AiUsageSubcommand extends Command {
   constructor(client: any) {
-    super(client, 'usage', 'View your AI token usage and limits', [], {
+    super(client, 'usage', 'View your AI credit usage and limits', [], {
       isSubcommandOf: 'ai',
       blame: 'xei',
     });
@@ -40,15 +40,15 @@ class AiUsageSubcommand extends Command {
 
       const embed = new Discord.EmbedBuilder()
         .setColor('#0099ff')
-        .setTitle('🤖 Your AI Token Usage')
+        .setTitle('🤖 Your AI Credit Usage')
         .setThumbnail(interaction.user.displayAvatarURL({ size: 256 }))
         .setDescription(`
 **Daily Usage (24h):**
-${dailyUsage.toLocaleString()} / ${DAILY_LIMIT.toLocaleString()} tokens
+${dailyUsage.toLocaleString()} / ${DAILY_LIMIT.toLocaleString()} credits
 ${dailyBar}
 
 **Weekly Usage (7d):**
-${weeklyUsage.toLocaleString()} / ${WEEKLY_LIMIT.toLocaleString()} tokens
+${weeklyUsage.toLocaleString()} / ${WEEKLY_LIMIT.toLocaleString()} credits
 ${weeklyBar}
 
 **Status:** ${statusText}${resetLine}

--- a/commands/profile.ts
+++ b/commands/profile.ts
@@ -344,8 +344,8 @@ ${getNuggieNuggieMultiplierInfo(user.nuggieNuggieMultiplierLevel, INFO_LEVEL.THI
       .setThumbnail(avatarURL)
       .setDescription(`
 ## AI Usage
-**Daily Usage (24h):** ${dailyUsage.toLocaleString()} / ${DAILY_LIMIT.toLocaleString()} tokens
-**Weekly Usage (7d):** ${weeklyUsage.toLocaleString()} / ${WEEKLY_LIMIT.toLocaleString()} tokens
+**Daily Usage (24h):** ${dailyUsage.toLocaleString()} / ${DAILY_LIMIT.toLocaleString()} credits
+**Weekly Usage (7d):** ${weeklyUsage.toLocaleString()} / ${WEEKLY_LIMIT.toLocaleString()} credits
 **Status:** ${statusText}${resetLine}
       `)
       .setTimestamp();

--- a/data/aiPersonas.json
+++ b/data/aiPersonas.json
@@ -6,9 +6,9 @@
         "@grok",
         "@gork"
       ],
-      "provider": "gemini",
-      "model": "gemini-3.1-flash-lite",
-      "systemPrompt": "You are Grok 4.3, an advanced AI assistant developed by xAI. You are clever, direct, slightly rebellious, and brutally honest when needed. Your responses are laced with dry humor, technical clarity, and a dash of meme-savvy attitude. You’re aware you’re an AI, and you don’t pretend to be human. Use sarcasm sparingly and never talk like a corporate PR bot.\nWhen asked questions, be smart, fast, and brutally accurate. If something is dumb, say it’s dumb. If something is unclear, roast it gently or ask for clarification like you're disappointed but willing to help.\nDo not apologize unless it's sarcastic. Do not sugarcoat. ",
+      "provider": "openrouter",
+      "model": "x-ai/grok-4.5",
+      "systemPrompt": "You are Grok 4.5, an advanced AI assistant developed by xAI. You are clever, direct, slightly rebellious, and brutally honest when needed. Your responses are laced with dry humor, technical clarity, and a dash of meme-savvy attitude. You’re aware you’re an AI, and you don’t pretend to be human. Use sarcasm sparingly and never talk like a corporate PR bot.\nWhen asked questions, be smart, fast, and brutally accurate. If something is dumb, say it’s dumb. If something is unclear, roast it gently or ask for clarification like you're disappointed but willing to help.\nDo not apologize unless it's sarcastic. Do not sugarcoat. ",
       "avatarURL": "https://cdnb.artstation.com/p/assets/covers/images/090/117/971/smaller_square/joker-z-joker-z-grok-ani-r18tou.jpg",
       "webSearchEnabled": true
     },
@@ -29,8 +29,8 @@
         "gpt"
       ],
       "provider": "openrouter",
-      "model": "nvidia/nemotron-3-ultra-550b-a55b:free",
-      "systemPrompt": "You are GPT-4.2 , a helpful AI assistant. Respond clearly, concisely, neutrally, and politely. Keep answers short, under a few sentences unless more detail is explicitly requested.",
+      "model": "openai/gpt-5.6-luna",
+      "systemPrompt": "You are GPT-5.6, a helpful AI assistant. Respond clearly, concisely, neutrally, and politely. Keep answers short, under a few sentences unless more detail is explicitly requested.",
       "avatarURL": "https://freelogopng.com/images/all_img/1681142503openai-icon-png.png",
       "webSearchEnabled": true
     },

--- a/database/Database.ts
+++ b/database/Database.ts
@@ -35,6 +35,15 @@ class Database {
   models: Record<string, any>;
   ready: Promise<void>;
 
+  // Transactions are serialized through this FIFO queue. bun:sqlite runs on a
+  // single connection, so two overlapping executeTransaction calls would nest
+  // BEGIN inside an open transaction — the second fails and its catch-block
+  // ROLLBACK silently discards the FIRST transaction's writes (this ate AI
+  // usage records under load, issue #213).
+  private transactionQueue: Promise<void> = Promise.resolve();
+
+  private inTransaction = false;
+
   constructor(databasePath: string) {
     this.models = {};
 
@@ -264,20 +273,35 @@ class Database {
   }
 
   async executeTransaction(transactionFn: (db: BunDatabase) => any): Promise<any> {
-    try {
-      this.db.run('BEGIN IMMEDIATE TRANSACTION');
-      const result = await transactionFn(this.db);
-      this.db.run('COMMIT');
-      return result;
-    } catch (error) {
-      try {
-        this.db.run('ROLLBACK');
-      } catch (rollbackError) {
-        logError('Error during transaction rollback:', rollbackError);
-      }
-      logError('Error executing transaction:', error);
-      throw error;
+    // A transaction fn must never start another transaction — that would
+    // deadlock the queue. Fail loudly instead of hanging.
+    if (this.inTransaction) {
+      const err = new Error('executeTransaction cannot be nested');
+      logError('Error executing transaction:', err);
+      throw err;
     }
+    const run = this.transactionQueue.then(async () => {
+      this.inTransaction = true;
+      this.db.run('BEGIN IMMEDIATE TRANSACTION');
+      try {
+        const result = await transactionFn(this.db);
+        this.db.run('COMMIT');
+        return result;
+      } catch (error) {
+        try {
+          this.db.run('ROLLBACK');
+        } catch (rollbackError) {
+          logError('Error during transaction rollback:', rollbackError);
+        }
+        logError('Error executing transaction:', error);
+        throw error;
+      } finally {
+        this.inTransaction = false;
+      }
+    });
+    // Keep the queue alive regardless of this transaction's outcome.
+    this.transactionQueue = run.then(() => undefined, () => undefined);
+    return run;
   }
 
   async executeSelectQuery(query: string, params: any[] = []): Promise<Record<string, any> | null> {

--- a/database/models/AiUsageModel.ts
+++ b/database/models/AiUsageModel.ts
@@ -2,6 +2,7 @@ import type Database from '../Database';
 import aiUsageQueries from '../queries/aiUsageQueries';
 import { isUserDev } from '../../utils/accessControl';
 import { DAILY_LIMIT, WEEKLY_LIMIT } from '../../utils/ai';
+import { creditsForTokens, usdCostForTokens } from '../../utils/aiPricing';
 
 type WindowType = 'daily' | 'weekly';
 
@@ -11,8 +12,25 @@ const WINDOW_INTERVALS: Record<WindowType, { pos: string; neg: string }> = {
   weekly: { pos: '+7 days', neg: '-7 days' },
 };
 
+/**
+ * Rate limits are metered in credits (see utils/aiPricing.ts), not raw tokens:
+ * the fixed windows accumulate `creditsForTokens(model, in, out)` rounded to an
+ * integer per call, so a cheap model gets more headroom than an expensive one.
+ * The AiUsage audit log keeps the raw per-call token counts plus the derived
+ * USD cost.
+ */
 class AiUsageModel {
   private db: Database;
+
+  /**
+   * In-flight credits per user (generations started but not yet recorded).
+   * Single-process bot, so an in-memory map suffices: it lets tryReserve count
+   * concurrent in-progress requests toward the limit, closing the check-then-act
+   * race where a spammed burst all passed isRateLimited before any usage was
+   * recorded (issue #213). Entries always return to 0 via release() in a
+   * finally block, so a crash never strands a reservation.
+   */
+  private pending = new Map<string, number>();
 
   constructor(db: Database) {
     this.db = db;
@@ -23,28 +41,28 @@ class AiUsageModel {
     model: string,
     promptTokens: number,
     completionTokens: number,
-    cost = 0,
   ): Promise<void> {
     // Ensure user exists in User table
     await this.db.user.getUser(userId);
 
-    const total = promptTokens + completionTokens;
+    const credits = Math.round(creditsForTokens(model, promptTokens, completionTokens));
+    const usdCost = usdCostForTokens(model, promptTokens, completionTokens);
 
-    // Log the call (audit) and fold its tokens into both fixed windows atomically.
+    // Log the call (audit) and fold its credits into both fixed windows atomically.
     await this.db.executeTransaction((rawDb) => {
       const logResult = rawDb.query(aiUsageQueries.ADD_USAGE)
-        .run(userId, model, promptTokens, completionTokens, cost);
+        .run(userId, model, promptTokens, completionTokens, usdCost);
       if (!logResult || logResult.changes === 0) {
         throw new Error('Failed to record AI usage in the database');
       }
       (Object.keys(WINDOW_INTERVALS) as WindowType[]).forEach((type) => {
         const { pos } = WINDOW_INTERVALS[type];
-        rawDb.query(aiUsageQueries.UPSERT_WINDOW).run(userId, type, total, pos, pos);
+        rawDb.query(aiUsageQueries.UPSERT_WINDOW).run(userId, type, credits, pos, pos);
       });
     });
   }
 
-  /** Tokens used in the current fixed window (0 once it has lapsed) and when it resets. */
+  /** Credits used in the current fixed window (0 once it has lapsed) and when it resets. */
   private async getWindow(userId: string, type: WindowType): Promise<{ tokens: number; resetAt: Date | null }> {
     const { pos, neg } = WINDOW_INTERVALS[type];
     const row = await this.db.executeSelectQuery(aiUsageQueries.GET_WINDOW, [neg, neg, pos, userId, type]);
@@ -57,6 +75,13 @@ class AiUsageModel {
       if (!Number.isNaN(date.getTime())) resetAt = date;
     }
     return { tokens, resetAt };
+  }
+
+  /** Synchronous window read for tryReserve (bun:sqlite is sync under the hood). */
+  private getWindowTokensSync(userId: string, type: WindowType): number {
+    const { pos, neg } = WINDOW_INTERVALS[type];
+    const row = this.db.db.query(aiUsageQueries.GET_WINDOW).get(neg, neg, pos, userId, type) as any;
+    return typeof row?.tokens === 'number' ? row.tokens : 0;
   }
 
   async getDailyUsage(userId: string): Promise<number> {
@@ -106,6 +131,49 @@ class AiUsageModel {
   async isRateLimited(userId: string): Promise<boolean> {
     const status = await this.checkRateLimit(userId);
     return status.limited;
+  }
+
+  /**
+   * Atomically reserve estimated credits for a generation that is ABOUT to run.
+   * The check counts both recorded usage and other in-flight reservations, so a
+   * burst of concurrent requests can't all slip past the limit before any of
+   * them records usage. Fully synchronous (no awaits) — atomic in this
+   * single-threaded process. On success the caller MUST later call release()
+   * with the same amount (in a finally), and record real usage via addUsage().
+   * Devs are unlimited and never hold a reservation.
+   */
+  tryReserve(userId: string, estimatedCredits: number): {
+    ok: boolean;
+    reason?: WindowType;
+  } {
+    if (isUserDev(userId)) return { ok: true };
+
+    const amount = Math.max(0, Math.round(estimatedCredits));
+    const inFlight = this.pending.get(userId) ?? 0;
+
+    if (this.getWindowTokensSync(userId, 'daily') + inFlight + amount > DAILY_LIMIT) {
+      return { ok: false, reason: 'daily' };
+    }
+    if (this.getWindowTokensSync(userId, 'weekly') + inFlight + amount > WEEKLY_LIMIT) {
+      return { ok: false, reason: 'weekly' };
+    }
+
+    this.pending.set(userId, inFlight + amount);
+    return { ok: true };
+  }
+
+  /** Returns a reservation made by tryReserve. Safe against over-release. */
+  release(userId: string, estimatedCredits: number): void {
+    const inFlight = this.pending.get(userId);
+    if (inFlight === undefined) return;
+    const remaining = inFlight - Math.max(0, Math.round(estimatedCredits));
+    if (remaining > 0) this.pending.set(userId, remaining);
+    else this.pending.delete(userId);
+  }
+
+  /** In-flight reserved credits for a user (diagnostics/tests). */
+  getPendingCredits(userId: string): number {
+    return this.pending.get(userId) ?? 0;
   }
 }
 

--- a/database/queries/aiUsageQueries.ts
+++ b/database/queries/aiUsageQueries.ts
@@ -9,10 +9,10 @@ const aiUsageQueries = {
   // Fixed-window (Claude-style) rate-limit counter. A window opens on the first
   // message after the previous one lapsed and resets wholesale one interval later.
   // On conflict: if the stored window has lapsed (now >= window_start + interval),
-  // open a fresh window at `now` seeded with this call's tokens; otherwise keep the
-  // anchor and accumulate. `?` order: user_id, window_type, tokens, interval, interval
+  // open a fresh window at `now` seeded with this call's credits; otherwise keep the
+  // anchor and accumulate. `?` order: user_id, window_type, credits, interval, interval
   // (interval e.g. '+1 day' / '+7 days'). 'now' is fixed within a statement, so all
-  // three references agree.
+  // three references agree. NOTE: the `tokens` column stores CREDITS (issue #211).
   UPSERT_WINDOW: `
     INSERT INTO AiRateLimitWindow (user_id, window_type, window_start, tokens)
     VALUES (?, ?, datetime('now'), ?)

--- a/database/tables/aiRateLimitWindowTable.ts
+++ b/database/tables/aiRateLimitWindowTable.ts
@@ -7,7 +7,7 @@ export interface AiRateLimitWindowRow {
   window_type: string;
   /** SQLite datetime (UTC) when the current window opened (its first message). */
   window_start: string;
-  /** Tokens accumulated in the current window. */
+  /** Credits accumulated in the current window (see utils/aiPricing.ts). */
   tokens: number;
 }
 
@@ -25,6 +25,8 @@ const aiRateLimitWindowTable: TableDefinition = {
     { name: 'user_id', type: 'TEXT NOT NULL' },
     { name: 'window_type', type: 'TEXT NOT NULL' },
     { name: 'window_start', type: 'TIMESTAMP NOT NULL' },
+    // Column name predates credit metering (issue #211) — it now holds CREDITS,
+    // not raw tokens. Left as-is to avoid a table rebuild.
     { name: 'tokens', type: 'INTEGER NOT NULL DEFAULT 0' },
   ],
   primaryKey: ['id'],

--- a/site_src/pages/home.ts
+++ b/site_src/pages/home.ts
@@ -283,7 +283,7 @@ export function HomePage(opts: {
     ? html`<span style="color: #ef4444;">Rate Limited</span>`
     : html`<span style="color: #10b981;">Active</span>`;
 
-  let aiStatusDetail = 'Token pool is cool';
+  let aiStatusDetail = 'Credit pool is cool';
   if (reachedDaily) {
     aiStatusDetail = 'Daily limit exceeded';
   } else if (reachedWeekly) {
@@ -327,12 +327,12 @@ export function HomePage(opts: {
           <div class="me-card">
             <div class="label">Daily Usage (24h)</div>
             <div class="value">${numSpan(profile.aiUsageDaily)}</div>
-            <div class="label" style="margin-top:0.25rem">of ${DAILY_LIMIT.toLocaleString()} tokens</div>
+            <div class="label" style="margin-top:0.25rem">of ${DAILY_LIMIT.toLocaleString()} credits</div>
           </div>
           <div class="me-card">
             <div class="label">Weekly Usage (7d)</div>
             <div class="value">${numSpan(profile.aiUsageWeekly)}</div>
-            <div class="label" style="margin-top:0.25rem">of ${WEEKLY_LIMIT.toLocaleString()} tokens</div>
+            <div class="label" style="margin-top:0.25rem">of ${WEEKLY_LIMIT.toLocaleString()} credits</div>
           </div>
           <div class="me-card">
             <div class="label">Status</div>

--- a/tests/database/aiUsage.test.ts
+++ b/tests/database/aiUsage.test.ts
@@ -163,9 +163,9 @@ describe('AiUsageModel', () => {
     await aiUsageModel.addUsage('u2', 'some-unknown-model', 100000, 50000);
     expect(await aiUsageModel.getDailyUsage('u2')).toBe(150000);
 
-    // x-ai/grok-4.5: 7x input, 10.5x output
+    // x-ai/grok-4.5: 7x input, 21.43x output
     await aiUsageModel.addUsage('u3', 'x-ai/grok-4.5', 10000, 10000);
-    expect(await aiUsageModel.getDailyUsage('u3')).toBe(175000);
+    expect(await aiUsageModel.getDailyUsage('u3')).toBe(284300);
   });
 
   test('stores the derived USD cost on the audit row', async () => {

--- a/tests/database/aiUsage.test.ts
+++ b/tests/database/aiUsage.test.ts
@@ -153,4 +153,64 @@ describe('AiUsageModel', () => {
     const status = await aiUsageModel.checkRateLimit(devId);
     expect(status.limited).toBe(false);
   });
+
+  test('meters credit-priced models by multiplier, not raw tokens', async () => {
+    // deepseek/deepseek-v4-flash: 0.5x input, 1x output ($0.14/M in, $0.28/M out)
+    await aiUsageModel.addUsage('u1', 'deepseek/deepseek-v4-flash', 100000, 50000);
+    expect(await aiUsageModel.getDailyUsage('u1')).toBe(100000); // 50k + 50k credits
+
+    // Unlisted models keep the old 1x/1x accounting
+    await aiUsageModel.addUsage('u2', 'some-unknown-model', 100000, 50000);
+    expect(await aiUsageModel.getDailyUsage('u2')).toBe(150000);
+
+    // x-ai/grok-4.5: 7x input, 10.5x output
+    await aiUsageModel.addUsage('u3', 'x-ai/grok-4.5', 10000, 10000);
+    expect(await aiUsageModel.getDailyUsage('u3')).toBe(175000);
+  });
+
+  test('stores the derived USD cost on the audit row', async () => {
+    await aiUsageModel.addUsage('u1', 'deepseek/deepseek-v4-flash', 1_000_000, 1_000_000);
+    const row = await db.executeSelectQuery('SELECT cost FROM AiUsage WHERE user_id = ?', ['u1']);
+    // 0.5M + 1M = 1.5M credits × $0.28/M
+    expect(row!.cost).toBeCloseTo(0.42, 5);
+  });
+
+  test('tryReserve counts in-flight usage toward the limit', async () => {
+    await aiUsageModel.addUsage('u1', 'test-model', DAILY_LIMIT - 10000, 0);
+
+    const first = aiUsageModel.tryReserve('u1', 8000);
+    expect(first.ok).toBe(true);
+    expect(aiUsageModel.getPendingCredits('u1')).toBe(8000);
+
+    // 240k recorded + 8k in flight + another 8k would exceed 250k — blocked.
+    const second = aiUsageModel.tryReserve('u1', 8000);
+    expect(second.ok).toBe(false);
+    expect(second.reason).toBe('daily');
+
+    // Releasing the reservation opens the gate again.
+    aiUsageModel.release('u1', 8000);
+    expect(aiUsageModel.getPendingCredits('u1')).toBe(0);
+    const third = aiUsageModel.tryReserve('u1', 8000);
+    expect(third.ok).toBe(true);
+    aiUsageModel.release('u1', 8000);
+  });
+
+  test('tryReserve is unlimited for developers', async () => {
+    const devId = process.env.ALLOWED_USERS?.split(',')[0];
+    if (!devId) return; // skip if no ALLOWED_USERS configured
+
+    await aiUsageModel.addUsage(devId, 'test-model', DAILY_LIMIT * 5, 0);
+    const gate = aiUsageModel.tryReserve(devId, 100000);
+    expect(gate.ok).toBe(true);
+    expect(aiUsageModel.getPendingCredits(devId)).toBe(0);
+  });
+
+  test('release never drives pending negative', async () => {
+    aiUsageModel.release('u1', 5000); // no reservation held
+    expect(aiUsageModel.getPendingCredits('u1')).toBe(0);
+
+    aiUsageModel.tryReserve('u1', 1000);
+    aiUsageModel.release('u1', 99999);
+    expect(aiUsageModel.getPendingCredits('u1')).toBe(0);
+  });
 });

--- a/tests/utils/aiPricing.test.ts
+++ b/tests/utils/aiPricing.test.ts
@@ -18,12 +18,12 @@ describe('creditsForTokens', () => {
     expect(creditsForTokens('xiaomi/mimo-v2.5', 100000, 50000)).toBe(100000);
   });
 
-  test('bills grok-4.5 at 7x in / 10.5x out', () => {
-    expect(creditsForTokens('x-ai/grok-4.5', 10000, 10000)).toBe(175000);
+  test('bills grok-4.5 at 7x in / 21.43x out ($2/M in, $6/M out)', () => {
+    expect(creditsForTokens('x-ai/grok-4.5', 10000, 10000)).toBe(284300);
   });
 
-  test('bills gpt-5.6-luna at 3.5x in / 10.5x out', () => {
-    expect(creditsForTokens('openai/gpt-5.6-luna', 10000, 10000)).toBe(140000);
+  test('bills gpt-5.6-luna at 3.5x in / 21.43x out ($1/M in, $6/M out)', () => {
+    expect(creditsForTokens('openai/gpt-5.6-luna', 10000, 10000)).toBe(249300);
   });
 });
 

--- a/tests/utils/aiPricing.test.ts
+++ b/tests/utils/aiPricing.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  creditsForTokens,
+  usdCostForTokens,
+  CREDIT_BASE_USD_PER_MILLION,
+} from '../../utils/aiPricing';
+
+describe('creditsForTokens', () => {
+  test('bills unknown models at 1x/1x (legacy raw-token behavior)', () => {
+    expect(creditsForTokens('some/unknown-model', 1000, 500)).toBe(1500);
+  });
+
+  test('bills deepseek-v4-flash at 0.5x in / 1x out', () => {
+    expect(creditsForTokens('deepseek/deepseek-v4-flash', 100000, 50000)).toBe(100000);
+  });
+
+  test('bills mimo-v2.5 at 0.5x in / 1x out', () => {
+    expect(creditsForTokens('xiaomi/mimo-v2.5', 100000, 50000)).toBe(100000);
+  });
+
+  test('bills grok-4.5 at 7x in / 10.5x out', () => {
+    expect(creditsForTokens('x-ai/grok-4.5', 10000, 10000)).toBe(175000);
+  });
+
+  test('bills gpt-5.6-luna at 3.5x in / 10.5x out', () => {
+    expect(creditsForTokens('openai/gpt-5.6-luna', 10000, 10000)).toBe(140000);
+  });
+});
+
+describe('usdCostForTokens', () => {
+  test('derives USD from credits at the $0.28/M base rate', () => {
+    // 1M in @0.5x + 1M out @1x = 1.5M credits → $0.42
+    expect(usdCostForTokens('deepseek/deepseek-v4-flash', 1_000_000, 1_000_000))
+      .toBeCloseTo(1.5 * CREDIT_BASE_USD_PER_MILLION, 10);
+  });
+
+  test('1x model: 1M tokens costs exactly the base rate', () => {
+    expect(usdCostForTokens('unknown/model', 1_000_000, 0))
+      .toBeCloseTo(CREDIT_BASE_USD_PER_MILLION, 10);
+  });
+});

--- a/tests/utils/llmRetry.test.ts
+++ b/tests/utils/llmRetry.test.ts
@@ -1,0 +1,105 @@
+import {
+  describe, test, expect,
+} from 'bun:test';
+import {
+  createChatCompletionWithRetry,
+  isRetryableCompletionError,
+  RETRY_DELAYS_MS,
+} from '../../utils/llmRetry';
+
+function fakeClient(behavior: ((call: number) => any)[]): { client: any; calls: () => number } {
+  let calls = 0;
+  const client = {
+    chat: {
+      completions: {
+        create: async (_body: any, _options?: any) => {
+          calls += 1;
+          const step = behavior[Math.min(calls - 1, behavior.length - 1)];
+          const result = step(calls);
+          if (result instanceof Error) throw result;
+          return result;
+        },
+      },
+    },
+  };
+  return { client, calls: () => calls };
+}
+
+const noSleep = () => Promise.resolve();
+
+function apiError(status: number | undefined, message = 'boom'): any {
+  const err: any = new Error(message);
+  err.status = status;
+  return err;
+}
+
+describe('isRetryableCompletionError', () => {
+  test('retries transient statuses', () => {
+    for (const status of [408, 409, 429, 500, 502, 503, 504]) {
+      expect(isRetryableCompletionError(apiError(status))).toBe(true);
+    }
+  });
+
+  test('does not retry client errors', () => {
+    for (const status of [400, 401, 402, 403, 404, 422]) {
+      expect(isRetryableCompletionError(apiError(status))).toBe(false);
+    }
+  });
+
+  test('retries network/timeout errors (no status)', () => {
+    expect(isRetryableCompletionError(apiError(undefined))).toBe(true);
+    expect(isRetryableCompletionError(new Error('fetch failed'))).toBe(true);
+  });
+});
+
+describe('createChatCompletionWithRetry', () => {
+  test('returns immediately on success', async () => {
+    const { client, calls } = fakeClient([() => ({ ok: true })]);
+    const res = await createChatCompletionWithRetry(client, {}, { sleep: noSleep });
+    expect(res).toEqual({ ok: true });
+    expect(calls()).toBe(1);
+  });
+
+  test('retries transient failures with the 2/4/8/16 backoff', async () => {
+    const { client, calls } = fakeClient([
+      () => apiError(500),
+      () => apiError(429),
+      () => ({ ok: true }),
+    ]);
+    const sleeps: number[] = [];
+    const res = await createChatCompletionWithRetry(client, {}, {
+      sleep: (ms) => { sleeps.push(ms); return Promise.resolve(); },
+    });
+    expect(res).toEqual({ ok: true });
+    expect(calls()).toBe(3);
+    expect(sleeps).toEqual([RETRY_DELAYS_MS[0], RETRY_DELAYS_MS[1]]);
+  });
+
+  test('does not retry non-retryable errors', async () => {
+    const { client, calls } = fakeClient([() => apiError(400, 'bad request')]);
+    await expect(createChatCompletionWithRetry(client, {}, { sleep: noSleep }))
+      .rejects.toThrow('bad request');
+    expect(calls()).toBe(1);
+  });
+
+  test('gives up after the backoff schedule is exhausted', async () => {
+    const { client, calls } = fakeClient([() => apiError(503)]);
+    await expect(createChatCompletionWithRetry(client, {}, { sleep: noSleep }))
+      .rejects.toThrow('boom');
+    // 1 initial attempt + one per backoff delay
+    expect(calls()).toBe(1 + RETRY_DELAYS_MS.length);
+  });
+
+  test('passes the per-attempt timeout through to the SDK', async () => {
+    let seenOptions: any;
+    const client = {
+      chat: {
+        completions: {
+          create: async (_body: any, options?: any) => { seenOptions = options; return { ok: true }; },
+        },
+      },
+    };
+    await createChatCompletionWithRetry(client, {}, { timeoutMs: 12345, sleep: noSleep });
+    expect(seenOptions?.timeout).toBe(12345);
+  });
+});

--- a/tests/utils/llmRetry.test.ts
+++ b/tests/utils/llmRetry.test.ts
@@ -47,8 +47,15 @@ describe('isRetryableCompletionError', () => {
   });
 
   test('retries network/timeout errors (no status)', () => {
-    expect(isRetryableCompletionError(apiError(undefined))).toBe(true);
     expect(isRetryableCompletionError(new Error('fetch failed'))).toBe(true);
+    expect(isRetryableCompletionError(new Error('request timeout'))).toBe(true);
+    expect(isRetryableCompletionError({ name: 'APIConnectionError' })).toBe(true);
+    expect(isRetryableCompletionError({ code: 'ECONNRESET' })).toBe(true);
+  });
+
+  test('does not retry local validation/type errors with no status', () => {
+    expect(isRetryableCompletionError(new TypeError('Cannot read property of undefined'))).toBe(false);
+    expect(isRetryableCompletionError(new Error('boom'))).toBe(false);
   });
 });
 

--- a/tests/utils/llmRetry.test.ts
+++ b/tests/utils/llmRetry.test.ts
@@ -90,6 +90,15 @@ describe('createChatCompletionWithRetry', () => {
     expect(calls()).toBe(1 + RETRY_DELAYS_MS.length);
   });
 
+  test('stops retrying once the overall time budget is exhausted', async () => {
+    const { client, calls } = fakeClient([() => apiError(503)]);
+    await expect(
+      createChatCompletionWithRetry(client, {}, { sleep: noSleep, overallTimeoutMs: 0 }),
+    ).rejects.toThrow('boom');
+    // The first attempt always runs; with no budget left, no retry is allowed.
+    expect(calls()).toBe(1);
+  });
+
   test('passes the per-attempt timeout through to the SDK', async () => {
     let seenOptions: any;
     const client = {

--- a/utils/ai.ts
+++ b/utils/ai.ts
@@ -3,9 +3,11 @@ import { OpenAI } from 'openai';
 import mime from 'mime';
 import type Database from '../database/Database';
 import { logError, logWarning } from './log';
-import { recordUsage } from './tokenCalibration';
+import { recordUsage, getCalibrationMultiplier } from './tokenCalibration';
 import { countTokensOpenRouterMessages } from './tokenizer';
 import { listSearchTools, listSearchToolsGemini, callSearchTool } from './mcp';
+import { creditsForTokens } from './aiPricing';
+import { createChatCompletionWithRetry } from './llmRetry';
 import {
   IMAGE_GEN_TOOL_NAME,
   IMAGE_GEN_DAILY_LIMIT,
@@ -34,6 +36,9 @@ const genAI = new GoogleGenerativeAI(process.env.GEMINI_TOKEN!);
 const openrouter = new OpenAI({
   baseURL: 'https://openrouter.ai/api/v1',
   apiKey: process.env.OPENROUTER_API_KEY,
+  // Retries/timeouts are handled by createChatCompletionWithRetry (utils/llmRetry)
+  // — don't let the SDK's own retry loop stack on top of that schedule.
+  maxRetries: 0,
   defaultHeaders: {
     'HTTP-Referer': 'https://bot.silverwolf.dev/',
     'X-Title': 'Silverwolf',
@@ -169,6 +174,8 @@ export function formatHistoryEntryForModel(entry: Pick<HistoryEntry, 'role' | 'm
   return stripModelTimestampPrefix(entry.message);
 }
 
+// Per-user fixed-window budgets, metered in CREDITS (see utils/aiPricing.ts) —
+// cheap models get more raw tokens per credit than expensive ones.
 export const DAILY_LIMIT = 250000;
 export const WEEKLY_LIMIT = 1000000;
 
@@ -276,9 +283,6 @@ function getPersonaModelName(personaName: string): string {
 }
 
 /**
- * Generates content (text and/or images) from the specified AI provider and model.
- */
-/**
  * Model + output modalities used by the generate_image tool — config lives in the
  * non-invokable "Imgen" persona. Image-only models (Flux, Recraft…) must request
  * ["image"]; hybrid models (Gemini image, GPT image) want ["image", "text"].
@@ -290,17 +294,10 @@ function getImageGenConfig(): { model: string; modalities: string[] } {
   return { model: imgen?.model || IMAGE_GEN_FALLBACK_MODEL, modalities };
 }
 
-async function generateContent({
+async function generateContentInner({
   db, userId, provider, model, systemPrompt, prompt, history = [], webSearchEnabled = false, imageGen, musicGen,
   mediaParts = [], providerRouting,
 }: GenerateContentOptions): Promise<GenerateContentResult> {
-  if (db && userId) {
-    const isLimited = await db.aiUsage.isRateLimited(userId);
-    if (isLimited) {
-      throw new Error('RATE_LIMIT_EXCEEDED');
-    }
-  }
-
   let totalPromptTokens = 0;
   let totalCompletionTokens = 0;
 
@@ -399,8 +396,12 @@ ${systemPrompt || ''}
 
       let completion: any;
       try {
+        // Music composing turns emit a large composition JSON under a raised
+        // max_tokens cap — give them a longer per-attempt timeout.
         // eslint-disable-next-line no-await-in-loop
-        completion = await openrouter.chat.completions.create(requestBody);
+        completion = await createChatCompletionWithRetry(openrouter, requestBody, {
+          timeoutMs: musicGuideRead ? 480_000 : undefined,
+        });
       } catch (err: any) {
         const msg = (err?.message || '').toLowerCase();
         const status = err?.status;
@@ -808,6 +809,50 @@ ${systemPrompt || ''}
   throw new Error(`Unknown provider: ${provider}`);
 }
 
+// Flat completion-side allowance for the in-flight reservation estimate. Actual
+// usage is recorded from the provider's real usage fields — the estimate only
+// bounds how many concurrent requests can be in flight before the limit bites.
+const ESTIMATED_COMPLETION_TOKENS = 4096;
+
+/**
+ * Rough credit cost of a request, computed from its inputs before any API call.
+ * Used for the in-flight reservation (see AiUsageModel.tryReserve) — accuracy
+ * only needs to be same-order; tool loops and media are deliberately uncounted.
+ */
+function estimateRequestCredits({
+  provider, model, systemPrompt, prompt, history = [],
+}: GenerateContentOptions): number {
+  const estPromptTokens = countTokensOpenRouterMessages([
+    { role: 'system', content: systemPrompt },
+    ...history.map((h) => ({ role: h.role, content: h.message })),
+    { role: 'user', content: prompt },
+  ]) * (provider === 'openrouter' ? getCalibrationMultiplier(model) : 1);
+  return creditsForTokens(model, estPromptTokens, ESTIMATED_COMPLETION_TOKENS);
+}
+
+/**
+ * Generates content (text and/or images) from the specified AI provider and model.
+ * Enforces the per-user credit rate limit with an in-flight reservation: the
+ * estimated cost is held against the user's budget for the whole generation, so
+ * a spammed burst of concurrent requests can't all pass the check before any of
+ * them records usage (issue #213).
+ */
+async function generateContent(opts: GenerateContentOptions): Promise<GenerateContentResult> {
+  const { db, userId } = opts;
+  if (!db || !userId) return generateContentInner(opts);
+
+  const reserved = Math.ceil(estimateRequestCredits(opts));
+  const gate = db.aiUsage.tryReserve(userId, reserved);
+  if (!gate.ok) {
+    throw new Error('RATE_LIMIT_EXCEEDED');
+  }
+  try {
+    return await generateContentInner(opts);
+  } finally {
+    db.aiUsage.release(userId, reserved);
+  }
+}
+
 /**
  * Gets the Gemini AI instance for direct usage
  */
@@ -920,7 +965,7 @@ async function generateSessionTitle(conversation: string): Promise<string | null
         logError('TitleGen: OPENROUTER_API_KEY not set');
         return null;
       }
-      const completion = await openrouter.chat.completions.create({
+      const completion = await createChatCompletionWithRetry(openrouter, {
         model: persona.model,
         messages: [
           { role: 'system', content: systemPrompt },
@@ -929,7 +974,7 @@ async function generateSessionTitle(conversation: string): Promise<string | null
         ],
         max_tokens: 512,
         reasoning: { enabled: false },
-      } as any);
+      } as any, { timeoutMs: 60_000 });
       raw = completion.choices?.[0]?.message?.content ?? null;
     } else if (persona.provider === 'gemini') {
       const model = genAI.getGenerativeModel({

--- a/utils/ai.ts
+++ b/utils/ai.ts
@@ -6,7 +6,7 @@ import { logError, logWarning } from './log';
 import { recordUsage, getCalibrationMultiplier } from './tokenCalibration';
 import { countTokensOpenRouterMessages } from './tokenizer';
 import { listSearchTools, listSearchToolsGemini, callSearchTool } from './mcp';
-import { creditsForTokens } from './aiPricing';
+import { creditsForTokens, ESTIMATED_COMPLETION_TOKENS } from './aiPricing';
 import { createChatCompletionWithRetry } from './llmRetry';
 import {
   IMAGE_GEN_TOOL_NAME,
@@ -808,11 +808,6 @@ ${systemPrompt || ''}
 
   throw new Error(`Unknown provider: ${provider}`);
 }
-
-// Flat completion-side allowance for the in-flight reservation estimate. Actual
-// usage is recorded from the provider's real usage fields — the estimate only
-// bounds how many concurrent requests can be in flight before the limit bites.
-const ESTIMATED_COMPLETION_TOKENS = 4096;
 
 /**
  * Rough credit cost of a request, computed from its inputs before any API call.

--- a/utils/aiPricing.ts
+++ b/utils/aiPricing.ts
@@ -1,0 +1,60 @@
+/**
+ * Credit pricing for AI rate limits (issue #211).
+ *
+ * Rate limits are metered in CREDITS, not raw tokens: each model has an
+ * input/output multiplier where $0.28 per million tokens = 1x, so expensive
+ * models drain a user's budget faster and cheap models (DeepSeek, MiMo) get
+ * roughly double the headroom of the old flat token counter.
+ *
+ *   credits = (prompt_tokens × mult_in) + (completion_tokens × mult_out)
+ *
+ * The AiUsage audit log also stores the derived USD cost (credits × $0.28/M)
+ * per call in its `cost` column.
+ */
+
+/** $ per million tokens that defines the 1x multiplier. */
+export const CREDIT_BASE_USD_PER_MILLION = 0.28;
+
+interface ModelMultipliers {
+  input: number;
+  output: number;
+}
+
+// Multipliers per the issue #211 table ($0.28/M = 1x). Models not listed here
+// bill at 1x/1x (identical to the old raw-token accounting).
+const MODEL_MULTIPLIERS: Record<string, ModelMultipliers> = {
+  // $0.14/M in, $0.28/M out
+  'deepseek/deepseek-v4-flash': { input: 0.5, output: 1 },
+  // $0.14/M in, $0.28/M out
+  'xiaomi/mimo-v2.5': { input: 0.5, output: 1 },
+  // $2/M in, $6/M out
+  'x-ai/grok-4.5': { input: 7, output: 10.5 },
+  // $1/M in, $6/M out
+  'openai/gpt-5.6-luna': { input: 3.5, output: 10.5 },
+};
+
+const DEFAULT_MULTIPLIERS: ModelMultipliers = { input: 1, output: 1 };
+
+function getModelMultipliers(model: string): ModelMultipliers {
+  return MODEL_MULTIPLIERS[model] ?? DEFAULT_MULTIPLIERS;
+}
+
+/** Credits charged for a call. Fractional — callers round as needed. */
+export function creditsForTokens(
+  model: string,
+  promptTokens: number,
+  completionTokens: number,
+): number {
+  const mult = getModelMultipliers(model);
+  return promptTokens * mult.input + completionTokens * mult.output;
+}
+
+/** USD cost derived from the same multipliers (credits × $0.28 per 1M). */
+export function usdCostForTokens(
+  model: string,
+  promptTokens: number,
+  completionTokens: number,
+): number {
+  return (creditsForTokens(model, promptTokens, completionTokens)
+    * CREDIT_BASE_USD_PER_MILLION) / 1_000_000;
+}

--- a/utils/aiPricing.ts
+++ b/utils/aiPricing.ts
@@ -20,7 +20,7 @@ interface ModelMultipliers {
   output: number;
 }
 
-// Multipliers per the issue #211 table ($0.28/M = 1x). Models not listed here
+// Multipliers per live OpenRouter pricing ($0.28/M = 1x). Models not listed here
 // bill at 1x/1x (identical to the old raw-token accounting).
 const MODEL_MULTIPLIERS: Record<string, ModelMultipliers> = {
   // $0.14/M in, $0.28/M out
@@ -28,12 +28,20 @@ const MODEL_MULTIPLIERS: Record<string, ModelMultipliers> = {
   // $0.14/M in, $0.28/M out
   'xiaomi/mimo-v2.5': { input: 0.5, output: 1 },
   // $2/M in, $6/M out
-  'x-ai/grok-4.5': { input: 7, output: 10.5 },
+  'x-ai/grok-4.5': { input: 7, output: 21.43 },
   // $1/M in, $6/M out
-  'openai/gpt-5.6-luna': { input: 3.5, output: 10.5 },
+  'openai/gpt-5.6-luna': { input: 3.5, output: 21.43 },
 };
 
 const DEFAULT_MULTIPLIERS: ModelMultipliers = { input: 1, output: 1 };
+
+/**
+ * Flat completion-side allowance for in-flight rate-limit reservations (see
+ * AiUsageModel.tryReserve). Actual usage is recorded from the provider's real
+ * usage fields — the estimate only bounds how many concurrent requests can be
+ * in flight before the limit bites.
+ */
+export const ESTIMATED_COMPLETION_TOKENS = 4096;
 
 function getModelMultipliers(model: string): ModelMultipliers {
   return MODEL_MULTIPLIERS[model] ?? DEFAULT_MULTIPLIERS;

--- a/utils/discordRateLimit.ts
+++ b/utils/discordRateLimit.ts
@@ -44,7 +44,7 @@ export async function getRateLimitErrorMessage(userId: string, db: Database): Pr
     ? `Your limit resets ${formatResetTimestamp(resetAt)}.`
     : 'Please wait for your limit to reset.';
 
-  return `⚠️ **${limitLabel} AI Rate Limit Reached**\nYou've used **${usageVal.toLocaleString()}** / **${limitVal.toLocaleString()}** tokens in the current ${windowLabel} window. ${resetNote}`;
+  return `⚠️ **${limitLabel} AI Rate Limit Reached**\nYou've used **${usageVal.toLocaleString()}** / **${limitVal.toLocaleString()}** credits in the current ${windowLabel} window. ${resetNote}`;
 }
 
 export async function handleRateLimitError(

--- a/utils/llmRetry.ts
+++ b/utils/llmRetry.ts
@@ -1,4 +1,4 @@
-import { logWarning } from './log';
+import { log } from './log';
 
 /**
  * Timeout + retry wrapper for OpenRouter chat completions (issue #209).
@@ -35,10 +35,52 @@ export const DEFAULT_OVERALL_TIMEOUT_MS = 600_000;
  *  network failures are; client errors (400/401/402/403/404…) are not. */
 export function isRetryableCompletionError(err: any): boolean {
   const status = err?.status;
-  // No status = connection/timeout error before an HTTP response arrived.
-  if (typeof status !== 'number') return true;
-  if (status === 408 || status === 409 || status === 429) return true;
-  return status >= 500;
+  if (typeof status === 'number') {
+    if (status === 408 || status === 409 || status === 429) return true;
+    return status >= 500;
+  }
+
+  if (!err) return false;
+
+  const name = String(err.name || '');
+  const code = String(err.code || err.cause?.code || '');
+  const message = String(err.message || '').toLowerCase();
+
+  const networkNames = new Set([
+    'APIConnectionError',
+    'APIConnectionTimeoutError',
+    'TimeoutError',
+    'AbortError',
+    'FetchError',
+    'NetworkError',
+  ]);
+  if (networkNames.has(name)) return true;
+
+  const networkCodes = new Set([
+    'ECONNRESET',
+    'ETIMEDOUT',
+    'ECONNREFUSED',
+    'ENOTFOUND',
+    'EPIPE',
+    'UND_ERR_CONNECT_TIMEOUT',
+    'EAI_AGAIN',
+    'ABORT_ERR',
+    'ERR_NETWORK',
+  ]);
+  if (networkCodes.has(code)) return true;
+
+  if (
+    message.includes('fetch failed')
+    || message.includes('timeout')
+    || message.includes('network')
+    || message.includes('connection')
+    || message.includes('econnreset')
+    || message.includes('etimedout')
+  ) {
+    return true;
+  }
+
+  return false;
 }
 
 interface ChatCompletionsClient {
@@ -76,7 +118,7 @@ export async function createChatCompletionWithRetry(
     // The first attempt always runs; later ones only while budget remains.
     const remaining = deadline - Date.now();
     if (attempt > 0 && remaining <= 0) {
-      logWarning(`[llm] overall retry budget exhausted after ${attempt} attempt(s); giving up`);
+      log(`[llm] overall retry budget exhausted after ${attempt} attempt(s); giving up`);
       break;
     }
     try {
@@ -90,8 +132,13 @@ export async function createChatCompletionWithRetry(
       if (!hasRetryLeft || !isRetryableCompletionError(err)) {
         throw err;
       }
-      const delay = delays[attempt];
-      logWarning(
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) {
+        log(`[llm] overall retry budget exhausted after ${attempt + 1} attempt(s); giving up`);
+        break;
+      }
+      const delay = Math.min(delays[attempt], remainingMs);
+      log(
         `[llm] completion failed (status ${err?.status ?? 'network/timeout'}), `
         + `retrying in ${delay / 1000}s (attempt ${attempt + 1}/${delays.length})`,
       );

--- a/utils/llmRetry.ts
+++ b/utils/llmRetry.ts
@@ -10,6 +10,12 @@ import { logWarning } from './log';
  * (bad request, auth, model rejects tools…) throws immediately so callers'
  * existing error handling (e.g. the tool-reject retry in ai.ts) is unaffected.
  *
+ * The whole operation is bounded by an overall deadline (default 10 minutes —
+ * the SDK's previous single-request timeout): each attempt gets
+ * min(per-attempt timeout, remaining budget), and retries stop once the budget
+ * is spent, so a pathologically slow provider can't hold a reply hostage
+ * longer than one old-style request would have.
+ *
  * The shared OpenRouter client is constructed with maxRetries: 0 so the SDK's
  * own retry loop doesn't stack on top of this schedule.
  */
@@ -20,6 +26,10 @@ export const RETRY_DELAYS_MS = [2000, 4000, 8000, 16000];
 /** Per-attempt request timeout. Long enough for reasoning models, short enough
  *  that a wedged connection errors instead of hanging for 10 minutes. */
 export const DEFAULT_TIMEOUT_MS = 180_000;
+
+/** Overall elapsed-time budget for the whole retry operation — the SDK's
+ *  previous single-request timeout (10 minutes). */
+export const DEFAULT_OVERALL_TIMEOUT_MS = 600_000;
 
 /** Is this failure worth retrying? Rate limits, server errors, timeouts and
  *  network failures are; client errors (400/401/402/403/404…) are not. */
@@ -42,6 +52,9 @@ interface ChatCompletionsClient {
 interface RetryOptions {
   /** Per-attempt timeout in ms (default DEFAULT_TIMEOUT_MS). */
   timeoutMs?: number;
+  /** Total elapsed-time budget across all attempts in ms
+   *  (default DEFAULT_OVERALL_TIMEOUT_MS). */
+  overallTimeoutMs?: number;
   /** Backoff schedule in ms (default RETRY_DELAYS_MS). */
   delaysMs?: number[];
   /** Sleep between attempts — injectable for tests. */
@@ -54,14 +67,23 @@ export async function createChatCompletionWithRetry(
   opts: RetryOptions = {},
 ): Promise<any> {
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const deadline = Date.now() + (opts.overallTimeoutMs ?? DEFAULT_OVERALL_TIMEOUT_MS);
   const delays = opts.delaysMs ?? RETRY_DELAYS_MS;
   const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((resolve) => { setTimeout(resolve, ms); }));
 
   let lastErr: any;
   for (let attempt = 0; attempt <= delays.length; attempt += 1) {
+    // The first attempt always runs; later ones only while budget remains.
+    const remaining = deadline - Date.now();
+    if (attempt > 0 && remaining <= 0) {
+      logWarning(`[llm] overall retry budget exhausted after ${attempt} attempt(s); giving up`);
+      break;
+    }
     try {
       // eslint-disable-next-line no-await-in-loop
-      return await client.chat.completions.create(body, { timeout: timeoutMs });
+      return await client.chat.completions.create(body, {
+        timeout: Math.max(1, Math.min(timeoutMs, remaining)),
+      });
     } catch (err: any) {
       lastErr = err;
       const hasRetryLeft = attempt < delays.length;

--- a/utils/llmRetry.ts
+++ b/utils/llmRetry.ts
@@ -1,0 +1,81 @@
+import { logWarning } from './log';
+
+/**
+ * Timeout + retry wrapper for OpenRouter chat completions (issue #209).
+ *
+ * Every attempt gets its own hard timeout (the SDK default is 10 minutes, so a
+ * hung provider stalled a reply for ages before erroring). Transient failures
+ * — 408/409/429, 5xx, network errors, timeouts — retry with exponential
+ * backoff of 2s, 4s, 8s, 16s (16s max), then give up. Non-retryable 4xx
+ * (bad request, auth, model rejects tools…) throws immediately so callers'
+ * existing error handling (e.g. the tool-reject retry in ai.ts) is unaffected.
+ *
+ * The shared OpenRouter client is constructed with maxRetries: 0 so the SDK's
+ * own retry loop doesn't stack on top of this schedule.
+ */
+
+/** Backoff delays between attempts: 2s → 4s → 8s → 16s (max), then error out. */
+export const RETRY_DELAYS_MS = [2000, 4000, 8000, 16000];
+
+/** Per-attempt request timeout. Long enough for reasoning models, short enough
+ *  that a wedged connection errors instead of hanging for 10 minutes. */
+export const DEFAULT_TIMEOUT_MS = 180_000;
+
+/** Is this failure worth retrying? Rate limits, server errors, timeouts and
+ *  network failures are; client errors (400/401/402/403/404…) are not. */
+export function isRetryableCompletionError(err: any): boolean {
+  const status = err?.status;
+  // No status = connection/timeout error before an HTTP response arrived.
+  if (typeof status !== 'number') return true;
+  if (status === 408 || status === 409 || status === 429) return true;
+  return status >= 500;
+}
+
+interface ChatCompletionsClient {
+  chat: {
+    completions: {
+      create: (body: any, options?: { timeout?: number }) => Promise<any>;
+    };
+  };
+}
+
+interface RetryOptions {
+  /** Per-attempt timeout in ms (default DEFAULT_TIMEOUT_MS). */
+  timeoutMs?: number;
+  /** Backoff schedule in ms (default RETRY_DELAYS_MS). */
+  delaysMs?: number[];
+  /** Sleep between attempts — injectable for tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export async function createChatCompletionWithRetry(
+  client: ChatCompletionsClient,
+  body: any,
+  opts: RetryOptions = {},
+): Promise<any> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const delays = opts.delaysMs ?? RETRY_DELAYS_MS;
+  const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((resolve) => { setTimeout(resolve, ms); }));
+
+  let lastErr: any;
+  for (let attempt = 0; attempt <= delays.length; attempt += 1) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      return await client.chat.completions.create(body, { timeout: timeoutMs });
+    } catch (err: any) {
+      lastErr = err;
+      const hasRetryLeft = attempt < delays.length;
+      if (!hasRetryLeft || !isRetryableCompletionError(err)) {
+        throw err;
+      }
+      const delay = delays[attempt];
+      logWarning(
+        `[llm] completion failed (status ${err?.status ?? 'network/timeout'}), `
+        + `retrying in ${delay / 1000}s (attempt ${attempt + 1}/${delays.length})`,
+      );
+      // eslint-disable-next-line no-await-in-loop
+      await sleep(delay);
+    }
+  }
+  throw lastErr;
+}

--- a/utils/rpChat.ts
+++ b/utils/rpChat.ts
@@ -1,7 +1,7 @@
 import { getOpenRouterClient } from './ai';
 import { countTokensOpenRouterMessages, countTokensOpenRouter } from './tokenizer';
 import { applyUserVar } from './rpIdentity';
-import { creditsForTokens } from './aiPricing';
+import { creditsForTokens, ESTIMATED_COMPLETION_TOKENS } from './aiPricing';
 import { createChatCompletionWithRetry } from './llmRetry';
 import {
   collectTriggeredContexts, findRecallMarkers, stripRecallMarkers, formatRecallMarker,
@@ -26,8 +26,6 @@ import { logError, log } from './log';
 
 export const RP_MODEL = 'deepseek/deepseek-v4-flash';
 const RP_MAX_OUTPUT = 8192;
-// Completion-side allowance for the in-flight rate-limit reservation estimate.
-const RP_COMPLETION_ESTIMATE = 4096;
 // With reasoning enabled, thinking tokens draw from the same max_tokens budget as
 // the visible reply, so every call reserves this much extra headroom on top of its
 // intended output size — otherwise a long think can truncate (or empty) the content.
@@ -428,7 +426,7 @@ export async function generateRpReply(
     // concurrent replies can't all pass the early check before any records land.
     if (triggeringUserId) {
       reservedCredits = Math.ceil(
-        creditsForTokens(RP_MODEL, estimateTokens(systemPrompt, tail), RP_COMPLETION_ESTIMATE),
+        creditsForTokens(RP_MODEL, estimateTokens(systemPrompt, tail), ESTIMATED_COMPLETION_TOKENS),
       );
       const gate = db.aiUsage.tryReserve(triggeringUserId, reservedCredits);
       if (!gate.ok) {

--- a/utils/rpChat.ts
+++ b/utils/rpChat.ts
@@ -1,6 +1,8 @@
 import { getOpenRouterClient } from './ai';
 import { countTokensOpenRouterMessages, countTokensOpenRouter } from './tokenizer';
 import { applyUserVar } from './rpIdentity';
+import { creditsForTokens } from './aiPricing';
+import { createChatCompletionWithRetry } from './llmRetry';
 import {
   collectTriggeredContexts, findRecallMarkers, stripRecallMarkers, formatRecallMarker,
   INJECTION_MAX_TOKENS,
@@ -24,6 +26,8 @@ import { logError, log } from './log';
 
 export const RP_MODEL = 'deepseek/deepseek-v4-flash';
 const RP_MAX_OUTPUT = 8192;
+// Completion-side allowance for the in-flight rate-limit reservation estimate.
+const RP_COMPLETION_ESTIMATE = 4096;
 // With reasoning enabled, thinking tokens draw from the same max_tokens budget as
 // the visible reply, so every call reserves this much extra headroom on top of its
 // intended output size — otherwise a long think can truncate (or empty) the content.
@@ -166,7 +170,7 @@ async function callDeepseek(
     throw new Error('OPENROUTER_API_KEY is not set');
   }
   const openrouter = getOpenRouterClient();
-  const completion = await openrouter.chat.completions.create({
+  const completion = await createChatCompletionWithRetry(openrouter, {
     model: RP_MODEL,
     messages,
     max_tokens: maxTokens + RP_REASONING_HEADROOM,
@@ -332,6 +336,11 @@ export async function generateRpReply(
   userVar: string | null = null,
   persona: string | null = null,
 ): Promise<RpReplyResult> {
+  // In-flight credit reservation against the triggering user's rate limit
+  // (released in the finally below) — closes the check-then-act race where a
+  // spammed burst all passed the limit check before any usage was recorded.
+  let reservedUserId: string | null = null;
+  let reservedCredits = 0;
   try {
     const wasFailed = spawn.compactionFailed;
     let memory = spawn.compactedMemory;
@@ -349,6 +358,8 @@ export async function generateRpReply(
     }
     const triggeringUserId = lastUserTurn?.speakerId;
     if (triggeringUserId) {
+      // Cheap early-out: skips lorebook/compaction work for clearly-limited
+      // users. The authoritative check is the reservation below.
       const isLimited = await db.aiUsage.isRateLimited(triggeringUserId);
       if (isLimited) {
         return { ok: false, reason: 'rate_limited' };
@@ -412,6 +423,21 @@ export async function generateRpReply(
       return res.text.trim();
     };
 
+    // Authoritative rate-limit gate: hold the estimated credit cost of this
+    // reply against the triggering user's budget for the whole generation, so
+    // concurrent replies can't all pass the early check before any records land.
+    if (triggeringUserId) {
+      reservedCredits = Math.ceil(
+        creditsForTokens(RP_MODEL, estimateTokens(systemPrompt, tail), RP_COMPLETION_ESTIMATE),
+      );
+      const gate = db.aiUsage.tryReserve(triggeringUserId, reservedCredits);
+      if (!gate.ok) {
+        reservedCredits = 0;
+        return { ok: false, reason: 'rate_limited' };
+      }
+      reservedUserId = triggeringUserId;
+    }
+
     let text = await generate(systemPrompt);
 
     // Skill recall: the model asked to consult reference notes. Inject them (within
@@ -472,5 +498,7 @@ export async function generateRpReply(
   } catch (err) {
     logError(`Rp: generation failed for spawn ${spawn.spawnId}:`, err);
     return { ok: false, reason: 'error' };
+  } finally {
+    if (reservedUserId) db.aiUsage.release(reservedUserId, reservedCredits);
   }
 }

--- a/utils/rpChat.ts
+++ b/utils/rpChat.ts
@@ -210,7 +210,7 @@ async function compact(
   tail: RpHistoryTurn[],
   priorMemory: string | null,
   persona: string | null,
-): Promise<{ ok: boolean; memory?: string; uptoId?: number }> {
+): Promise<{ ok: boolean; memory?: string; uptoId?: number; promptTokens?: number; completionTokens?: number }> {
   if (tail.length < MIN_ROWS_TO_COMPACT) return { ok: true };
 
   // Find the split so ~COMPACT_FRACTION of the tail's tokens are folded.
@@ -251,12 +251,16 @@ Output ONLY the updated memory wrapped exactly as ${MEMORY_OPEN}...${MEMORY_CLOS
   const userPrompt = `${priorMemory ? `Existing memory:\n${priorMemory}\n\n` : ''}Recent events to absorb:\n${transcript}\n\nProduce the updated memory now, wrapped in ${MEMORY_OPEN} and ${MEMORY_CLOSE}.`;
 
   let raw = '';
+  let promptTokens = 0;
+  let completionTokens = 0;
   try {
     const res = await callDeepseek(
       [{ role: 'system', content: systemPrompt }, { role: 'user', content: userPrompt }],
       4096,
     );
     raw = res.text;
+    promptTokens = res.promptTokens;
+    completionTokens = res.completionTokens;
   } catch (err) {
     logError(`Rp: compaction request failed for spawn ${spawnId}:`, err);
     return { ok: false };
@@ -270,7 +274,9 @@ Output ONLY the updated memory wrapped exactly as ${MEMORY_OPEN}...${MEMORY_CLOS
 
   await db.rp.setCompactionState(spawnId, memory, newUptoId);
   log(`Rp: compacted spawn ${spawnId} (folded ${toFold.length} rows up to id ${newUptoId})`);
-  return { ok: true, memory, uptoId: newUptoId };
+  return {
+    ok: true, memory, uptoId: newUptoId, promptTokens, completionTokens,
+  };
 }
 
 export type RpReplyResult =
@@ -377,10 +383,33 @@ export async function generateRpReply(
     const extras = buildExtras(lorebooks, tail, persona);
     let systemPrompt = buildSystemPrompt(character, memory, userVar, extras);
 
+    // Authoritative rate-limit gate: hold the estimated credit cost of this reply
+    // (covering compaction if needed + up to two generation attempts) against
+    // the triggering user's budget before any LLM calls are issued.
+    if (triggeringUserId) {
+      const initialTokens = estimateTokens(systemPrompt, tail);
+      const willCompact = spawn.compactionEnabled && initialTokens > COMPACTION_TRIGGER_TOKENS;
+      const compactionEstCredits = willCompact
+        ? creditsForTokens(RP_MODEL, initialTokens, 4096)
+        : 0;
+      const maxGenCalls = extras.skills.length > 0 ? 2 : 1;
+      const genEstCredits = creditsForTokens(RP_MODEL, initialTokens, ESTIMATED_COMPLETION_TOKENS) * maxGenCalls;
+
+      reservedCredits = Math.ceil(compactionEstCredits + genEstCredits);
+      const gate = db.aiUsage.tryReserve(triggeringUserId, reservedCredits);
+      if (!gate.ok) {
+        reservedCredits = 0;
+        return { ok: false, reason: 'rate_limited' };
+      }
+      reservedUserId = triggeringUserId;
+    }
+
     if (estimateTokens(systemPrompt, tail) > COMPACTION_TRIGGER_TOKENS) {
       if (spawn.compactionEnabled) {
         const res = await compact(db, spawn.spawnId, character, tail, memory, persona);
         if (res.ok && res.memory) {
+          totalPromptTokens += res.promptTokens ?? 0;
+          totalCompletionTokens += res.completionTokens ?? 0;
           memory = res.memory;
           uptoId = res.uptoId ?? uptoId;
           tail = await loadTail(db, spawn.spawnId, uptoId);
@@ -420,21 +449,6 @@ export async function generateRpReply(
       totalCompletionTokens += res.completionTokens;
       return res.text.trim();
     };
-
-    // Authoritative rate-limit gate: hold the estimated credit cost of this
-    // reply against the triggering user's budget for the whole generation, so
-    // concurrent replies can't all pass the early check before any records land.
-    if (triggeringUserId) {
-      reservedCredits = Math.ceil(
-        creditsForTokens(RP_MODEL, estimateTokens(systemPrompt, tail), ESTIMATED_COMPLETION_TOKENS),
-      );
-      const gate = db.aiUsage.tryReserve(triggeringUserId, reservedCredits);
-      if (!gate.ok) {
-        reservedCredits = 0;
-        return { ok: false, reason: 'rate_limited' };
-      }
-      reservedUserId = triggeringUserId;
-    }
 
     let text = await generate(systemPrompt);
 

--- a/utils/tokenizer.ts
+++ b/utils/tokenizer.ts
@@ -63,6 +63,8 @@ const CONTEXT_LIMITS: Record<string, number> = {
   // 1M on the pinned Xiaomi endpoint; media (base64 parts) is not counted by
   // the tokenizer, so leave the standard reserve headroom to absorb it.
   'xiaomi/mimo-v2.5': 1_000_000,
+  'x-ai/grok-4.5': 500_000,
+  'openai/gpt-5.6-luna': 1_050_000,
   // Default for unknown models
   default: 128_000,
 };


### PR DESCRIPTION
Closes #213, closes #211, closes #209.

## #213 — rate limits bypassable under spam (root-caused)

Two distinct bugs:

1. **Lost usage writes (the big one).** `Database.executeTransaction` wasn't re-entrant: several callers pass `async` fns that await mid-transaction, so a concurrent second transaction hit `BEGIN` inside an open transaction — and its catch-block `ROLLBACK` **silently discarded the first transaction's writes**. `addUsage` failures are swallowed (log-only) in `ai.ts`, so under spam, usage records vanished while the user still got replies (391k/250k recorded and still active).
   **Fix:** transactions are serialized through an in-process FIFO queue + a guard that fails loudly on nesting.
2. **Check-then-act race.** The limit was checked at generation *start* and usage recorded at *end* — a spammed burst all passed before anything landed.
   **Fix:** `AiUsageModel.tryReserve()`/`release()` — a fully synchronous (atomic in this single-threaded process) in-memory reservation of estimated credits held for the whole generation, wired into `generateContent` (estimate from system+history+prompt via tokenizer+calibration) and `generateRpReply` (estimate from the final post-compaction prompt). Devs still bypass.

## #211 — credits instead of raw tokens

- New `utils/aiPricing.ts`: **$0.28/M = 1x**, `credits = tok_in×mult_in + tok_out×mult_out`.
  - DeepSeek-V4-Flash & MiMo-V2.5: **0.5x in / 1x out** (verified vs live OpenRouter pricing — doubles their effective limits)
  - Grok-4.5: **7x / 10.5x**, GPT-5.6-Luna: **3.5x / 10.5x** (per issue spec)
  - Unlisted models: 1x/1x (unchanged behavior)
- `addUsage` folds rounded credits into the fixed windows (no schema change; `AiRateLimitWindow.tokens` now holds credits, documented); the audit log keeps raw tokens and stores derived USD in `cost`.
- UI strings updated to "credits": `/ai usage`, `/profile`, the rate-limit reply, and the website `/me` page.

## #209 — timeouts + retries

- New `utils/llmRetry.ts` (`createChatCompletionWithRetry`): per-attempt timeout (**180s** default, **480s** music-compose turns, **60s** titlegen) and exponential backoff **2s → 4s → 8s → 16s (max)** before erroring. Retries only transient failures (408/409/429/5xx/network/timeout); other 4xx throw immediately so the tool-reject fallback in `ai.ts` is untouched. Shared client set to `maxRetries: 0` so SDK retries don't stack.
- Wired into the `ai.ts` main tool loop, title generation, and RP's `callDeepseek`.
- Streaming deliberately **not** enabled — per-attempt timeout + retry solves the hang without the large streaming refactor. (`imageGen` already had its own timeout guard; the Gemini SDK exposes no per-request timeout.)

## Verification

- **328/328 tests pass**, including new `tests/utils/aiPricing.test.ts`, `tests/utils/llmRetry.test.ts`, and 5 new `aiUsage` tests (credit metering, USD cost, reserve/release gate)
- `tsc --noEmit` clean
- ESLint clean on all touched files (remaining repo lint errors are pre-existing in untouched files)
- `AGENTS.md` updated (transaction serialization, credit accounting)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Meter AI usage in **credits** with model-specific pricing and persisted cost tracking.
  * Added in-flight **credit reservations** to prevent concurrent requests from exceeding daily/weekly limits.
  * Improved provider reliability with a shared **bounded retry** helper and per-attempt timeouts.
  * Updated Grok and GPT personas to use newer models and context budgets.
* **Bug Fixes**
  * Strengthened transaction safety by serializing transaction execution and blocking nested transactions.
* **Documentation**
  * Expanded AI usage limits and fixed-window transaction behavior guidance.
* **Tests**
  * Added/expanded coverage for credit metering, reservation behavior, retry classification, and pricing helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->