### PR TITLE
fix(quote): rework vertical layout and add a /quote command group

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Bun process**. It serves fun/games both as slash commands and as web pages, plus
 **The website is public, so security and performance are first-class concerns — code defensively:
 validate every input, never trust client data, keep the CSP tight.**
 
-**Last updated: 2026-07-27**
+**Last updated: 2026-07-29**
 
 > **Maintenance rule.** Edit this file only on *substantive architectural* change — new
 > architecture, new auth, new data flows/services, schema or security-model changes, or when
@@ -155,6 +155,12 @@ Rules an agent must follow:
   serialized through an in-process FIFO queue (a single connection can't interleave BEGINs —
   the second used to roll back the first's writes); never call `executeTransaction` from inside
   a transaction fn (there is a guard that throws).
+- Per-user quote defaults: `QuotePreference` (`db.quotePreference`, one nullable-column row per
+  user) — saved via `/quote settings` and applied to every quote that user makes (slash **and**
+  mention). Resolution order is bot defaults → saved settings → flags on this invocation
+  (`utils/quote.ts`: `parseQuoteFlags` → `resolveQuoteFlags`); `-o` / `override:true` drops the
+  saved layer for one quote. Mention quoting takes compact space-separated flags
+  (`@bot w v caveat #ff0124`), documented in-bot by `/quote help`.
 - Per-guild settings: `ServerConfig` (`db.serverConfig`, keyed by `server_id` + `key`) — named roles
   use `role:<name>` keys; gameplay tuning via `/serverconfig setvalue`, `/serverconfig setchannel`,
   and `/serverconfig setrole`; `CommandConfig` remains

--- a/classes/silverwolf.ts
+++ b/classes/silverwolf.ts
@@ -18,11 +18,10 @@ import {
   ChristmasHandler, NormalHandler, HalloweenHandler, AprilFoolsHandler,
 } from './handlers/index';
 import scriptHandlers from './handlers/keywordsBehaviorHandler';
-import quoteDefault from '../utils/quote';
+import quoteDefault, { parseQuoteFlags, resolveQuoteFlags, QUOTE_FLAG_HELP } from '../utils/quote';
 import { loadAllowedServers } from '../utils/accessControl';
 import { loadResolvedServerConfig } from '../utils/serverConfig';
 
-const FONT_INDEX: string[] = (quoteDefault as any).FONT_INDEX;
 const MAX_MESSAGE_HISTORY = 100;
 
 const handlers: Record<string, any> = {
@@ -310,59 +309,20 @@ All wrongs reserved.
       const referencedMessageId = message.reference.messageId;
       message.channel.messages.fetch(referencedMessageId).then(async (referencedMessage: any) => {
         const sentMessage = await message.reply({
-          content: '<a:quoteLoading:1290494754202583110> Generating...',
+          content: `<a:quoteLoading:1290494754202583110> Generating... *${QUOTE_FLAG_HELP}*`,
         });
 
         // ── Parse parameters from message content ──────────────────────────
-        // Strip the bot mention to get raw parameter text
-        const paramText = message.content.replace(/<@!?\d+>/g, '').trim();
-
-        // Parse key:value pairs (no brackets needed)
-        const getParam = (key: string): string | null => {
-          const re = new RegExp(`(?:^|\\s)${key}:(\\S+)`, 'i');
-          const match = re.exec(paramText);
-          return match ? match[1].trim() : null;
-        };
-
-        // bg:b or bg:w → background colour
-        const bgParam = getParam('bg');
-        let background = 'black';
-        if (bgParam === 'w') background = 'white';
-        // 'b' or anything else stays black (default)
-
-        // pfp:server or pfp:global → avatar source
-        const pfpParam = getParam('pfp');
-        let avatarSource = 'server';
-        if (pfpParam === 'global') avatarSource = 'global';
-
-        // pfpc:normal/bw/inverted/sepia/nightmare → profile colour filter
-        const pfpcParam = getParam('pfpc');
-        const validPfpc = ['normal', 'bw', 'inverted', 'sepia', 'nightmare'];
-        const profileColor = (pfpcParam && validPfpc.includes(pfpcParam)) ? pfpcParam : 'normal';
-
-        // font:1-13 → font style (mapped via FONT_INDEX)
-        const fontParam = getParam('font');
-        let fontStyle = 'sans-serif';
-        if (fontParam) {
-          const fontNum = parseInt(fontParam, 10);
-          if (!Number.isNaN(fontNum) && fontNum >= 1 && fontNum <= FONT_INDEX.length) {
-            fontStyle = FONT_INDEX[fontNum - 1]; // 1-indexed for users
-          }
-        }
-
-        // format:v / format:vertical → portrait layout (default landscape)
-        const formatParam = getParam('format') || getParam('fmt');
-        let quoteFormat = 'landscape';
-        if (formatParam && /^v(ertical)?$/i.test(formatParam)) quoteFormat = 'vertical';
-
-        // txt:#hex → text colour
-        const txtParam = getParam('txt');
-        let textColor = null;
-        if (txtParam) {
-          // Accept with or without '#' prefix
-          const hexTest = /^#?([0-9A-Fa-f]{6})$/.exec(txtParam);
-          if (hexTest) textColor = `#${hexTest[1]}`;
-        }
+        // Compact space-separated flags, e.g. `@bot w v caveat #ff00aa bw`
+        // (the legacy `bg:w font:3 fmt:v` spelling still parses). Layered over
+        // the invoker's saved `/quote settings`, which `-o` opts out of.
+        const parsedFlags = parseQuoteFlags(message.content.replace(/<@!?\d+>/g, ''));
+        const savedFlags = parsedFlags.override
+          ? null
+          : await this.db.quotePreference.getPreferences(message.author.id);
+        const {
+          background, textColor, profileColor, avatarSource, fontStyle, format: quoteFormat,
+        } = resolveQuoteFlags(parsedFlags, savedFlags);
 
         const person = referencedMessage.author;
         let nickname: string;

--- a/commands/commandgroups/quote.ts
+++ b/commands/commandgroups/quote.ts
@@ -1,0 +1,9 @@
+import { CommandGroup } from '../classes/commandGroup';
+
+export default class Quote extends CommandGroup {
+  constructor(client: any) {
+    super(client, 'quote', 'Make it a quote', [
+      'fake', 'settings', 'help',
+    ]);
+  }
+}

--- a/commands/quote_fake.ts
+++ b/commands/quote_fake.ts
@@ -7,11 +7,12 @@ import quote, {
   FAKEQUOTE_PROFILE_COLORS,
   FAKEQUOTE_AVATAR_SOURCES,
   fakeQuoteChoices,
+  type QuotePrefField,
 } from '../utils/quote';
 
-class FakeQuote extends Command {
+class QuoteFake extends Command {
   constructor(client: any) {
-    super(client, 'fakequote', 'fake make it a quote', [
+    super(client, 'fake', 'fake make it a quote', [
       {
         name: 'person',
         description: 'person to quote',
@@ -71,7 +72,13 @@ class FakeQuote extends Command {
         required: false,
         choices: fakeQuoteChoices(FAKEQUOTE_AVATAR_SOURCES),
       },
-    ], { blame: 'both' });
+      {
+        name: 'override',
+        description: 'ignore your saved /quote settings for this one quote (same as -o when mention-quoting)',
+        type: 5,
+        required: false,
+      },
+    ], { isSubcommandOf: 'quote', blame: 'both' });
   }
 
   async run(interaction: any): Promise<void> {
@@ -81,17 +88,26 @@ class FakeQuote extends Command {
         fetchReply: true,
       });
 
+      const override = interaction.options.getBoolean('override') ?? false;
+      const saved = override ? {} : await this.client.db.quotePreference.getPreferences(interaction.user.id);
+
+      // Explicit option wins; then the saved default; then null, which lets
+      // quote() apply its own built-in default.
+      const pick = (option: string, field: QuotePrefField): string | null => (
+        interaction.options.getString(option) ?? saved[field] ?? null
+      );
+
       const result = await quote(
         interaction.guild,
         interaction.options.getUser('person'),
         interaction.options.getString('nickname'),
         interaction.options.getString('message'),
-        interaction.options.getString('background'),
-        interaction.options.getString('text_color'),
-        interaction.options.getString('profile_color'),
-        interaction.options.getString('avatar_source'),
-        interaction.options.getString('font_style'),
-        interaction.options.getString('format'),
+        pick('background', 'background'),
+        pick('text_color', 'textColor'),
+        pick('profile_color', 'profileColor'),
+        pick('avatar_source', 'avatarSource'),
+        pick('font_style', 'fontStyle'),
+        pick('format', 'format'),
       );
 
       await interaction.editReply({ content: null, files: [result] });
@@ -102,4 +118,4 @@ class FakeQuote extends Command {
   }
 }
 
-export default FakeQuote;
+export default QuoteFake;

--- a/commands/quote_fake.ts
+++ b/commands/quote_fake.ts
@@ -92,7 +92,8 @@ class QuoteFake extends Command {
       const saved = override ? {} : await this.client.db.quotePreference.getPreferences(interaction.user.id);
 
       // Explicit option wins; then the saved default; then null, which lets
-      // quote() apply its own built-in default.
+      // quote() fall back to QUOTE_FLAG_DEFAULTS — the same baseline the
+      // mention flags, /quote settings and /quote help all report.
       const pick = (option: string, field: QuotePrefField): string | null => (
         interaction.options.getString(option) ?? saved[field] ?? null
       );

--- a/commands/quote_help.ts
+++ b/commands/quote_help.ts
@@ -1,0 +1,74 @@
+import { EmbedBuilder } from 'discord.js';
+import { Command } from './classes/Command';
+import {
+  FAKEQUOTE_FONTS,
+  QUOTE_PREF_FIELDS,
+  QUOTE_PREF_LABELS,
+} from '../utils/quote';
+
+const FONT_LIST = FAKEQUOTE_FONTS
+  .map((font, index) => `\`${index + 1}\` ${font.label} — \`${font.value}\``)
+  .join('\n');
+
+const FLAG_TABLE = [
+  '`w` `white` / `b` `black` — background',
+  '`v` `vertical` / `h` `landscape` — layout',
+  '`#ff0124` (or `ff0124`) — text colour',
+  '`normal` `bw` `inverted` `sepia` `nightmare` — profile picture filter',
+  '`server` / `global` — which avatar to use',
+  `\`1\`–\`${FAKEQUOTE_FONTS.length}\` or a font name — font (see below)`,
+  '`-o` — ignore your saved settings for this quote',
+].join('\n');
+
+class QuoteHelp extends Command {
+  constructor(client: any) {
+    super(client, 'help', 'how to use quotes, mention flags and saved settings', [], {
+      isSubcommandOf: 'quote',
+      blame: 'both',
+    });
+  }
+
+  async run(interaction: any): Promise<void> {
+    const embed = new EmbedBuilder()
+      .setColor('Blurple')
+      .setTitle('Quote — how it works')
+      .setDescription(
+        '**Reply-quote:** reply to any message, mention me, and add flags — '
+        + '`@Silverwolf w v caveat #ff0124`\n'
+        + '**Slash:** `/quote fake` for a made-up quote, `/quote settings` for your defaults.\n\n'
+        + 'Flags are order-independent and all optional; anything I don\'t recognise is ignored, '
+        + 'so a normal sentence never breaks a quote. If two flags set the same thing, the last one wins.',
+      )
+      .addFields(
+        { name: 'Flags', value: FLAG_TABLE },
+        { name: 'Fonts', value: FONT_LIST },
+        {
+          name: 'Saved settings',
+          value: `\`/quote settings\` stores your own defaults (${
+            QUOTE_PREF_FIELDS.map((field) => QUOTE_PREF_LABELS[field].toLowerCase()).join(', ')
+          }) and they apply to every quote **you** make, slash or mention.\n`
+            + '`/quote settings clear:Everything` wipes them; `clear:<field>` unsets just one.',
+        },
+        {
+          name: 'Override (`-o`)',
+          value: 'Saved settings are applied *under* the flags you type, so a flag always wins for that '
+            + 'one field. To ignore your saved settings **entirely** for a single quote, add `-o` '
+            + '(aliases: `--override`, `-d`, `--default`) — you get the bot defaults plus whatever '
+            + 'flags you pass alongside it. On slash commands that\'s `override:True`.\n'
+            + 'Precedence: **bot defaults → your saved settings → flags on this quote**.',
+        },
+        {
+          name: 'Examples',
+          value: '`@Silverwolf` — your saved settings, or plain black landscape\n'
+            + '`@Silverwolf v w playfair` — portrait, white, Playfair\n'
+            + '`@Silverwolf -o` — bot defaults, ignoring your saved settings\n'
+            + '`@Silverwolf -o v` — portrait on bot defaults\n'
+            + '`@Silverwolf bg:w font:3 fmt:v` — the old `key:value` spelling still works',
+        },
+      );
+
+    await interaction.editReply({ embeds: [embed] });
+  }
+}
+
+export default QuoteHelp;

--- a/commands/quote_settings.ts
+++ b/commands/quote_settings.ts
@@ -1,0 +1,167 @@
+import { EmbedBuilder } from 'discord.js';
+import { Command } from './classes/Command';
+import { logError } from '../utils/log';
+import {
+  FAKEQUOTE_FONTS,
+  FAKEQUOTE_FORMATS,
+  FAKEQUOTE_BACKGROUNDS,
+  FAKEQUOTE_PROFILE_COLORS,
+  FAKEQUOTE_AVATAR_SOURCES,
+  FAKEQUOTE_FONT_VALUES,
+  FAKEQUOTE_FORMAT_VALUES,
+  FAKEQUOTE_BACKGROUND_VALUES,
+  FAKEQUOTE_PROFILE_COLOR_VALUES,
+  FAKEQUOTE_AVATAR_SOURCE_VALUES,
+  fakeQuoteChoices,
+  validateAndNormaliseHex,
+  QUOTE_PREF_FIELDS,
+  QUOTE_PREF_LABELS,
+  QUOTE_FLAG_DEFAULTS,
+  type QuotePrefField,
+  type QuotePreferences,
+} from '../utils/quote';
+
+// Slash option → (preference field, allowed values). Anything outside the
+// whitelist is rejected rather than stored.
+const OPTION_FIELDS: { option: string; field: QuotePrefField; allowed: string[] | null }[] = [
+  { option: 'format', field: 'format', allowed: FAKEQUOTE_FORMAT_VALUES },
+  { option: 'background', field: 'background', allowed: FAKEQUOTE_BACKGROUND_VALUES },
+  { option: 'text_color', field: 'textColor', allowed: null }, // free-form hex, validated below
+  { option: 'font_style', field: 'fontStyle', allowed: FAKEQUOTE_FONT_VALUES },
+  { option: 'profile_color', field: 'profileColor', allowed: FAKEQUOTE_PROFILE_COLOR_VALUES },
+  { option: 'avatar_source', field: 'avatarSource', allowed: FAKEQUOTE_AVATAR_SOURCE_VALUES },
+];
+
+const CLEAR_CHOICES = [
+  { name: 'Everything', value: 'all' },
+  ...QUOTE_PREF_FIELDS.map((field) => ({ name: QUOTE_PREF_LABELS[field], value: field })),
+];
+
+function describeDefault(field: QuotePrefField): string {
+  if (field === 'textColor') return 'auto (white on black, black on white)';
+  return `${QUOTE_FLAG_DEFAULTS[field]}`;
+}
+
+function buildSettingsEmbed(prefs: QuotePreferences, note: string | null): EmbedBuilder {
+  const lines = QUOTE_PREF_FIELDS.map((field) => {
+    const value = prefs[field];
+    return value
+      ? `**${QUOTE_PREF_LABELS[field]}:** \`${value}\``
+      : `**${QUOTE_PREF_LABELS[field]}:** *not set* — bot default (${describeDefault(field)})`;
+  });
+
+  const embed = new EmbedBuilder()
+    .setColor(Object.keys(prefs).length > 0 ? 'Green' : 'Grey')
+    .setTitle('Your quote settings')
+    .setDescription(lines.join('\n'))
+    .setFooter({
+      text: 'Applied to every quote you make. Skip them once with /quote fake override:true, '
+        + 'or -o when mention-quoting.',
+    });
+
+  if (note) embed.addFields({ name: '​', value: note });
+  return embed;
+}
+
+class QuoteSettings extends Command {
+  constructor(client: any) {
+    super(client, 'settings', 'save your personal quote defaults (run with no options to view them)', [
+      {
+        name: 'format',
+        description: 'default image layout',
+        type: 3,
+        required: false,
+        choices: fakeQuoteChoices(FAKEQUOTE_FORMATS),
+      },
+      {
+        name: 'background',
+        description: 'default background colour',
+        type: 3,
+        required: false,
+        choices: fakeQuoteChoices(FAKEQUOTE_BACKGROUNDS),
+      },
+      {
+        name: 'font_style',
+        description: 'default font',
+        type: 3,
+        required: false,
+        choices: fakeQuoteChoices(FAKEQUOTE_FONTS),
+      },
+      {
+        name: 'text_color',
+        description: 'default text colour as hex, e.g. #FF0124',
+        type: 3,
+        required: false,
+      },
+      {
+        name: 'profile_color',
+        description: 'default profile picture filter',
+        type: 3,
+        required: false,
+        choices: fakeQuoteChoices(FAKEQUOTE_PROFILE_COLORS),
+      },
+      {
+        name: 'avatar_source',
+        description: 'default avatar source',
+        type: 3,
+        required: false,
+        choices: fakeQuoteChoices(FAKEQUOTE_AVATAR_SOURCES),
+      },
+      {
+        name: 'clear',
+        description: 'unset a saved default (or all of them)',
+        type: 3,
+        required: false,
+        choices: CLEAR_CHOICES,
+      },
+    ], { ephemeral: true, isSubcommandOf: 'quote', blame: 'both' });
+  }
+
+  async run(interaction: any): Promise<void> {
+    const userId = interaction.user.id;
+    const model = this.client.db.quotePreference;
+
+    try {
+      const clear = interaction.options.getString('clear');
+      const patch: Partial<Record<QuotePrefField, string>> = {};
+
+      OPTION_FIELDS.forEach(({ option, field, allowed }) => {
+        const value = interaction.options.getString(option);
+        if (value === null || value === undefined) return;
+        if (allowed && !allowed.includes(value)) return; // not a known choice — ignore
+        patch[field] = value;
+      });
+
+      if (patch.textColor) {
+        // Throws with a readable message on anything that isn't a 6-digit hex.
+        patch.textColor = validateAndNormaliseHex(patch.textColor);
+      }
+
+      const changed = Object.keys(patch) as QuotePrefField[];
+      const notes: string[] = [];
+
+      if (clear === 'all') {
+        await model.clearAllPreferences(userId);
+        notes.push('Cleared every saved default.');
+      } else if (clear) {
+        await model.clearPreference(userId, clear as QuotePrefField);
+        notes.push(`Cleared **${QUOTE_PREF_LABELS[clear as QuotePrefField] ?? clear}**.`);
+      }
+
+      if (changed.length > 0) {
+        await model.setPreferences(userId, patch);
+        notes.push(`Saved **${changed.map((field) => QUOTE_PREF_LABELS[field]).join('**, **')}**.`);
+      }
+
+      const prefs = await model.getPreferences(userId);
+      await interaction.editReply({
+        embeds: [buildSettingsEmbed(prefs, notes.length > 0 ? notes.join('\n') : null)],
+      });
+    } catch (error) {
+      logError('Error updating quote settings:', error);
+      await interaction.editReply(`Error: ${(error as Error).message}`);
+    }
+  }
+}
+
+export default QuoteSettings;

--- a/database/Database.ts
+++ b/database/Database.ts
@@ -27,6 +27,7 @@ import type ServerConfigModel from './models/ServerConfigModel';
 import type BirthdayReminderModel from './models/BirthdayReminderModel';
 import type FootballMatchAnnouncementModel from './models/FootballMatchAnnouncementModel';
 import type PoopModel from './models/PoopModel';
+import type QuotePreferenceModel from './models/QuotePreferenceModel';
 import type RpModel from './models/RpModel';
 import type WebSessionModel from './models/WebSessionModel';
 
@@ -378,6 +379,7 @@ class Database {
   get musicGen(): MusicGenModel { return this.models.MusicGenModel; }
   get pokemon(): PokemonModel { return this.models.PokemonModel; }
   get poop(): PoopModel { return this.models.PoopModel; }
+  get quotePreference(): QuotePreferenceModel { return this.models.QuotePreferenceModel; }
   get rp(): RpModel { return this.models.RpModel; }
   get serverConfig(): ServerConfigModel { return this.models.ServerConfigModel; }
   get user(): UserModel { return this.models.UserModel; }

--- a/database/models/QuotePreferenceModel.ts
+++ b/database/models/QuotePreferenceModel.ts
@@ -1,0 +1,67 @@
+import quotePreferenceQueries from '../queries/quotePreferenceQueries';
+import type Database from '../Database';
+import type { QuotePreferences, QuotePrefField } from '../../utils/quote';
+
+/**
+ * The only column names this model will ever put into SQL. User input is
+ * matched against these keys, never interpolated.
+ */
+const COLUMNS: Record<QuotePrefField, string> = {
+  background: 'background',
+  textColor: 'text_color',
+  profileColor: 'profile_color',
+  avatarSource: 'avatar_source',
+  fontStyle: 'font_style',
+  format: 'format',
+};
+
+const FIELDS = Object.keys(COLUMNS) as QuotePrefField[];
+
+class QuotePreferenceModel {
+  private db: Database;
+
+  constructor(database: Database) {
+    this.db = database;
+  }
+
+  /** Returns only the fields the user has actually set; `{}` when they have none. */
+  async getPreferences(userId: string): Promise<QuotePreferences> {
+    const row = await this.db.executeSelectQuery(quotePreferenceQueries.GET_PREFERENCES, [userId]);
+    if (!row) return {};
+    const prefs: QuotePreferences = {};
+    FIELDS.forEach((field) => {
+      const value = row[field];
+      if (value !== null && value !== undefined && value !== '') prefs[field] = value;
+    });
+    return prefs;
+  }
+
+  /**
+   * Upserts the given fields. Unknown keys are ignored; an explicit `null`
+   * clears that field. Returns the number of fields written.
+   */
+  async setPreferences(userId: string, patch: Partial<Record<QuotePrefField, string | null>>): Promise<number> {
+    const fields = FIELDS.filter((field) => patch[field] !== undefined);
+    if (fields.length === 0) return 0;
+
+    return this.db.executeTransaction(async () => {
+      await this.db.executeQuery(quotePreferenceQueries.ENSURE_ROW, [userId]);
+      const query = quotePreferenceQueries.updatePreferences(fields.map((field) => COLUMNS[field]));
+      await this.db.executeQuery(query, [...fields.map((field) => patch[field] ?? null), userId]);
+      return fields.length;
+    });
+  }
+
+  /** Clears a single saved field, falling back to the bot default. */
+  async clearPreference(userId: string, field: QuotePrefField): Promise<void> {
+    if (!FIELDS.includes(field)) return;
+    await this.setPreferences(userId, { [field]: null });
+  }
+
+  /** Drops every saved preference for the user. */
+  async clearAllPreferences(userId: string): Promise<void> {
+    await this.db.executeQuery(quotePreferenceQueries.DELETE_PREFERENCES, [userId]);
+  }
+}
+
+export default QuotePreferenceModel;

--- a/database/models/index.ts
+++ b/database/models/index.ts
@@ -13,6 +13,7 @@ import MarriageModel from './MarriageModel';
 import MusicGenModel from './MusicGenModel';
 import PokemonModel from './PokemonModel';
 import PoopModel from './PoopModel';
+import QuotePreferenceModel from './QuotePreferenceModel';
 import RpModel from './RpModel';
 import ServerConfigModel from './ServerConfigModel';
 import UserModel from './UserModel';
@@ -34,6 +35,7 @@ export {
   MusicGenModel,
   PokemonModel,
   PoopModel,
+  QuotePreferenceModel,
   RpModel,
   ServerConfigModel,
   UserModel,

--- a/database/queries/quotePreferenceQueries.ts
+++ b/database/queries/quotePreferenceQueries.ts
@@ -1,0 +1,15 @@
+// Column names are never taken from user input: SET clauses are assembled from
+// QUOTE_PREFERENCE_COLUMNS below, and every value is bound with a `?`.
+const quotePreferenceQueries = {
+  GET_PREFERENCES: 'SELECT * FROM QuotePreference WHERE user_id = ?',
+  DELETE_PREFERENCES: 'DELETE FROM QuotePreference WHERE user_id = ?',
+  ENSURE_ROW: 'INSERT OR IGNORE INTO QuotePreference (user_id) VALUES (?)',
+  /** Builds `UPDATE QuotePreference SET <col> = ?, ... WHERE user_id = ?`. */
+  updatePreferences: (columns: string[]): string => `
+    UPDATE QuotePreference
+    SET ${columns.map((c) => `${c} = ?`).join(', ')}, updated_at = CURRENT_TIMESTAMP
+    WHERE user_id = ?
+  `,
+};
+
+export default quotePreferenceQueries;

--- a/database/tables/index.ts
+++ b/database/tables/index.ts
@@ -16,6 +16,7 @@ import musicGenLogTable from './musicGenLogTable';
 import pokemonTable from './pokemonTable';
 import poopEntryTable from './poopEntryTable';
 import poopProfileTable from './poopProfileTable';
+import quotePreferenceTable from './quotePreferenceTable';
 import rpCharacterTable from './rpCharacterTable';
 import rpSpawnTable from './rpSpawnTable';
 import rpHistoryTable from './rpHistoryTable';
@@ -44,6 +45,7 @@ export {
   pokemonTable,
   poopEntryTable,
   poopProfileTable,
+  quotePreferenceTable,
   rpCharacterTable,
   rpSpawnTable,
   rpHistoryTable,
@@ -71,6 +73,7 @@ export type { MarriageRow } from './marriageTable';
 export type { MusicGenLogRow } from './musicGenLogTable';
 export type { PokemonRow } from './pokemonTable';
 export type { PoopEntryRow } from './poopEntryTable';
+export type { QuotePreferenceRow } from './quotePreferenceTable';
 export type { RpCharacterRow } from './rpCharacterTable';
 export type { RpSpawnRow } from './rpSpawnTable';
 export type { RpHistoryRow } from './rpHistoryTable';

--- a/database/tables/quotePreferenceTable.ts
+++ b/database/tables/quotePreferenceTable.ts
@@ -1,0 +1,37 @@
+import type { TableDefinition } from '../types';
+
+/**
+ * A user's saved quote defaults, applied to every quote *they* generate
+ * (slash or mention) unless the invocation opts out with the override flag.
+ * One row per user, global across servers. Every field is nullable: NULL means
+ * "not set", so the bot's own default applies.
+ */
+export interface QuotePreferenceRow {
+  user_id: string;
+  background: string | null;
+  text_color: string | null;
+  profile_color: string | null;
+  avatar_source: string | null;
+  font_style: string | null;
+  format: string | null;
+  updated_at: string;
+}
+
+const quotePreferenceTable: TableDefinition = {
+  name: 'QuotePreference',
+  columns: [
+    { name: 'user_id', type: 'VARCHAR PRIMARY KEY' },
+    { name: 'background', type: 'TEXT' },
+    { name: 'text_color', type: 'TEXT' },
+    { name: 'profile_color', type: 'TEXT' },
+    { name: 'avatar_source', type: 'TEXT' },
+    { name: 'font_style', type: 'TEXT' },
+    { name: 'format', type: 'TEXT' },
+    { name: 'updated_at', type: 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP' },
+  ],
+  primaryKey: ['user_id'],
+  specialConstraints: [],
+  constraints: [],
+};
+
+export default quotePreferenceTable;

--- a/tests/database/quotePreference.test.ts
+++ b/tests/database/quotePreference.test.ts
@@ -1,0 +1,81 @@
+import {
+  describe, it, expect, beforeAll, afterAll, beforeEach,
+} from 'bun:test';
+import Database from '../../database/Database';
+import type QuotePreferenceModel from '../../database/models/QuotePreferenceModel';
+import { parseQuoteFlags, resolveQuoteFlags, QUOTE_FLAG_DEFAULTS } from '../../utils/quote';
+
+describe('QuotePreferenceModel', () => {
+  let db: Database;
+  let prefs: QuotePreferenceModel;
+  const USER = 'user-1';
+
+  beforeAll(async () => {
+    db = new Database(`./tests/temp/testQuotePrefs-${Date.now()}.db`);
+    await db.ready;
+    prefs = db.quotePreference;
+  });
+
+  afterAll(() => {
+    db.db.close();
+  });
+
+  beforeEach(async () => {
+    await db.executeQuery('DELETE FROM QuotePreference');
+  });
+
+  it('returns an empty object for a user with nothing saved', async () => {
+    expect(await prefs.getPreferences(USER)).toEqual({});
+  });
+
+  it('saves and reads back a partial patch', async () => {
+    await prefs.setPreferences(USER, { background: 'white', textColor: '#ff0124' });
+    expect(await prefs.getPreferences(USER)).toEqual({ background: 'white', textColor: '#ff0124' });
+  });
+
+  it('merges further patches instead of replacing the row', async () => {
+    await prefs.setPreferences(USER, { background: 'white' });
+    await prefs.setPreferences(USER, { format: 'vertical' });
+    expect(await prefs.getPreferences(USER)).toEqual({ background: 'white', format: 'vertical' });
+  });
+
+  it('clears a single field and leaves the rest', async () => {
+    await prefs.setPreferences(USER, { background: 'white', format: 'vertical' });
+    await prefs.clearPreference(USER, 'background');
+    expect(await prefs.getPreferences(USER)).toEqual({ format: 'vertical' });
+  });
+
+  it('clears everything', async () => {
+    await prefs.setPreferences(USER, { background: 'white', format: 'vertical' });
+    await prefs.clearAllPreferences(USER);
+    expect(await prefs.getPreferences(USER)).toEqual({});
+  });
+
+  it('ignores unknown keys rather than putting them in SQL', async () => {
+    const written = await prefs.setPreferences(USER, { nickname: 'nope' } as any);
+    expect(written).toBe(0);
+    expect(await prefs.getPreferences(USER)).toEqual({});
+  });
+
+  it('keeps preferences per user', async () => {
+    await prefs.setPreferences(USER, { background: 'white' });
+    await prefs.setPreferences('user-2', { background: 'black' });
+    expect(await prefs.getPreferences(USER)).toEqual({ background: 'white' });
+    expect(await prefs.getPreferences('user-2')).toEqual({ background: 'black' });
+  });
+
+  it('feeds the mention-quote resolution chain end to end', async () => {
+    await prefs.setPreferences(USER, { background: 'white', textColor: '#ff0124' });
+    const saved = await prefs.getPreferences(USER);
+
+    // saved settings apply on a bare mention
+    expect(resolveQuoteFlags(parseQuoteFlags(''), saved)).toEqual({
+      ...QUOTE_FLAG_DEFAULTS, background: 'white', textColor: '#ff0124',
+    });
+    // a flag beats the saved value for that field only
+    expect(resolveQuoteFlags(parseQuoteFlags('b'), saved).background).toBe('black');
+    expect(resolveQuoteFlags(parseQuoteFlags('b'), saved).textColor).toBe('#ff0124');
+    // -o drops the whole saved layer
+    expect(resolveQuoteFlags(parseQuoteFlags('-o'), saved)).toEqual(QUOTE_FLAG_DEFAULTS);
+  });
+});

--- a/tests/quoteFlags.test.ts
+++ b/tests/quoteFlags.test.ts
@@ -4,6 +4,10 @@ import {
   resolveQuoteFlags,
   FONT_INDEX,
   FAKEQUOTE_FONT_VALUES,
+  FAKEQUOTE_FORMAT_VALUES,
+  FAKEQUOTE_BACKGROUND_VALUES,
+  FAKEQUOTE_PROFILE_COLOR_VALUES,
+  FAKEQUOTE_AVATAR_SOURCE_VALUES,
   QUOTE_FLAG_DEFAULTS,
 } from '../utils/quote';
 
@@ -64,6 +68,18 @@ describe('parseQuoteFlags', () => {
   // stay in the same order.
   test('numeric font index matches the slash-command font list', () => {
     expect(FONT_INDEX).toEqual(FAKEQUOTE_FONT_VALUES);
+  });
+
+  // quote(), the mention resolver and what /quote help and /quote settings
+  // advertise all read QUOTE_FLAG_DEFAULTS, so every default must be a value
+  // the slash-command choices actually offer.
+  test('declared defaults are all valid choice values', () => {
+    expect(FAKEQUOTE_FORMAT_VALUES).toContain(QUOTE_FLAG_DEFAULTS.format);
+    expect(FAKEQUOTE_BACKGROUND_VALUES).toContain(QUOTE_FLAG_DEFAULTS.background);
+    expect(FAKEQUOTE_FONT_VALUES).toContain(QUOTE_FLAG_DEFAULTS.fontStyle);
+    expect(FAKEQUOTE_PROFILE_COLOR_VALUES).toContain(QUOTE_FLAG_DEFAULTS.profileColor);
+    expect(FAKEQUOTE_AVATAR_SOURCE_VALUES).toContain(QUOTE_FLAG_DEFAULTS.avatarSource);
+    expect(QUOTE_FLAG_DEFAULTS.textColor).toBeNull(); // derived from the background
   });
 });
 

--- a/tests/quoteFlags.test.ts
+++ b/tests/quoteFlags.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  parseQuoteFlags,
+  resolveQuoteFlags,
+  FONT_INDEX,
+  FAKEQUOTE_FONT_VALUES,
+  QUOTE_FLAG_DEFAULTS,
+} from '../utils/quote';
+
+describe('parseQuoteFlags', () => {
+  test('returns only what was named, nothing implied', () => {
+    expect(parseQuoteFlags('')).toEqual({ override: false });
+    expect(parseQuoteFlags('v')).toEqual({ override: false, format: 'vertical' });
+  });
+
+  test('compact bare flags, order-independent and case-insensitive', () => {
+    expect(parseQuoteFlags(' V caveat #FF00AA BW global ')).toEqual({
+      override: false,
+      textColor: '#ff00aa', // normalised to lowercase
+      profileColor: 'bw',
+      avatarSource: 'global',
+      fontStyle: 'caveat',
+      format: 'vertical',
+    });
+  });
+
+  test('legacy key:value spelling still parses', () => {
+    expect(parseQuoteFlags('bg:w font:3 fmt:v txt:ff00aa pfpc:bw pfp:global')).toEqual({
+      override: false,
+      background: 'white',
+      textColor: '#ff00aa',
+      profileColor: 'bw',
+      avatarSource: 'global',
+      fontStyle: 'caveat',
+      format: 'vertical',
+    });
+  });
+
+  test('fonts by 1-based number and by slug', () => {
+    expect(parseQuoteFlags('1').fontStyle).toBe('sans-serif');
+    expect(parseQuoteFlags('11').fontStyle).toBe('bebas-neue');
+    expect(parseQuoteFlags('minecraft').fontStyle).toBe('minecraft');
+    // out of range / not a font → not set at all
+    expect(parseQuoteFlags('0 99 nope').fontStyle).toBeUndefined();
+  });
+
+  test('unknown tokens are ignored rather than breaking the quote', () => {
+    expect(parseQuoteFlags('lol quote this one #ggg')).toEqual({ override: false });
+  });
+
+  test('last token wins for the same field', () => {
+    expect(parseQuoteFlags('w b').background).toBe('black');
+    expect(parseQuoteFlags('v h').format).toBe('landscape');
+  });
+
+  test('override flag and its aliases', () => {
+    ['-o', '-O', '--override', '-d', '--default', '--defaults'].forEach((token) => {
+      expect(parseQuoteFlags(token).override).toBe(true);
+    });
+    expect(parseQuoteFlags('o override d').override).toBe(false); // needs the dash
+  });
+
+  // The mention parser addresses fonts by position, so these two lists must
+  // stay in the same order.
+  test('numeric font index matches the slash-command font list', () => {
+    expect(FONT_INDEX).toEqual(FAKEQUOTE_FONT_VALUES);
+  });
+});
+
+describe('resolveQuoteFlags', () => {
+  const saved = { background: 'white', textColor: '#ff0124', format: 'vertical' };
+
+  test('nothing set anywhere → bot defaults', () => {
+    expect(resolveQuoteFlags(parseQuoteFlags(''), null)).toEqual(QUOTE_FLAG_DEFAULTS);
+  });
+
+  test('saved settings layer over the defaults', () => {
+    expect(resolveQuoteFlags(parseQuoteFlags(''), saved)).toEqual({
+      ...QUOTE_FLAG_DEFAULTS,
+      background: 'white',
+      textColor: '#ff0124',
+      format: 'vertical',
+    });
+  });
+
+  test('flags on the invocation beat saved settings, field by field', () => {
+    const resolved = resolveQuoteFlags(parseQuoteFlags('h caveat'), saved);
+    expect(resolved.format).toBe('landscape'); // flag wins
+    expect(resolved.fontStyle).toBe('caveat');
+    expect(resolved.background).toBe('white'); // untouched saved value survives
+    expect(resolved.textColor).toBe('#ff0124');
+  });
+
+  test('-o drops the saved layer but keeps flags passed with it', () => {
+    expect(resolveQuoteFlags(parseQuoteFlags('-o'), saved)).toEqual(QUOTE_FLAG_DEFAULTS);
+    expect(resolveQuoteFlags(parseQuoteFlags('-o v'), saved)).toEqual({
+      ...QUOTE_FLAG_DEFAULTS,
+      format: 'vertical',
+    });
+  });
+});

--- a/utils/quote.ts
+++ b/utils/quote.ts
@@ -30,6 +30,31 @@ const FONT_MAP: Record<string, { family: string }> = {
 // Numeric index for mention-based quote parameter parsing (font:1, font:2, etc.)
 const FONT_INDEX: string[] = Object.keys(FONT_MAP);
 
+export interface QuoteFlags {
+  background: string;
+  textColor: string | null;
+  profileColor: string;
+  avatarSource: string;
+  fontStyle: string;
+  format: string;
+}
+
+/**
+ * The single source of truth for "no preference given" — used by `quote()`
+ * itself, by the mention-flag resolver, and by what `/quote help` and
+ * `/quote settings` advertise as the default. Keep those in step: `server`
+ * degrades to the global avatar anyway when a member has no server-specific
+ * one, so it is the safe default in a guild context.
+ */
+export const QUOTE_FLAG_DEFAULTS: QuoteFlags = {
+  background: 'black',
+  textColor: null,
+  profileColor: 'normal',
+  avatarSource: 'server',
+  fontStyle: 'sans-serif',
+  format: 'landscape',
+};
+
 interface FontRegistration {
   file: string;
   family: string;
@@ -843,10 +868,10 @@ async function quote(
     ? `${messageChars.slice(0, MAX_QUOTE_CHARS).join('').trimEnd()}…`
     : resolvedMessage;
   const message = `"${clippedMessage}"`;
-  const backgroundColor = _backgroundColor || 'black';
-  const profileColor = _profileColor || 'normal';
-  const avatarSource = _avatarSource || 'global';
-  const fontStyle = _fontStyle || 'sans-serif';
+  const backgroundColor = _backgroundColor || QUOTE_FLAG_DEFAULTS.background;
+  const profileColor = _profileColor || QUOTE_FLAG_DEFAULTS.profileColor;
+  const avatarSource = _avatarSource || QUOTE_FLAG_DEFAULTS.avatarSource;
+  const fontStyle = _fontStyle || QUOTE_FLAG_DEFAULTS.fontStyle;
 
   // Resolve font family
   const fontFamily = (FONT_MAP[fontStyle] || FONT_MAP['sans-serif']).family;
@@ -1095,15 +1120,6 @@ export const fakeQuoteChoices = (
 // the table below; the legacy `key:value` spelling still works because the
 // value half is resolved with exactly the same table.
 
-export interface QuoteFlags {
-  background: string;
-  textColor: string | null;
-  profileColor: string;
-  avatarSource: string;
-  fontStyle: string;
-  format: string;
-}
-
 /** The fields a user can save as a personal default via `/quote settings`. */
 export type QuotePrefField = keyof QuoteFlags;
 export type QuotePreferences = Partial<Record<QuotePrefField, string>>;
@@ -1120,15 +1136,6 @@ export const QUOTE_PREF_LABELS: Record<QuotePrefField, string> = {
   fontStyle: 'Font',
   profileColor: 'Profile filter',
   avatarSource: 'Avatar source',
-};
-
-export const QUOTE_FLAG_DEFAULTS: QuoteFlags = {
-  background: 'black',
-  textColor: null,
-  profileColor: 'normal',
-  avatarSource: 'server',
-  fontStyle: 'sans-serif',
-  format: 'landscape',
 };
 
 // Bare aliases → the field they set. First match wins, so `b` is "black" and

--- a/utils/quote.ts
+++ b/utils/quote.ts
@@ -87,7 +87,7 @@ FONT_REGISTRATIONS.forEach(({
 // ─── Hex Colour Validation ────────────────────────────────────────────────────
 const HEX_RE = /^#?([0-9A-Fa-f]{6})$/;
 
-function validateAndNormaliseHex(hex: string): string {
+export function validateAndNormaliseHex(hex: string): string {
   const match = HEX_RE.exec(hex);
   if (!match) {
     throw new Error(`Invalid hex colour "${hex}". Please use a 6-digit hex value like #FF00AA.`);
@@ -412,6 +412,7 @@ function adjustFontSize(
   _fontSize: number,
   fontFamily: string,
   maxHeight?: number,
+  minFontSize: number = MIN_QUOTE_FONT_SIZE,
 ): number {
   let fontSize = _fontSize;
   const height = maxHeight !== undefined ? maxHeight : 350;
@@ -421,7 +422,7 @@ function adjustFontSize(
   let totalHeight = lines.length * lineHeight;
 
   while (
-    fontSize > MIN_QUOTE_FONT_SIZE
+    fontSize > minFontSize
     && (
       totalHeight > height
       || anyLineExceedsWidth(ctx, lines, fontSize, maxWidth)
@@ -648,10 +649,10 @@ function truncateWithEllipsis(
 
 function resolveAvatarUrl(person: User | APIUser): string {
   if (typeof (person as User).displayAvatarURL === 'function') {
-    return (person as User).displayAvatarURL({ extension: 'png', size: 512 });
+    return (person as User).displayAvatarURL({ extension: 'png', size: 1024 });
   }
   if (person.avatar) {
-    return `https://cdn.discordapp.com/avatars/${person.id}/${person.avatar}.png?size=512`;
+    return `https://cdn.discordapp.com/avatars/${person.id}/${person.avatar}.png?size=1024`;
   }
   // eslint-disable-next-line no-bitwise, node/no-unsupported-features/es-builtins
   const defaultIndex = (BigInt(person.id) >> 22n) % 6n;
@@ -684,8 +685,15 @@ async function renderVerticalQuote(input: VerticalQuoteInput): Promise<Buffer> {
   const HEIGHT = 800;
   const AVATAR_SIZE = 640; // full-width square at the top
   const MAX_TEXT_WIDTH = 560;
-  const MAX_TEXT_HEIGHT = 250;
-  const CONTENT_BOTTOM = 760; // baseline the content block sits above
+  // The content block is bottom-anchored and grows upwards, so these two caps
+  // are what keep a long quote from swallowing the avatar: the text can never
+  // be taller than MAX_TEXT_HEIGHT (it gets truncated instead), and the block
+  // as a whole never starts above CONTENT_TOP_MIN.
+  const MAX_TEXT_HEIGHT = 170;
+  const CONTENT_BOTTOM = 762; // baseline the content block sits above
+  const CONTENT_TOP_MIN = 430; // avatar always keeps the top ~54% of the canvas
+  // Shrinking below this is unreadable at portrait size — truncate instead.
+  const VERTICAL_MIN_FONT_SIZE = 22;
 
   const canvas = Canvas.createCanvas(WIDTH, HEIGHT);
   const ctx = canvas.getContext('2d');
@@ -709,7 +717,7 @@ async function renderVerticalQuote(input: VerticalQuoteInput): Promise<Buffer> {
   ctx.textBaseline = 'top';
 
   let lines = wrapSegments(ctx, rawSegments, MAX_TEXT_WIDTH, fontSize);
-  fontSize = adjustFontSize(ctx, lines, MAX_TEXT_WIDTH, fontSize, fontFamily, MAX_TEXT_HEIGHT);
+  fontSize = adjustFontSize(ctx, lines, MAX_TEXT_WIDTH, fontSize, fontFamily, MAX_TEXT_HEIGHT, VERTICAL_MIN_FONT_SIZE);
   ctx.font = buildFont(fontSize, fontFamily);
   lines = wrapSegments(ctx, rawSegments, MAX_TEXT_WIDTH, fontSize);
 
@@ -727,28 +735,31 @@ async function renderVerticalQuote(input: VerticalQuoteInput): Promise<Buffer> {
   const userFontSize = Math.min(20, Math.max(12, nickFontSize - 10));
   const showUser = username !== nickname;
 
-  const glyphSize = 56;
-  const gapAfterGlyph = 14;
+  const glyphSize = 48;
+  const gapAfterGlyph = 12;
   const textHeight = lines.length * lineHeight;
-  const gapAfterText = 26;
-  const gapAfterDivider = 18;
+  const gapAfterText = 24;
+  const gapAfterDivider = 16;
   const nickHeight = nickFontSize * 1.2;
   const userHeight = showUser ? userFontSize * 1.3 + 4 : 0;
 
   const totalHeight = glyphSize + gapAfterGlyph + textHeight
     + gapAfterText + gapAfterDivider + nickHeight + userHeight;
-  let y = CONTENT_BOTTOM - totalHeight;
+  let y = Math.max(CONTENT_TOP_MIN, CONTENT_BOTTOM - totalHeight);
   const centerX = WIDTH / 2;
 
   // ── Gradient fade (avatar → content) ──────────────────────────────────────
   // Anchored to wherever the content block starts so the text always sits on
-  // an opaque background, however tall the quote is.
-  const fadeBottom = Math.min(AVATAR_SIZE, y + 50);
-  const fadeTop = Math.max(0, fadeBottom - 320);
+  // an opaque background, however tall the quote is. The gradient is fully
+  // opaque a little *above* the content, and the solid fill picks up exactly
+  // where it lands, so there is never a visible seam across the avatar.
+  const fadeBottom = Math.min(AVATAR_SIZE, y - 8);
+  const fadeTop = Math.max(0, fadeBottom - 380);
   const gradient = ctx.createLinearGradient(0, fadeTop, 0, fadeBottom);
   gradient.addColorStop(0, `rgba(${bgRgb}, 0)`);
-  gradient.addColorStop(0.5, `rgba(${bgRgb}, 0.55)`);
-  gradient.addColorStop(0.8, `rgba(${bgRgb}, 0.9)`);
+  gradient.addColorStop(0.35, `rgba(${bgRgb}, 0.18)`);
+  gradient.addColorStop(0.65, `rgba(${bgRgb}, 0.6)`);
+  gradient.addColorStop(0.85, `rgba(${bgRgb}, 0.9)`);
   gradient.addColorStop(1, `rgba(${bgRgb}, 1)`);
   ctx.fillStyle = gradient;
   ctx.fillRect(0, fadeTop, WIDTH, fadeBottom - fadeTop);
@@ -854,7 +865,7 @@ async function quote(
     try {
       const member = guild.members.cache.get(_person.id);
       if (member && member.avatar) {
-        pfp = member.displayAvatarURL({ extension: 'png', size: 512 });
+        pfp = member.displayAvatarURL({ extension: 'png', size: 1024 });
       } else {
         throw new Error('Server avatar not found, falling back to global avatar.');
       }
@@ -1076,6 +1087,152 @@ export const FAKEQUOTE_AVATAR_SOURCE_VALUES = valuesOf(FAKEQUOTE_AVATAR_SOURCES)
 export const fakeQuoteChoices = (
   opts: FakeQuoteOption[],
 ): { name: string; value: string }[] => opts.map(({ label, value }) => ({ name: label, value }));
+
+// ─── Mention-style flag parsing ───────────────────────────────────────────────
+// `@bot w v caveat #ff00aa bw` instead of
+// `@bot bg:w format:v font:3 txt:#ff00aa pfpc:bw`.
+// Tokens are order-independent, all optional, and each one is matched against
+// the table below; the legacy `key:value` spelling still works because the
+// value half is resolved with exactly the same table.
+
+export interface QuoteFlags {
+  background: string;
+  textColor: string | null;
+  profileColor: string;
+  avatarSource: string;
+  fontStyle: string;
+  format: string;
+}
+
+/** The fields a user can save as a personal default via `/quote settings`. */
+export type QuotePrefField = keyof QuoteFlags;
+export type QuotePreferences = Partial<Record<QuotePrefField, string>>;
+
+export const QUOTE_PREF_FIELDS: QuotePrefField[] = [
+  'format', 'background', 'textColor', 'fontStyle', 'profileColor', 'avatarSource',
+];
+
+/** Human labels for the saved-settings readout. */
+export const QUOTE_PREF_LABELS: Record<QuotePrefField, string> = {
+  format: 'Format',
+  background: 'Background',
+  textColor: 'Text colour',
+  fontStyle: 'Font',
+  profileColor: 'Profile filter',
+  avatarSource: 'Avatar source',
+};
+
+export const QUOTE_FLAG_DEFAULTS: QuoteFlags = {
+  background: 'black',
+  textColor: null,
+  profileColor: 'normal',
+  avatarSource: 'server',
+  fontStyle: 'sans-serif',
+  format: 'landscape',
+};
+
+// Bare aliases → the field they set. First match wins, so `b` is "black" and
+// never "bebas-neue"; fonts are always addressed by full slug or by number.
+const BACKGROUND_ALIASES: Record<string, string> = {
+  w: 'white', white: 'white', b: 'black', black: 'black',
+};
+const FORMAT_ALIASES: Record<string, string> = {
+  v: 'vertical',
+  vert: 'vertical',
+  vertical: 'vertical',
+  portrait: 'vertical',
+  h: 'landscape',
+  land: 'landscape',
+  landscape: 'landscape',
+};
+const PROFILE_COLOR_ALIASES: Record<string, string> = {
+  normal: 'normal', bw: 'bw', inv: 'inverted', inverted: 'inverted', sepia: 'sepia', nightmare: 'nightmare',
+};
+const AVATAR_SOURCE_ALIASES: Record<string, string> = {
+  srv: 'server', server: 'server', glob: 'global', global: 'global',
+};
+const FONT_ALIASES: Record<string, string> = {
+  sans: 'sans-serif', default: 'sans-serif', hp: 'harrypotter', comic: 'comic-sans', bebas: 'bebas-neue',
+};
+
+/** Resolves one token against every field. Returns null when nothing matches. */
+function resolveQuoteToken(raw: string): Partial<QuoteFlags> | null {
+  const t = raw.toLowerCase();
+  if (BACKGROUND_ALIASES[t]) return { background: BACKGROUND_ALIASES[t] };
+  if (FORMAT_ALIASES[t]) return { format: FORMAT_ALIASES[t] };
+  if (PROFILE_COLOR_ALIASES[t]) return { profileColor: PROFILE_COLOR_ALIASES[t] };
+  if (AVATAR_SOURCE_ALIASES[t]) return { avatarSource: AVATAR_SOURCE_ALIASES[t] };
+  if (FONT_ALIASES[t]) return { fontStyle: FONT_ALIASES[t] };
+  if (FONT_MAP[t]) return { fontStyle: t };
+
+  const hex = HEX_RE.exec(t);
+  if (hex) return { textColor: `#${hex[1]}` };
+
+  // font by 1-based number, matching the order of FONT_MAP / FAKEQUOTE_FONTS
+  if (/^\d+$/.test(t)) {
+    const n = parseInt(t, 10);
+    if (n >= 1 && n <= FONT_INDEX.length) return { fontStyle: FONT_INDEX[n - 1] };
+  }
+  return null;
+}
+
+// Legacy `key:value` spellings, kept working so old muscle memory doesn't break.
+const LEGACY_KEYS = ['bg', 'txt', 'pfpc', 'pfp', 'font', 'format', 'fmt'];
+
+// Opts this one quote out of the invoker's saved `/quote settings` defaults.
+// Flags passed alongside it still apply — `-o` drops the saved layer only.
+const OVERRIDE_TOKENS = ['-o', '--override', '-d', '--default', '--defaults'];
+
+export interface ParsedQuoteFlags extends Partial<QuoteFlags> {
+  /** True when the message asked to ignore the invoker's saved settings. */
+  override: boolean;
+}
+
+/**
+ * Parses mention-style quote options out of free text (the message content with
+ * the bot mention already stripped). Only the fields actually named are
+ * returned, so callers can layer defaults → saved settings → these. Unknown
+ * tokens are ignored, so ordinary words in the message never break a quote.
+ */
+export function parseQuoteFlags(text: string): ParsedQuoteFlags {
+  const flags: ParsedQuoteFlags = { override: false };
+
+  text.split(/\s+/).filter(Boolean).forEach((token) => {
+    if (OVERRIDE_TOKENS.includes(token.toLowerCase())) {
+      flags.override = true;
+      return;
+    }
+    const key = LEGACY_KEYS.find((k) => token.toLowerCase().startsWith(`${k}:`));
+    const value = key ? token.slice(key.length + 1) : token;
+    if (!value) return;
+    const resolved = resolveQuoteToken(value);
+    if (resolved) Object.assign(flags, resolved);
+  });
+
+  return flags;
+}
+
+/**
+ * Layers the three sources of truth into the values `quote()` is called with:
+ * bot defaults → the invoker's saved settings → flags given on this invocation.
+ * The saved layer is skipped when the invocation used the override flag.
+ */
+export function resolveQuoteFlags(
+  parsed: ParsedQuoteFlags,
+  saved: QuotePreferences | null,
+  base: QuoteFlags = QUOTE_FLAG_DEFAULTS,
+): QuoteFlags {
+  const { override, ...explicit } = parsed;
+  return {
+    ...base,
+    ...(override || !saved ? {} : saved),
+    ...explicit,
+  };
+}
+
+/** One-line usage hint shown while a mention quote renders. */
+export const QUOTE_FLAG_HELP = 'flags: w/b · v/h · #hex · bw/inverted/sepia/nightmare · server/global · font '
+  + `1-${FONT_INDEX.length} or name · -o to ignore your saved settings · /quote help`;
 
 export default quote;
 export { FONT_MAP, FONT_INDEX };


### PR DESCRIPTION
Closes #210.

## Vertical quotes

The portrait layout was unreadable for anything but a short message. The content block is bottom-anchored and grew upwards **without a cap**, so a long quote pushed the gradient fade up over the avatar's face while `adjustFontSize` shrank the text to ~19px across 15 lines to make it fit.

- **Text budget capped** — `MAX_TEXT_HEIGHT` 250 → 170, plus a new `CONTENT_TOP_MIN`, so the avatar always keeps the top ~54% of the canvas no matter the quote length.
- **Readability floor** — `adjustFontSize` takes an optional `minFontSize`; vertical uses 22 instead of the global 14. Long quotes land at 26px/6 lines and get an `…` instead of shrinking into mush.
- **Gradient** — now ends 8px *above* the content block (was 50px *below* it, which is why the `""` glyph and first lines sat on the face), span 320→380px, smoother stops.
- **Avatar sharpness** — vertical draws at 640px but we only fetched 512. Now 1024 (landscape downsamples from it, also a small win).

Landscape is untouched and re-renders identically.

## Mention flags

Long `key:value` parameters become compact space-separated tokens, order-independent, all optional, unknown tokens ignored so ordinary words never break a quote:

```
@Silverwolf w v caveat #ff0124
```

| token | sets |
|---|---|
| `w`/`white`, `b`/`black` | background |
| `v`/`vertical`, `h`/`landscape` | format |
| `#ff0124` or `ff0124` | text colour |
| `bw`, `inverted`, `sepia`, `nightmare` | pfp filter |
| `server`, `global` | avatar source |
| font slug or `1`–`11` | font |

The legacy `bg:w font:3 fmt:v txt:#ff0124 pfpc:bw pfp:global` spelling still parses — the key half is stripped and the value goes through the same alias table, so both share one code path (54 lines of hand-rolled regex parsing → 3).

**Bug fixed along the way:** `FONT_INDEX` was read as a property off the default-exported `quote` *function*, so it was `undefined`. Any `font:` token threw a `TypeError` inside the `.then`, swallowed by `.catch(console.error)` — the reply just sat on "Generating..." forever.

## `/quote` command group

- **`/quote fake`** — the old `/fakequote` (removed), plus an `override` option.
- **`/quote settings`** — ephemeral. Run bare to view your saved defaults, pass any subset of options to save them, `clear:<field>` / `clear:Everything` to unset. Values are whitelist-checked against the same `FAKEQUOTE_*_VALUES` the web page uses; hex goes through `validateAndNormaliseHex`.
- **`/quote help`** — flags, fonts and precedence, built *from* the shared lists so it can't drift.

New `QuotePreference` table, one row per user, **every column nullable** so "not set" and "set to black" stay distinguishable. Column names come from a fixed allow-list keyed by field — user input never reaches the SQL string, only `?` binds. `setPreferences` is a partial upsert (ensure-row + UPDATE in one `executeTransaction`), so saving `format` later doesn't wipe `background`.

### Precedence

**bot defaults → your saved settings → flags on this invocation**

A flag beats a saved value *for that field only*, which is the common case and needs no flag at all. `-o` (aliases `--override`, `-d`, `--default`), or `override:True` on slash, drops the saved layer entirely for one quote — flags passed alongside it still apply.

```
@Silverwolf              → your saved settings
@Silverwolf b            → saved settings, but black this time
@Silverwolf -o           → bot defaults, saved settings ignored
@Silverwolf -o v caveat  → bot defaults + vertical + Caveat
```

A leading dash is deliberate: the parser ignores unrecognised tokens, so a bare word like `raw` or `plain` risks colliding with real message text, whereas nothing else in the grammar starts with `-`.

## Testing

- `tsc --noEmit` clean; `eslint` clean on every touched file (the one remaining repo error is pre-existing in `tests/database/serverConfig.test.ts`).
- **355 tests pass.** New: `tests/quoteFlags.test.ts` (12 — parsing, override aliases, layering, and a guard that `FONT_INDEX` stays aligned with the slash font list since the parser addresses fonts by position) and `tests/database/quotePreference.test.ts` (8 — against a real temp SQLite DB, including the end-to-end resolution chain).
- Rendered every vertical case (long / medium / short / emoji / newline-spam / no-nickname / white bg) against a grid-marked test avatar to verify the layout, and re-rendered landscape to confirm no regression.
- Ran a loader harness that instantiates all 164 command entries and validates the built payload against Discord's schema rules — no problems.

## Notes for review

- **`/fakequote` is gone.** Registration does a full `PUT`, so it disappears from Discord on next boot. If any guild has `fakequote` blacklisted in `CommandConfig`, that row is now dangling and the new `/quote` group is unblocked there until someone blacklists `quote` — worth a quick check on the table.
- No migration needed: `Database.init()` creates `QuotePreference` via `CREATE TABLE IF NOT EXISTS`.
- The **website** fakequote page (`/games/fakequote`) is untouched and still uses hardcoded defaults. Wiring saved settings into it is a natural follow-up — it has the user's identity via OAuth — but it's a separate surface with its own CSRF/validation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added personal quote defaults with `/quote settings` (save, update, or clear fields).
  * Added `/quote help` with flags, fonts, and examples.
  * Enhanced quote flags with per-invocation overrides that can bypass saved preferences.
* **Bug Fixes**
  * Improved portrait quote rendering (layout constraints, truncation/readability) and font shrinking behavior.
  * Upgraded avatar image resolution and improved avatar-to-content rendering.
* **Documentation**
  * Updated quote behavior guidance on saved defaults, precedence, and override rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->