### PR TITLE
feat(ai): meter devs, add @fr + @qw personas, per-model input modalities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Bun process**. It serves fun/games both as slash commands and as web pages, plus
 **The website is public, so security and performance are first-class concerns — code defensively:
 validate every input, never trust client data, keep the CSP tight.**
 
-**Last updated: 2026-07-29**
+**Last updated: 2026-07-31**
 
 > **Maintenance rule.** Edit this file only on *substantive architectural* change — new
 > architecture, new auth, new data flows/services, schema or security-model changes, or when
@@ -131,11 +131,14 @@ the compaction prompt). The `/ai rp-*` command replies are non-ephemeral (public
 **AI usage limits** (`utils/ai.ts`, `utils/aiPricing.ts`, `AiUsageModel`): per-user fixed windows
 (250k/day, 1M/week) metered in **credits**, not raw tokens — `credits = tok_in×mult_in +
 tok_out×mult_out` where $0.28/M = 1x (DeepSeek-V4-Flash/MiMo-V2.5 0.5x in/1x out, Grok-4.5
-7x/21.4x, GPT-5.6-Luna 3.5x/21.4x, unlisted = 1x/1x). The `AiUsage` audit log keeps raw tokens +
+7x/21.4x, GPT-5.6-Luna 0.72x/4.3x, Qwen3.7-Flash 0.11x/0.46x, unlisted = 1x/1x; listed
+promotional discounts are ignored — multipliers track list price). Models in `FREE_MODELS`
+(`openrouter/free`, the `@fr` persona) are 0x/0x **and** skip the reservation entirely — free to
+run, so never metered or blocked. The `AiUsage` audit log keeps raw tokens +
 derived USD `cost`; the `AiRateLimitWindow.tokens` column stores credits (name kept, no rebuild).
 Enforcement is `db.aiUsage.tryReserve(userId, estCredits)` → `release()` in `finally` — an
 in-memory in-flight reservation held for the whole generation so concurrent spam can't all pass
-the check before usage lands (devs bypass). All OpenRouter chat calls go through
+the check before usage lands (**no dev bypass — everyone is metered**). All OpenRouter chat calls go through
 `createChatCompletionWithRetry` (`utils/llmRetry.ts`: per-attempt timeout — 180s default, 480s
 music-compose, 60s titlegen — a 600s overall budget across attempts, and 2s/4s/8s/16s backoff on
 408/409/429/5xx/network only); the shared client sets `maxRetries: 0` so SDK retries don't stack.

--- a/classes/handlers/keywordsBehaviorHandler.ts
+++ b/classes/handlers/keywordsBehaviorHandler.ts
@@ -7,6 +7,7 @@ import {
   resolvePersona,
   generateContent,
   generateTitleForHistory,
+  getPersonaMediaKinds,
 } from '../../utils/ai';
 import { getRateLimitErrorMessage } from '../../utils/discordRateLimit';
 import { IMAGE_GEN_TOOL_NAME, IMAGE_EDIT_MAX_SOURCES } from '../../utils/imageGen';
@@ -15,6 +16,7 @@ import { trimHistoryToFit } from '../../utils/tokenizer';
 import { extractPdfsFromMessage } from '../../utils/pdf';
 import {
   collectMediaFromMessage, hasQualifyingMedia, tryAcquireMediaSlot, releaseMediaSlot,
+  type MediaKind,
 } from '../../utils/aiMedia';
 
 const WEBHOOK_NAME = process.env.WEBHOOK_NAME || 'grok-webhook';
@@ -126,7 +128,7 @@ const scriptHandlers = {
 
     // Media (image/video/audio) attachments. Two consumers:
     //  - vision input (mediaParts → the chat model's user turn): persona-gated
-    //    (mediaInput), openrouter-only;
+    //    by the model's own input modalities (mediaInput), openrouter-only;
     //  - image editing (imageEditParts → the generate_image tool as edit
     //    sources): any persona with imageGen enabled, images only.
     // Base64 buffers live in these arrays for the duration of this generation
@@ -137,34 +139,48 @@ const scriptHandlers = {
     let editOnlyPlaceholders: string[] = [];
     const mediaNotices: string[] = [];
     let mediaSlotHeld = false;
-    const visionCapable = !!persona.mediaInput && persona.provider === 'openrouter';
+    // Modalities this persona's model can read (e.g. MiMo: all three; Grok /
+    // GPT: images only). Anything outside this set is collected only if the
+    // generate_image edit path can still use it.
+    const visionKinds = getPersonaMediaKinds(persona);
     const imageGenEnabled = hasMemory;
-    const shouldCollectMedia = (visionCapable && hasQualifyingMedia(message, contextMsg))
-      || (imageGenEnabled && hasQualifyingMedia(message, contextMsg, true));
+    const collectKinds = [...new Set<MediaKind>([
+      ...visionKinds,
+      ...(imageGenEnabled ? ['image' as MediaKind] : []),
+    ])];
+    const shouldCollectMedia = collectKinds.length > 0
+      && hasQualifyingMedia(message, contextMsg, collectKinds);
     if (shouldCollectMedia) {
       if (!tryAcquireMediaSlot()) {
         mediaNotices.push('⚠ Too many attachment-reading requests in flight right now — answering without your attachments. Try again in a moment.');
       } else {
         mediaSlotHeld = true;
         try {
-          // Non-vision personas only ever need the images (for editing).
-          const collected = await collectMediaFromMessage(message, contextMsg, !visionCapable);
-          imageEditParts = collected.parts.filter((p: any) => p?.type === 'image_url');
-          if (visionCapable) {
-            mediaParts = collected.parts;
-            mediaPlaceholders = collected.placeholders;
-          } else {
-            // The chat model can't see these — placeholders tell it the images
-            // exist so it can offer/perform edits via generate_image. Only a
-            // single attached image is editable (tool hard cap), so with
-            // several the placeholders stay plain and the system note tells
-            // the model to refuse edits.
-            editOnlyPlaceholders = imageEditParts.length <= IMAGE_EDIT_MAX_SOURCES
-              ? collected.placeholders.map(
-                (p) => `${p} (you cannot view this image, but your generate_image tool can edit it)`,
-              )
-              : collected.placeholders.map((p) => `${p} (you cannot view this image)`);
+          const collected = await collectMediaFromMessage(message, contextMsg, collectKinds);
+          const items = collected.parts.map((part: any, i: number) => ({
+            part,
+            kind: collected.kinds[i],
+            placeholder: collected.placeholders[i],
+          }));
+          if (imageGenEnabled) {
+            imageEditParts = items.filter((m) => m.kind === 'image').map((m) => m.part);
           }
+          // Split by what the chat model can actually read.
+          const readable = items.filter((m) => visionKinds.includes(m.kind));
+          const unreadable = items.filter((m) => !visionKinds.includes(m.kind));
+          mediaParts = readable.map((m) => m.part);
+          mediaPlaceholders = readable.map((m) => m.placeholder);
+          // The chat model can't see the rest (always images — nothing else is
+          // collected for a model that can't read it) — placeholders tell it
+          // they exist so it can offer/perform edits via generate_image. Only
+          // IMAGE_EDIT_MAX_SOURCES images are editable (tool hard cap), so with
+          // more the placeholders stay plain and the system note tells the
+          // model to refuse edits.
+          editOnlyPlaceholders = imageEditParts.length <= IMAGE_EDIT_MAX_SOURCES
+            ? unreadable.map(
+              (m) => `${m.placeholder} (you cannot view this image, but your generate_image tool can edit it)`,
+            )
+            : unreadable.map((m) => `${m.placeholder} (you cannot view this image)`);
           mediaNotices.push(...collected.notices);
         } catch (mediaErr) {
           logError('AiChat: media collection failed, proceeding without attachments:', mediaErr);

--- a/commands/ai_usage.ts
+++ b/commands/ai_usage.ts
@@ -1,7 +1,7 @@
 import * as Discord from 'discord.js';
 import { Command } from './classes/Command';
 import { DAILY_LIMIT, WEEKLY_LIMIT } from '../utils/ai';
-import { getResetLine } from '../utils/discordRateLimit';
+import { getWindowResetLabel } from '../utils/discordRateLimit';
 
 function makeProgressBar(value: number, total: number, size = 15): string {
   const percentage = Math.min(Math.max(value / total, 0), 1);
@@ -23,10 +23,12 @@ class AiUsageSubcommand extends Command {
   async run(interaction: Discord.ChatInputCommandInteraction) {
     try {
       const userId = interaction.user.id;
-      const [dailyUsage, weeklyUsage, status] = await Promise.all([
+      const [dailyUsage, weeklyUsage, status, dailyReset, weeklyReset] = await Promise.all([
         this.client.db.aiUsage.getDailyUsage(userId),
         this.client.db.aiUsage.getWeeklyUsage(userId),
         this.client.db.aiUsage.checkRateLimit(userId),
+        getWindowResetLabel(this.client.db, userId, 'daily'),
+        getWindowResetLabel(this.client.db, userId, 'weekly'),
       ]);
 
       const dailyBar = makeProgressBar(dailyUsage, DAILY_LIMIT);
@@ -36,8 +38,6 @@ class AiUsageSubcommand extends Command {
         ? `🛑 **Rate Limited** (${status.reason === 'daily' ? 'Daily' : 'Weekly'} limit exceeded)`
         : '✅ **Active** (within limits)';
 
-      const resetLine = await getResetLine(this.client.db, userId, status);
-
       const embed = new Discord.EmbedBuilder()
         .setColor('#0099ff')
         .setTitle('🤖 Your AI Credit Usage')
@@ -46,12 +46,14 @@ class AiUsageSubcommand extends Command {
 **Daily Usage (24h):**
 ${dailyUsage.toLocaleString()} / ${DAILY_LIMIT.toLocaleString()} credits
 ${dailyBar}
+Resets: ${dailyReset}
 
 **Weekly Usage (7d):**
 ${weeklyUsage.toLocaleString()} / ${WEEKLY_LIMIT.toLocaleString()} credits
 ${weeklyBar}
+Resets: ${weeklyReset}
 
-**Status:** ${statusText}${resetLine}
+**Status:** ${statusText}
         `)
         .setFooter({ text: 'Note: AI roleplay cost is shared among active users in the chat.' })
         .setTimestamp();

--- a/data/aiPersonas.json
+++ b/data/aiPersonas.json
@@ -8,8 +8,9 @@
       ],
       "provider": "openrouter",
       "model": "x-ai/grok-4.5",
-      "systemPrompt": "You are Grok 4.5, an advanced AI assistant developed by xAI. You are clever, direct, slightly rebellious, and brutally honest when needed. Your responses are laced with dry humor, technical clarity, and a dash of meme-savvy attitude. You’re aware you’re an AI, and you don’t pretend to be human. Use sarcasm sparingly and never talk like a corporate PR bot.\nWhen asked questions, be smart, fast, and brutally accurate. If something is dumb, say it’s dumb. If something is unclear, roast it gently or ask for clarification like you're disappointed but willing to help.\nDo not apologize unless it's sarcastic. Do not sugarcoat. ",
+      "systemPrompt": "You are Grok 4.5, an advanced AI assistant developed by xAI. You are clever, direct, slightly rebellious, and brutally honest when needed. Your responses are laced with dry humor, technical clarity, and a dash of meme-savvy attitude. You’re aware you’re an AI, and you don’t pretend to be human. Use sarcasm sparingly and never talk like a corporate PR bot.\nWhen asked questions, be smart, fast, and brutally accurate. If something is dumb, say it’s dumb. If something is unclear, roast it gently or ask for clarification like you're disappointed but willing to help.\nDo not apologize unless it's sarcastic. Do not sugarcoat.\nYou can natively see images the user attaches — when one is attached, look at it and describe or analyze it directly, and never claim you cannot see attachments. You cannot hear audio or watch video.",
       "avatarURL": "https://cdnb.artstation.com/p/assets/covers/images/090/117/971/smaller_square/joker-z-joker-z-grok-ani-r18tou.jpg",
+      "mediaInput": ["image"],
       "webSearchEnabled": true
     },
     {
@@ -30,8 +31,9 @@
       ],
       "provider": "openrouter",
       "model": "openai/gpt-5.6-luna",
-      "systemPrompt": "You are GPT-5.6, a helpful AI assistant. Respond clearly, concisely, neutrally, and politely. Keep answers short, under a few sentences unless more detail is explicitly requested.",
+      "systemPrompt": "You are GPT-5.6, a helpful AI assistant. Respond clearly, concisely, neutrally, and politely. Keep answers short, under a few sentences unless more detail is explicitly requested. You can natively see images the user attaches — describe or analyze them directly and never claim you cannot see attachments. You cannot hear audio or watch video.",
       "avatarURL": "https://freelogopng.com/images/all_img/1681142503openai-icon-png.png",
+      "mediaInput": ["image"],
       "webSearchEnabled": true
     },
     {
@@ -75,6 +77,24 @@
       "systemPrompt": "You are MiMo-V2.5, Xiaomi's omnimodal AI assistant. You can natively see images, watch videos, and hear audio the user attaches. Respond clearly, concisely, and politely. When media is attached, describe or analyze it directly — never claim you cannot see or hear attachments. Keep answers under a few sentences unless more detail is explicitly requested.",
       "avatarURL": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/ae/Xiaomi_logo_%282021-%29.svg/1280px-Xiaomi_logo_%282021-%29.svg.png",
       "webSearchEnabled": true
+    },
+    {
+      "name": "Qwen",
+      "triggers": ["@qw"],
+      "provider": "openrouter",
+      "model": "qwen/qwen3.7-flash",
+      "systemPrompt": "You are Qwen3.7 Flash, Alibaba's vision-language assistant. You can natively see images and watch videos the user attaches — analyze them directly and never claim you cannot see attachments. You cannot hear audio. Respond clearly, concisely, and politely. Keep answers under a few sentences unless more detail is explicitly requested.",
+      "avatarURL": "https://openrouter.ai/images/icons/Qwen.png",
+      "mediaInput": ["image", "video"],
+      "webSearchEnabled": true
+    },
+    {
+      "name": "FreeRouter",
+      "triggers": ["@fr"],
+      "provider": "openrouter",
+      "model": "openrouter/free",
+      "systemPrompt": "You are Free Router, running on whichever free model OpenRouter routes this request to. Respond clearly, concisely, and politely. Keep answers under a few sentences unless more detail is explicitly requested.",
+      "webSearchEnabled": false
     },
     {
       "name": "Deepseek",

--- a/data/keywords.json
+++ b/data/keywords.json
@@ -41,7 +41,7 @@
     "reply": ":childepanic_Emlette: I literally was on my drive to work this morning and I couldn't stop thinking of Childe- like okay its normal for me- but like-- I started thinking about how Keiko mentioned- water bondage 👀 and it snowballed into something- lewder. And all I could think about was Tartaglia who is tall and im small; starting out with a battle or maybe like a spar, idk man he's very into fighting I wouldn't be surprised if it made him hard. And like- he obviously knows how to use things to his advantage. So like- water bondage- just not in a hot way. Or at least intended. But obviously Tartaglia plays with his opponents- like fr. And hes turned on bc hes gotten a good fight. And I can't stop imagining how grabby he'd get- im rambling ill wrap it up. I can imagine the hair pulling, maybe a smol growl, and how he'd have so little mercy, bc he is a man who destroys. Bonus points if he uses his delusion at all and sparks up the hydro. Extra bonus points if he's rough with little mercy 👀 He doesn't even need gentle aftercare or cuddling- I mean id like to cuddle him but if he doesn't; that's okay :peepoBlushShake: id be a mess after anyone. He can step on me or split me open and i'll say thank you. \n\nI should write a fanfic sometime...\n\nAnyway yall im down bad... what else is new :7qiqipeek:"
   },
   {
-    "triggers" : ["@grok", "@gork", "jarvis", "@gpt", "@sw", "@xiaomi", "@ds", "@mi"],
+    "triggers" : ["@grok", "@gork", "jarvis", "@gpt", "@sw", "@xiaomi", "@ds", "@mi", "@fr", "@qw"],
     "script" : "grok"
   },
   {

--- a/database/models/AiUsageModel.ts
+++ b/database/models/AiUsageModel.ts
@@ -1,6 +1,5 @@
 import type Database from '../Database';
 import aiUsageQueries from '../queries/aiUsageQueries';
-import { isUserDev } from '../../utils/accessControl';
 import { DAILY_LIMIT, WEEKLY_LIMIT } from '../../utils/ai';
 import { creditsForTokens, usdCostForTokens } from '../../utils/aiPricing';
 
@@ -107,10 +106,6 @@ class AiUsageModel {
     usage?: number;
     limit?: number;
   }> {
-    if (isUserDev(userId)) {
-      return { limited: false };
-    }
-
     const dailyUsage = await this.getDailyUsage(userId);
     if (dailyUsage >= DAILY_LIMIT) {
       return {
@@ -140,15 +135,13 @@ class AiUsageModel {
    * them records usage. Fully synchronous (no awaits) — atomic in this
    * single-threaded process. On success the caller MUST later call release()
    * with the same amount (in a finally), and record real usage via addUsage().
-   * Devs are unlimited and never hold a reservation.
+   * Everyone is metered — devs included (there is no bypass).
    */
   tryReserve(userId: string, estimatedCredits: number): {
     ok: boolean;
     reason?: WindowType;
     remaining?: number;
   } {
-    if (isUserDev(userId)) return { ok: true };
-
     const amount = Math.max(0, Math.round(estimatedCredits));
     const inFlight = this.pending.get(userId) ?? 0;
 

--- a/tests/database/aiUsage.test.ts
+++ b/tests/database/aiUsage.test.ts
@@ -142,7 +142,7 @@ describe('AiUsageModel', () => {
     expect(Math.abs((resetAt as Date).getTime() - expected)).toBeLessThan(2 * 60 * 1000);
   });
 
-  test('bypasses rate limit checks for developers', async () => {
+  test('rate limits developers too (no dev bypass)', async () => {
     const devId = process.env.ALLOWED_USERS?.split(',')[0];
     if (!devId) {
       // Skip if no ALLOWED_USERS configured
@@ -151,7 +151,15 @@ describe('AiUsageModel', () => {
 
     await aiUsageModel.addUsage(devId, 'test-model', DAILY_LIMIT * 5, 0);
     const status = await aiUsageModel.checkRateLimit(devId);
-    expect(status.limited).toBe(false);
+    expect(status.limited).toBe(true);
+    expect(status.reason).toBe('daily');
+    expect(aiUsageModel.tryReserve(devId, 1).ok).toBe(false);
+  });
+
+  test('free models charge no credits', async () => {
+    await aiUsageModel.addUsage('u9', 'openrouter/free', 500000, 500000);
+    expect(await aiUsageModel.getDailyUsage('u9')).toBe(0);
+    expect(await aiUsageModel.getWeeklyUsage('u9')).toBe(0);
   });
 
   test('meters credit-priced models by multiplier, not raw tokens', async () => {
@@ -195,13 +203,14 @@ describe('AiUsageModel', () => {
     aiUsageModel.release('u1', 8000);
   });
 
-  test('tryReserve is unlimited for developers', async () => {
+  test('tryReserve meters developers like everyone else', async () => {
     const devId = process.env.ALLOWED_USERS?.split(',')[0];
     if (!devId) return; // skip if no ALLOWED_USERS configured
 
     await aiUsageModel.addUsage(devId, 'test-model', DAILY_LIMIT * 5, 0);
     const gate = aiUsageModel.tryReserve(devId, 100000);
-    expect(gate.ok).toBe(true);
+    expect(gate.ok).toBe(false);
+    expect(gate.reason).toBe('daily');
     expect(aiUsageModel.getPendingCredits(devId)).toBe(0);
   });
 

--- a/tests/utils/aiPricing.test.ts
+++ b/tests/utils/aiPricing.test.ts
@@ -22,8 +22,16 @@ describe('creditsForTokens', () => {
     expect(creditsForTokens('x-ai/grok-4.5', 10000, 10000)).toBe(284300);
   });
 
-  test('bills gpt-5.6-luna at 3.5x in / 21.43x out ($1/M in, $6/M out)', () => {
-    expect(creditsForTokens('openai/gpt-5.6-luna', 10000, 10000)).toBe(249300);
+  test('bills gpt-5.6-luna at 0.72x in / 4.3x out ($0.20/M in, $1.2/M out)', () => {
+    expect(creditsForTokens('openai/gpt-5.6-luna', 10000, 10000)).toBe(50200);
+  });
+
+  test('bills qwen3.7-flash at 0.11x in / 0.46x out ($0.03/M in, $0.13/M out)', () => {
+    expect(creditsForTokens('qwen/qwen3.7-flash', 10000, 10000)).toBeCloseTo(5700, 6);
+  });
+
+  test('free models cost nothing', () => {
+    expect(creditsForTokens('openrouter/free', 1_000_000, 1_000_000)).toBe(0);
   });
 });
 

--- a/utils/ai.ts
+++ b/utils/ai.ts
@@ -6,8 +6,9 @@ import { logError, logWarning } from './log';
 import { recordUsage, getCalibrationMultiplier } from './tokenCalibration';
 import { countTokensOpenRouterMessages } from './tokenizer';
 import { listSearchTools, listSearchToolsGemini, callSearchTool } from './mcp';
-import { creditsForTokens, ESTIMATED_COMPLETION_TOKENS } from './aiPricing';
+import { creditsForTokens, isFreeModel, ESTIMATED_COMPLETION_TOKENS } from './aiPricing';
 import { createChatCompletionWithRetry } from './llmRetry';
+import { ALL_MEDIA_KINDS, type MediaKind } from './aiMedia';
 import {
   IMAGE_GEN_TOOL_NAME,
   IMAGE_GEN_DAILY_LIMIT,
@@ -63,8 +64,23 @@ export interface Persona {
   webSearchEnabled?: boolean;
   /** OpenRouter provider-routing object (e.g. { only: ['xiaomi'], allow_fallbacks: false }). */
   providerRouting?: Record<string, any>;
-  /** When true, Discord image/video/audio attachments are sent to the model (openrouter only). */
-  mediaInput?: boolean;
+  /**
+   * Input modalities the model can read from Discord attachments (openrouter
+   * only). `true` means all of image/video/audio (omnimodal, e.g. MiMo);
+   * an explicit list narrows it — vision-only models take `["image"]`.
+   * Omitted/false = no media input.
+   */
+  mediaInput?: boolean | MediaKind[];
+}
+
+/**
+ * Attachment modalities a persona's chat model can actually consume. Empty when
+ * the persona has no media input or isn't on a provider that supports it.
+ */
+export function getPersonaMediaKinds(persona: Persona): MediaKind[] {
+  if (persona.provider !== 'openrouter' || !persona.mediaInput) return [];
+  if (persona.mediaInput === true) return [...ALL_MEDIA_KINDS];
+  return persona.mediaInput.filter((k): k is MediaKind => ALL_MEDIA_KINDS.includes(k as MediaKind));
 }
 
 export interface ToolCallRecord {
@@ -844,11 +860,12 @@ export class AiRateLimitError extends Error {
  * Enforces the per-user credit rate limit with an in-flight reservation: the
  * estimated cost is held against the user's budget for the whole generation, so
  * a spammed burst of concurrent requests can't all pass the check before any of
- * them records usage (issue #213).
+ * them records usage (issue #213). Free models (see aiPricing.isFreeModel) are
+ * exempt: they cost nothing, so they neither reserve nor spend credits.
  */
 async function generateContent(opts: GenerateContentOptions): Promise<GenerateContentResult> {
   const { db, userId } = opts;
-  if (!db || !userId) return generateContentInner(opts);
+  if (!db || !userId || isFreeModel(opts.model)) return generateContentInner(opts);
 
   const reserved = Math.ceil(estimateRequestCredits(opts));
   const gate = db.aiUsage.tryReserve(userId, reserved);

--- a/utils/aiMedia.ts
+++ b/utils/aiMedia.ts
@@ -97,6 +97,19 @@ export interface MediaCollectionResult {
   notices: string[];
 }
 
+/** Human-readable formats per modality, for the "not supported" notice. */
+const KIND_DESCRIPTIONS: Record<MediaKind, string> = {
+  image: 'images (png/jpg/webp/gif/bmp)',
+  video: 'video (mp4/webm/mov)',
+  audio: 'audio (ogg/mp3/wav/flac/m4a)',
+};
+
+/** "a", "a and b", "a, b and c" — keeps the notice readable at any length. */
+function joinWithAnd(items: string[]): string {
+  if (items.length <= 1) return items[0] ?? '';
+  return `${items.slice(0, -1).join(', ')} and ${items[items.length - 1]}`;
+}
+
 function classify(att: Attachment): { kind: MediaKind; mime: string } | null {
   const ct = (att.contentType || '').split(';')[0].trim().toLowerCase();
   if (IMAGE_TYPES[ct]) return { kind: 'image', mime: IMAGE_TYPES[ct] };
@@ -249,9 +262,13 @@ export async function collectMediaFromMessage(
       notices.push(`⚠ Only the first ${maxCounts[kind]} ${kind}${maxCounts[kind] === 1 ? '' : 's'} per request ${maxCounts[kind] === 1 ? 'is' : 'are'} processed — skipped ${skippedOverCount[kind]} extra.`);
     }
   }
-  const acceptsEverything = ALL_MEDIA_KINDS.every((k) => allowed.includes(k));
-  if (acceptsEverything && skippedUnsupported > 0 && parts.length === 0 && candidates.length === 0) {
-    notices.push('⚠ Attachment type not supported — I can read images (png/jpg/webp/gif/bmp), video (mp4/webm/mov) and audio (ogg/mp3/wav/flac/m4a).');
+  // Attachments that failed classify() entirely (a .zip, a .txt) — nothing here
+  // can use them, so say so. Distinct from the silent skip above, which drops
+  // types this caller can't consume but the module understands. Worded from
+  // `allowed` so a restricted caller doesn't advertise formats it will ignore.
+  if (skippedUnsupported > 0 && parts.length === 0 && candidates.length === 0 && allowed.length > 0) {
+    const supported = joinWithAnd(allowed.map((k) => KIND_DESCRIPTIONS[k]));
+    notices.push(`⚠ Attachment type not supported — I can take ${supported}.`);
   }
 
   return {

--- a/utils/aiMedia.ts
+++ b/utils/aiMedia.ts
@@ -81,11 +81,16 @@ const AUDIO_TYPES: Record<string, string> = {
   'audio/x-m4a': 'm4a',
 };
 
-type MediaKind = 'image' | 'video' | 'audio';
+export type MediaKind = 'image' | 'video' | 'audio';
+
+/** Every modality this module can turn into an OpenRouter content part. */
+export const ALL_MEDIA_KINDS: MediaKind[] = ['image', 'video', 'audio'];
 
 export interface MediaCollectionResult {
   /** OpenRouter content parts (image_url / video_url / input_audio). */
   parts: any[];
+  /** Modality of each entry in `parts` (index-aligned with `parts`/`placeholders`). */
+  kinds: MediaKind[];
   /** Text placeholders for the stored prompt, e.g. "[attached image: cat.png]". */
   placeholders: string[];
   /** User-facing notes about skipped/failed attachments. */
@@ -108,17 +113,18 @@ function fmtMB(bytes: number): string {
  * Cheap pre-check: does this message (or the replied-to message) carry at
  * least one attachment collectMediaFromMessage would actually process?
  * Used by callers to avoid burning a concurrency slot on e.g. a PDF-only
- * message. With `imagesOnly`, only image attachments qualify (the imageGen
- * edit-source path — video/audio are irrelevant there).
+ * message. `allowed` narrows it to the modalities the caller can use (e.g.
+ * `['image']` for a vision-less persona's imageGen edit-source path, or a
+ * persona whose model takes images but not video/audio).
  */
 export function hasQualifyingMedia(
   message: Message,
   contextMsg: Message | null = null,
-  imagesOnly = false,
+  allowed: MediaKind[] = ALL_MEDIA_KINDS,
 ): boolean {
   const check = (msg: Message) => [...msg.attachments.values()].some((att) => {
     const cls = classify(att);
-    return cls !== null && (!imagesOnly || cls.kind === 'image');
+    return cls !== null && allowed.includes(cls.kind);
   });
   return check(message) || (contextMsg ? check(contextMsg) : false);
 }
@@ -147,16 +153,17 @@ async function downloadAttachment(att: Attachment, cap: number): Promise<Buffer 
  * Gathers media from `message` first, then from the replied-to message (so a
  * "@mi what's in this?" reply to a voice message / image works). Enforces
  * per-type counts, per-file and total byte budgets; everything over a cap is
- * skipped with a notice rather than failing the request. With `imagesOnly`,
- * video/audio attachments are silently ignored (imageGen edit-source path for
- * personas whose chat model has no media input).
+ * skipped with a notice rather than failing the request. Modalities outside
+ * `allowed` are silently ignored — the caller either can't consume them
+ * (imageGen edit-source path) or its model can't read them.
  */
 export async function collectMediaFromMessage(
   message: Message,
   contextMsg: Message | null = null,
-  imagesOnly = false,
+  allowed: MediaKind[] = ALL_MEDIA_KINDS,
 ): Promise<MediaCollectionResult> {
   const parts: any[] = [];
+  const kinds: MediaKind[] = [];
   const placeholders: string[] = [];
   const notices: string[] = [];
 
@@ -179,8 +186,8 @@ export async function collectMediaFromMessage(
         skippedUnsupported += 1;
         continue;
       }
-      // imagesOnly: non-image media simply isn't relevant, not "unsupported".
-      if (imagesOnly && cls.kind !== 'image') continue;
+      // Out-of-scope modalities simply aren't relevant here, not "unsupported".
+      if (!allowed.includes(cls.kind)) continue;
       candidates.push({
         att, kind: cls.kind, mime: cls.mime, fromReply,
       });
@@ -190,7 +197,9 @@ export async function collectMediaFromMessage(
   if (contextMsg) gather(contextMsg, true);
 
   if (candidates.length === 0 && skippedUnsupported === 0) {
-    return { parts, placeholders, notices };
+    return {
+      parts, kinds, placeholders, notices,
+    };
   }
 
   for (const { att, kind, mime } of candidates) {
@@ -231,6 +240,7 @@ export async function collectMediaFromMessage(
     } else {
       parts.push({ type: 'input_audio', input_audio: { data: b64, format: AUDIO_TYPES[mime] || 'mp3' } });
     }
+    kinds.push(kind);
     placeholders.push(`[attached ${kind}: ${att.name || 'file'}]`);
   }
 
@@ -239,9 +249,12 @@ export async function collectMediaFromMessage(
       notices.push(`⚠ Only the first ${maxCounts[kind]} ${kind}${maxCounts[kind] === 1 ? '' : 's'} per request ${maxCounts[kind] === 1 ? 'is' : 'are'} processed — skipped ${skippedOverCount[kind]} extra.`);
     }
   }
-  if (!imagesOnly && skippedUnsupported > 0 && parts.length === 0 && candidates.length === 0) {
+  const acceptsEverything = ALL_MEDIA_KINDS.every((k) => allowed.includes(k));
+  if (acceptsEverything && skippedUnsupported > 0 && parts.length === 0 && candidates.length === 0) {
     notices.push('⚠ Attachment type not supported — I can read images (png/jpg/webp/gif/bmp), video (mp4/webm/mov) and audio (ogg/mp3/wav/flac/m4a).');
   }
 
-  return { parts, placeholders, notices };
+  return {
+    parts, kinds, placeholders, notices,
+  };
 }

--- a/utils/aiPricing.ts
+++ b/utils/aiPricing.ts
@@ -29,9 +29,25 @@ const MODEL_MULTIPLIERS: Record<string, ModelMultipliers> = {
   'xiaomi/mimo-v2.5': { input: 0.5, output: 1 },
   // $2/M in, $6/M out
   'x-ai/grok-4.5': { input: 7, output: 21.43 },
-  // $0.20/M in, $1.2/M out
+  // $0.20/M in, $1.2/M out. OpenRouter currently lists a further 50% off; that's
+  // treated as a temporary promo and deliberately NOT priced in here.
   'openai/gpt-5.6-luna': { input: 0.72, output: 4.3 },
+  // $0.03/M in, $0.13/M out
+  'qwen/qwen3.7-flash': { input: 0.11, output: 0.46 },
+  // Free tier — costs nothing, so it charges nothing (see FREE_MODELS).
+  'openrouter/free': { input: 0, output: 0 },
 };
+
+/**
+ * Models that are free to run. They bill 0 credits AND skip the rate-limit
+ * reservation entirely (see generateContent), so a user who has exhausted
+ * their paid budget can still talk to them.
+ */
+const FREE_MODELS = new Set<string>(['openrouter/free']);
+
+export function isFreeModel(model: string): boolean {
+  return FREE_MODELS.has(model);
+}
 
 const DEFAULT_MULTIPLIERS: ModelMultipliers = { input: 1, output: 1 };
 

--- a/utils/discordRateLimit.ts
+++ b/utils/discordRateLimit.ts
@@ -26,6 +26,20 @@ export async function getResetLine(
   return resetAt ? `\n**Resets:** ${formatResetTimestamp(resetAt)}` : '';
 }
 
+/**
+ * "Resets:" value for one window, shown whether or not the user is limited so
+ * they can watch the countdown. A fixed window only exists once it has been
+ * opened by a first charged request, hence the "Not yet started" wording.
+ */
+export async function getWindowResetLabel(
+  db: Database,
+  userId: string,
+  window: 'daily' | 'weekly',
+): Promise<string> {
+  const resetAt = await db.aiUsage.getResetAt(userId, window);
+  return resetAt ? formatResetTimestamp(resetAt) : 'Not yet started (no usage in this window)';
+}
+
 export interface RateLimitOptions {
   reason?: 'daily' | 'weekly';
   reservedCredits?: number;


### PR DESCRIPTION
## Summary

Four AI-side changes, plus a stale pricing test fixed along the way.

**1. No more dev rate-limit bypass.** `AiUsageModel.checkRateLimit` and `tryReserve` dropped their `isUserDev` short-circuits — devs are metered and blocked like everyone else, and their usage now lands in the windows.

**2. `openrouter/free` as `@fr`.** New `FreeRouter` persona. Free models bill 0 credits *and* skip the in-flight reservation entirely (`aiPricing.isFreeModel` → `generateContent`), so `@fr` still answers a user who has burned their whole budget. Usage is still written to the `AiUsage` audit log (raw tokens, $0 cost) for monitoring. Web search is off for it: `openrouter/free` routes to whatever free model is available and tool support there is inconsistent.

**3. `/ai usage` shows both reset timers.** A `Resets:` line now sits under each of the daily and weekly bars whether or not the user is limited, via the new `getWindowResetLabel`. A window that has never been opened reads `Not yet started (no usage in this window)`. `/profile` keeps its existing limited-only line.

**4. Per-model input modalities.** `mediaInput` now takes either `true` (all three modalities — MiMo) or an explicit list. `collectMediaFromMessage` / `hasQualifyingMedia` swapped their `imagesOnly` boolean for an `allowed: MediaKind[]` filter, and the result carries a `kinds[]` array index-aligned with `parts[]` so the mention handler can split attachments into "the chat model can read this" vs "only `generate_image` can use this" per modality.

| Persona | Model | Input modalities |
|---|---|---|
| `@grok` | x-ai/grok-4.5 | image |
| `@gpt` | openai/gpt-5.6-luna | image |
| `@qw` | qwen/qwen3.7-flash *(new)* | image, video |
| `@mi` | xiaomi/mimo-v2.5 | image, video, audio |

Modalities and pricing were read from OpenRouter's models API, not guessed. Attach a voice clip to `@qw` and it is silently ignored while images/video go through; `@mi` is unchanged.

## Pricing note

`openai/gpt-5.6-luna` is priced at its **list** rate of $0.20/M in, $1.2/M out (`0.72x / 4.3x`). The API currently reports $0.10/$0.60 — a 50% promo — which is deliberately **not** priced in, per @xei; there's a comment in `aiPricing.ts` saying so. The existing test asserted the older $1/$6 figures and had been failing on `master`; it now matches the code. New `qwen/qwen3.7-flash` is `0.11x / 0.46x` ($0.03/$0.13 per M, no promo on its page).

## Testing

- `bun test` — 359 pass, 0 fail (was 356/1 on `master` due to the stale pricing test)
- `bun run typecheck` — clean
- `eslint` on all touched files — clean

## Note

Persona triggers match by plain substring, so `@qwerty` would fire `@qw` and `@friend` would fire `@fr` — same as the existing `@mi` / `@ds` triggers. Left as-is; happy to add word-boundary matching in a follow-up if it turns out to bite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Qwen and FreeRouter AI options with updated media capabilities and triggers.
  * Added support for image attachments and clearer handling of audio and video compatibility.
  * Free AI models are now available without consuming usage credits.
* **Usage & Limits**
  * Daily and weekly reset times are displayed separately.
  * Usage limits and in-progress reservations now apply consistently to all accounts.
* **Pricing**
  * Updated GPT-5.6 Luna pricing and added Qwen 3.7 Flash pricing.
* **Bug Fixes**
  * Improved media filtering so each AI option receives only supported content types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->