### PR TITLE
fix(ai): preserve rate limit failure reason and show request credit estimates

### DIFF
--- a/classes/handlers/keywordsBehaviorHandler.ts
+++ b/classes/handlers/keywordsBehaviorHandler.ts
@@ -478,7 +478,10 @@ const scriptHandlers = {
       }
       if (err?.message === 'RATE_LIMIT_EXCEEDED') {
         const db = (message.client as any).db;
-        const content = await getRateLimitErrorMessage(message.author.id, db);
+        const content = await getRateLimitErrorMessage(message.author.id, db, {
+          reason: err.reason,
+          reservedCredits: err.reservedCredits,
+        });
         await message.reply(content);
         return;
       }

--- a/classes/handlers/keywordsBehaviorHandler.ts
+++ b/classes/handlers/keywordsBehaviorHandler.ts
@@ -481,6 +481,7 @@ const scriptHandlers = {
         const content = await getRateLimitErrorMessage(message.author.id, db, {
           reason: err.reason,
           reservedCredits: err.reservedCredits,
+          remainingCredits: err.remainingCredits,
         });
         await message.reply(content);
         return;

--- a/commands/askSilverwolfAI.ts
+++ b/commands/askSilverwolfAI.ts
@@ -127,6 +127,7 @@ class AskSilverwolfAI extends Command {
         await handleRateLimitError(interaction, this.client.db, {
           reason: error.reason,
           reservedCredits: error.reservedCredits,
+          remainingCredits: error.remainingCredits,
         });
         return;
       }

--- a/commands/askSilverwolfAI.ts
+++ b/commands/askSilverwolfAI.ts
@@ -124,7 +124,10 @@ class AskSilverwolfAI extends Command {
       }
     } catch (error: any) {
       if (error?.message === 'RATE_LIMIT_EXCEEDED') {
-        await handleRateLimitError(interaction, this.client.db);
+        await handleRateLimitError(interaction, this.client.db, {
+          reason: error.reason,
+          reservedCredits: error.reservedCredits,
+        });
         return;
       }
       logError('Error generating text:', error);

--- a/commands/summary_count.ts
+++ b/commands/summary_count.ts
@@ -70,7 +70,10 @@ class Summary extends Command {
       log(`Generated summary: ${summary.text}`);
     } catch (error: any) {
       if (error?.message === 'RATE_LIMIT_EXCEEDED') {
-        await handleRateLimitError(interaction, this.client.db);
+        await handleRateLimitError(interaction, this.client.db, {
+          reason: error.reason,
+          reservedCredits: error.reservedCredits,
+        });
         return;
       }
       logError('Failed to generate summary:', error);

--- a/commands/summary_count.ts
+++ b/commands/summary_count.ts
@@ -73,6 +73,7 @@ class Summary extends Command {
         await handleRateLimitError(interaction, this.client.db, {
           reason: error.reason,
           reservedCredits: error.reservedCredits,
+          remainingCredits: error.remainingCredits,
         });
         return;
       }

--- a/commands/summary_time.ts
+++ b/commands/summary_time.ts
@@ -84,7 +84,10 @@ class Summary extends Command {
       log(`Generated summary: ${summary.text}`);
     } catch (error: any) {
       if (error?.message === 'RATE_LIMIT_EXCEEDED') {
-        await handleRateLimitError(interaction, this.client.db);
+        await handleRateLimitError(interaction, this.client.db, {
+          reason: error.reason,
+          reservedCredits: error.reservedCredits,
+        });
         return;
       }
       logError('Failed to generate summary:', error);

--- a/commands/summary_time.ts
+++ b/commands/summary_time.ts
@@ -87,6 +87,7 @@ class Summary extends Command {
         await handleRateLimitError(interaction, this.client.db, {
           reason: error.reason,
           reservedCredits: error.reservedCredits,
+          remainingCredits: error.remainingCredits,
         });
         return;
       }

--- a/database/models/AiUsageModel.ts
+++ b/database/models/AiUsageModel.ts
@@ -145,17 +145,23 @@ class AiUsageModel {
   tryReserve(userId: string, estimatedCredits: number): {
     ok: boolean;
     reason?: WindowType;
+    remaining?: number;
   } {
     if (isUserDev(userId)) return { ok: true };
 
     const amount = Math.max(0, Math.round(estimatedCredits));
     const inFlight = this.pending.get(userId) ?? 0;
 
-    if (this.getWindowTokensSync(userId, 'daily') + inFlight + amount > DAILY_LIMIT) {
-      return { ok: false, reason: 'daily' };
+    const dailyTokens = this.getWindowTokensSync(userId, 'daily');
+    if (dailyTokens + inFlight + amount > DAILY_LIMIT) {
+      const remaining = Math.max(0, DAILY_LIMIT - (dailyTokens + inFlight));
+      return { ok: false, reason: 'daily', remaining };
     }
-    if (this.getWindowTokensSync(userId, 'weekly') + inFlight + amount > WEEKLY_LIMIT) {
-      return { ok: false, reason: 'weekly' };
+
+    const weeklyTokens = this.getWindowTokensSync(userId, 'weekly');
+    if (weeklyTokens + inFlight + amount > WEEKLY_LIMIT) {
+      const remaining = Math.max(0, WEEKLY_LIMIT - (weeklyTokens + inFlight));
+      return { ok: false, reason: 'weekly', remaining };
     }
 
     this.pending.set(userId, inFlight + amount);

--- a/site_src/routes/ai-slop-api.ts
+++ b/site_src/routes/ai-slop-api.ts
@@ -8,6 +8,7 @@ import {
   getPersonaByName,
   type Persona,
   DAILY_LIMIT,
+  WEEKLY_LIMIT,
 } from '../../utils/ai';
 import { trimHistoryToFit } from '../../utils/tokenizer';
 import { type AppEnv, authedGameRequest, readGameBody } from '../shared';
@@ -220,11 +221,21 @@ export function registerAiSlopApiRoutes(app: Hono<AppEnv>, silverwolf: Silverwol
       if (err?.message === 'RATE_LIMIT_EXCEEDED') {
         const dailyUsage = await silverwolf.db.aiUsage.getDailyUsage(auth.discordId);
         const weeklyUsage = await silverwolf.db.aiUsage.getWeeklyUsage(auth.discordId);
-        const reachedDaily = dailyUsage >= DAILY_LIMIT;
+        let reason: 'daily' | 'weekly';
+        if (err.reason) {
+          reason = err.reason;
+        } else if (dailyUsage >= DAILY_LIMIT) {
+          reason = 'daily';
+        } else if (weeklyUsage >= WEEKLY_LIMIT) {
+          reason = 'weekly';
+        } else {
+          reason = (dailyUsage / DAILY_LIMIT) >= (weeklyUsage / WEEKLY_LIMIT) ? 'daily' : 'weekly';
+        }
         return c.json({
           ok: false,
           error: 'rate_limited' as const,
-          reason: reachedDaily ? ('daily' as const) : ('weekly' as const),
+          reason,
+          reservedCredits: err.reservedCredits,
           dailyUsage,
           weeklyUsage,
         }, 429);

--- a/site_src/routes/ai-slop-api.ts
+++ b/site_src/routes/ai-slop-api.ts
@@ -222,7 +222,7 @@ export function registerAiSlopApiRoutes(app: Hono<AppEnv>, silverwolf: Silverwol
         const dailyUsage = await silverwolf.db.aiUsage.getDailyUsage(auth.discordId);
         const weeklyUsage = await silverwolf.db.aiUsage.getWeeklyUsage(auth.discordId);
         let reason: 'daily' | 'weekly';
-        if (err.reason) {
+        if (err.reason === 'daily' || err.reason === 'weekly') {
           reason = err.reason;
         } else if (dailyUsage >= DAILY_LIMIT) {
           reason = 'daily';
@@ -236,6 +236,7 @@ export function registerAiSlopApiRoutes(app: Hono<AppEnv>, silverwolf: Silverwol
           error: 'rate_limited' as const,
           reason,
           reservedCredits: err.reservedCredits,
+          remainingCredits: err.remainingCredits,
           dailyUsage,
           weeklyUsage,
         }, 429);

--- a/tests/utils/discordRateLimit.test.ts
+++ b/tests/utils/discordRateLimit.test.ts
@@ -24,20 +24,22 @@ describe('discordRateLimit & AiRateLimitError', () => {
     await db.executeQuery('DELETE FROM User');
   });
 
-  test('AiRateLimitError sets reason and reservedCredits correctly', () => {
-    const err = new AiRateLimitError('daily', 89527);
+  test('AiRateLimitError sets reason, reservedCredits, and remainingCredits correctly', () => {
+    const err = new AiRateLimitError('daily', 89527, 87126);
     expect(err.message).toBe('RATE_LIMIT_EXCEEDED');
     expect(err.reason).toBe('daily');
     expect(err.reservedCredits).toBe(89527);
+    expect(err.remainingCredits).toBe(87126);
   });
 
-  test('getRateLimitErrorMessage includes reservation details when specified', async () => {
+  test('getRateLimitErrorMessage includes reservation details when effective remaining capacity is provided', async () => {
     // Add 162,874 recorded daily usage out of 250,000
     await db.aiUsage.addUsage('u1', 'test-model', 162874, 0);
 
     const msg = await getRateLimitErrorMessage('u1', db, {
       reason: 'daily',
       reservedCredits: 89527,
+      remainingCredits: 87126,
     });
 
     expect(msg).toContain('Daily AI Rate Limit Reached');
@@ -45,6 +47,19 @@ describe('discordRateLimit & AiRateLimitError', () => {
     expect(msg).toContain('250,000');
     expect(msg).toContain('requires ~**89,527** estimated credits');
     expect(msg).toContain('exceeds your remaining **87,126** credits');
+  });
+
+  test('getRateLimitErrorMessage omits comparison note when remainingCredits capacity is unavailable', async () => {
+    await db.aiUsage.addUsage('u1', 'test-model', 162874, 0);
+
+    // Omit remainingCredits: detailNote should be omitted rather than showing DB-only credits
+    const msg = await getRateLimitErrorMessage('u1', db, {
+      reason: 'daily',
+      reservedCredits: 89527,
+    });
+
+    expect(msg).toContain('Daily AI Rate Limit Reached');
+    expect(msg).not.toContain('estimated credits');
   });
 
   test('getRateLimitErrorMessage fallback selects window closer to capacity when DB total < limit', async () => {

--- a/tests/utils/discordRateLimit.test.ts
+++ b/tests/utils/discordRateLimit.test.ts
@@ -1,0 +1,76 @@
+import {
+  describe, test, expect, beforeAll, afterAll, beforeEach,
+} from 'bun:test';
+import Database from '../../database/Database';
+import { getRateLimitErrorMessage } from '../../utils/discordRateLimit';
+import { AiRateLimitError, WEEKLY_LIMIT } from '../../utils/ai';
+
+describe('discordRateLimit & AiRateLimitError', () => {
+  let db: Database;
+
+  beforeAll(async () => {
+    const timestamp = Date.now();
+    db = new Database(`./tests/temp/testRateLimitMsg-${timestamp}.db`);
+    await db.ready;
+  });
+
+  afterAll(() => {
+    db.db.close();
+  });
+
+  beforeEach(async () => {
+    await db.executeQuery('DELETE FROM AiUsage');
+    await db.executeQuery('DELETE FROM AiRateLimitWindow');
+    await db.executeQuery('DELETE FROM User');
+  });
+
+  test('AiRateLimitError sets reason and reservedCredits correctly', () => {
+    const err = new AiRateLimitError('daily', 89527);
+    expect(err.message).toBe('RATE_LIMIT_EXCEEDED');
+    expect(err.reason).toBe('daily');
+    expect(err.reservedCredits).toBe(89527);
+  });
+
+  test('getRateLimitErrorMessage includes reservation details when specified', async () => {
+    // Add 162,874 recorded daily usage out of 250,000
+    await db.aiUsage.addUsage('u1', 'test-model', 162874, 0);
+
+    const msg = await getRateLimitErrorMessage('u1', db, {
+      reason: 'daily',
+      reservedCredits: 89527,
+    });
+
+    expect(msg).toContain('Daily AI Rate Limit Reached');
+    expect(msg).toContain('162,874');
+    expect(msg).toContain('250,000');
+    expect(msg).toContain('requires ~**89,527** estimated credits');
+    expect(msg).toContain('exceeds your remaining **87,126** credits');
+  });
+
+  test('getRateLimitErrorMessage fallback selects window closer to capacity when DB total < limit', async () => {
+    // Daily is at 65% (162,874 / 250,000), Weekly is at 43% (428,469 / 1,000,000)
+    await db.aiUsage.addUsage('u1', 'test-model', 162874, 0);
+
+    // Explicitly set weekly window to 428,469
+    await db.executeQuery(
+      'UPDATE AiRateLimitWindow SET tokens = 428469 WHERE user_id = ? AND window_type = ?',
+      ['u1', 'weekly'],
+    );
+
+    // Omit explicit reason: fallback should pick 'daily' because 65% > 43%
+    const msg = await getRateLimitErrorMessage('u1', db);
+    expect(msg).toContain('Daily AI Rate Limit Reached');
+    expect(msg).not.toContain('Weekly AI Rate Limit Reached');
+  });
+
+  test('getRateLimitErrorMessage correctly identifies weekly limit when weekly >= WEEKLY_LIMIT', async () => {
+    // Set weekly window to WEEKLY_LIMIT while daily remains 0
+    await db.executeQuery(
+      "INSERT INTO AiRateLimitWindow (user_id, window_type, window_start, tokens) VALUES (?, 'weekly', datetime('now'), ?)",
+      ['u1', WEEKLY_LIMIT],
+    );
+
+    const msg = await getRateLimitErrorMessage('u1', db);
+    expect(msg).toContain('Weekly AI Rate Limit Reached');
+  });
+});

--- a/utils/ai.ts
+++ b/utils/ai.ts
@@ -825,6 +825,18 @@ function estimateRequestCredits({
   return creditsForTokens(model, estPromptTokens, ESTIMATED_COMPLETION_TOKENS);
 }
 
+export class AiRateLimitError extends Error {
+  reason: 'daily' | 'weekly';
+  reservedCredits: number;
+
+  constructor(reason: 'daily' | 'weekly', reservedCredits: number) {
+    super('RATE_LIMIT_EXCEEDED');
+    this.name = 'AiRateLimitError';
+    this.reason = reason;
+    this.reservedCredits = reservedCredits;
+  }
+}
+
 /**
  * Generates content (text and/or images) from the specified AI provider and model.
  * Enforces the per-user credit rate limit with an in-flight reservation: the
@@ -839,7 +851,7 @@ async function generateContent(opts: GenerateContentOptions): Promise<GenerateCo
   const reserved = Math.ceil(estimateRequestCredits(opts));
   const gate = db.aiUsage.tryReserve(userId, reserved);
   if (!gate.ok) {
-    throw new Error('RATE_LIMIT_EXCEEDED');
+    throw new AiRateLimitError(gate.reason ?? 'daily', reserved);
   }
   try {
     return await generateContentInner(opts);

--- a/utils/ai.ts
+++ b/utils/ai.ts
@@ -828,12 +828,14 @@ function estimateRequestCredits({
 export class AiRateLimitError extends Error {
   reason: 'daily' | 'weekly';
   reservedCredits: number;
+  remainingCredits?: number;
 
-  constructor(reason: 'daily' | 'weekly', reservedCredits: number) {
+  constructor(reason: 'daily' | 'weekly', reservedCredits: number, remainingCredits?: number) {
     super('RATE_LIMIT_EXCEEDED');
     this.name = 'AiRateLimitError';
     this.reason = reason;
     this.reservedCredits = reservedCredits;
+    this.remainingCredits = remainingCredits;
   }
 }
 
@@ -851,7 +853,7 @@ async function generateContent(opts: GenerateContentOptions): Promise<GenerateCo
   const reserved = Math.ceil(estimateRequestCredits(opts));
   const gate = db.aiUsage.tryReserve(userId, reserved);
   if (!gate.ok) {
-    throw new AiRateLimitError(gate.reason ?? 'daily', reserved);
+    throw new AiRateLimitError(gate.reason ?? 'daily', reserved, gate.remaining);
   }
   try {
     return await generateContentInner(opts);

--- a/utils/discordRateLimit.ts
+++ b/utils/discordRateLimit.ts
@@ -29,6 +29,7 @@ export async function getResetLine(
 export interface RateLimitOptions {
   reason?: 'daily' | 'weekly';
   reservedCredits?: number;
+  remainingCredits?: number;
 }
 
 export async function getRateLimitErrorMessage(
@@ -42,7 +43,7 @@ export async function getRateLimitErrorMessage(
   ]);
 
   let reason: 'daily' | 'weekly';
-  if (opts?.reason) {
+  if (opts?.reason === 'daily' || opts?.reason === 'weekly') {
     reason = opts.reason;
   } else if (dailyUsage >= DAILY_LIMIT) {
     reason = 'daily';
@@ -67,10 +68,12 @@ export async function getRateLimitErrorMessage(
     ? `Your limit resets ${formatResetTimestamp(resetAt)}.`
     : 'Please wait for your limit to reset.';
 
-  const remaining = Math.max(0, limitVal - usageVal);
   let detailNote = '';
   if (typeof opts?.reservedCredits === 'number' && opts.reservedCredits > 0 && usageVal < limitVal) {
-    detailNote = `\nThis request requires ~**${opts.reservedCredits.toLocaleString()}** estimated credits, which exceeds your remaining **${remaining.toLocaleString()}** credits for this window.`;
+    if (typeof opts.remainingCredits === 'number') {
+      const remaining = Math.max(0, opts.remainingCredits);
+      detailNote = `\nThis request requires ~**${opts.reservedCredits.toLocaleString()}** estimated credits, which exceeds your remaining **${remaining.toLocaleString()}** credits for this window.`;
+    }
   }
 
   return `⚠️ **${limitLabel} AI Rate Limit Reached**\nYou've used **${usageVal.toLocaleString()}** / **${limitVal.toLocaleString()}** credits in the current ${windowLabel} window.${detailNote}\n${resetNote}`;

--- a/utils/discordRateLimit.ts
+++ b/utils/discordRateLimit.ts
@@ -26,32 +26,62 @@ export async function getResetLine(
   return resetAt ? `\n**Resets:** ${formatResetTimestamp(resetAt)}` : '';
 }
 
-export async function getRateLimitErrorMessage(userId: string, db: Database): Promise<string> {
+export interface RateLimitOptions {
+  reason?: 'daily' | 'weekly';
+  reservedCredits?: number;
+}
+
+export async function getRateLimitErrorMessage(
+  userId: string,
+  db: Database,
+  opts?: RateLimitOptions,
+): Promise<string> {
   const [dailyUsage, weeklyUsage] = await Promise.all([
     db.aiUsage.getDailyUsage(userId),
     db.aiUsage.getWeeklyUsage(userId),
   ]);
-  const reachedDaily = dailyUsage >= DAILY_LIMIT;
 
-  const reason: 'daily' | 'weekly' = reachedDaily ? 'daily' : 'weekly';
-  const limitLabel = reachedDaily ? 'Daily' : 'Weekly';
-  const usageVal = reachedDaily ? dailyUsage : weeklyUsage;
-  const limitVal = reachedDaily ? DAILY_LIMIT : WEEKLY_LIMIT;
-  const windowLabel = reachedDaily ? '24-hour' : '7-day';
+  let reason: 'daily' | 'weekly';
+  if (opts?.reason) {
+    reason = opts.reason;
+  } else if (dailyUsage >= DAILY_LIMIT) {
+    reason = 'daily';
+  } else if (weeklyUsage >= WEEKLY_LIMIT) {
+    reason = 'weekly';
+  } else {
+    // Neither recorded DB total alone reaches the limit (e.g. pre-flight reservation
+    // pushed usage over). Pick the window closer to its capacity limit.
+    const dailyRatio = dailyUsage / DAILY_LIMIT;
+    const weeklyRatio = weeklyUsage / WEEKLY_LIMIT;
+    reason = dailyRatio >= weeklyRatio ? 'daily' : 'weekly';
+  }
+
+  const isDaily = reason === 'daily';
+  const limitLabel = isDaily ? 'Daily' : 'Weekly';
+  const usageVal = isDaily ? dailyUsage : weeklyUsage;
+  const limitVal = isDaily ? DAILY_LIMIT : WEEKLY_LIMIT;
+  const windowLabel = isDaily ? '24-hour' : '7-day';
 
   const resetAt = await db.aiUsage.getResetAt(userId, reason);
   const resetNote = resetAt
     ? `Your limit resets ${formatResetTimestamp(resetAt)}.`
     : 'Please wait for your limit to reset.';
 
-  return `⚠️ **${limitLabel} AI Rate Limit Reached**\nYou've used **${usageVal.toLocaleString()}** / **${limitVal.toLocaleString()}** credits in the current ${windowLabel} window. ${resetNote}`;
+  const remaining = Math.max(0, limitVal - usageVal);
+  let detailNote = '';
+  if (typeof opts?.reservedCredits === 'number' && opts.reservedCredits > 0 && usageVal < limitVal) {
+    detailNote = `\nThis request requires ~**${opts.reservedCredits.toLocaleString()}** estimated credits, which exceeds your remaining **${remaining.toLocaleString()}** credits for this window.`;
+  }
+
+  return `⚠️ **${limitLabel} AI Rate Limit Reached**\nYou've used **${usageVal.toLocaleString()}** / **${limitVal.toLocaleString()}** credits in the current ${windowLabel} window.${detailNote}\n${resetNote}`;
 }
 
 export async function handleRateLimitError(
   interaction: ChatInputCommandInteraction,
   db: Database,
+  opts?: RateLimitOptions,
 ): Promise<void> {
-  const content = await getRateLimitErrorMessage(interaction.user.id, db);
+  const content = await getRateLimitErrorMessage(interaction.user.id, db, opts);
   await interaction.editReply({
     content,
   });


### PR DESCRIPTION
## Summary
When an AI request is blocked because its pre-flight credit reservation pushes total usage over a limit,  previously threw a generic  that discarded the failure reason (`'daily'` vs `'weekly'`) and the estimated request cost (`reserved`).

When rendering the error message in `getRateLimitErrorMessage` or `ai-slop-api.ts`, the system checked whether recorded DB usage alone was $\ge \text{DAILY\_LIMIT}$. Because recorded usage was under the daily limit (the request was blocked by recorded usage + estimated request cost exceeding the limit), this check evaluated to `false` and blindly defaulted to reporting a **Weekly** limit hit (e.g. *"Weekly AI Rate Limit Reached: 428,469 / 1,000,000 credits"*).

## Changes Included
1. **`AiRateLimitError`**: `generateContent` now throws an `AiRateLimitError` carrying both `reason` and `reservedCredits`.
2. **Request Reservation Breakdown**: `getRateLimitErrorMessage` displays a breakdown when estimated credits exceed remaining allowance:
   > ⚠️ **Daily AI Rate Limit Reached**
   > You've used **162,874** / **250,000** credits in the current 24-hour window.
   > This request requires ~**89,527** estimated credits, which exceeds your remaining **87,126** credits for this window.
   > Your limit resets 2:14 PM (in 4 hours).
3. **Corrected Fallback**: Uses relative usage ratios (`dailyUsage / DAILY_LIMIT >= weeklyUsage / WEEKLY_LIMIT ? 'daily' : 'weekly'`) if no explicit reason is passed, preventing incorrect fallback to weekly limits.
4. **Command & API Updates**: Updated `askSilverwolfAI`, `keywordsBehaviorHandler`, `summary_count`, `summary_time`, and `ai-slop-api.ts` to forward error details down.
5. **Unit Tests**: Added `tests/utils/discordRateLimit.test.ts` verifying error creation, reservation message rendering, and fallback window resolution.

## Verification
- `bun test` (334 passed, 0 failed)
- `bun run typecheck` (Clean)
- ESLint (Clean)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced rate-limit handling to produce more accurate daily vs weekly limit messaging across AI commands and the ai-slop API.
  * Improved rate-limit responses by including reserved credits and remaining-credit estimates (when available), along with clearer reset timing.
  * Updated reservation logic to surface remaining credits when a limit would be exceeded.
* **Tests**
  * Added/expanded Bun tests to validate `RATE_LIMIT_EXCEEDED` reason selection, reserved/remaining credits behavior, and rate-limit message formatting for both daily and weekly scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->