### PR TITLE
amnesia

### DIFF
--- a/classes/handlers/keywordsBehaviorHandler.ts
+++ b/classes/handlers/keywordsBehaviorHandler.ts
@@ -21,6 +21,26 @@ import {
 
 const WEBHOOK_NAME = process.env.WEBHOOK_NAME || 'grok-webhook';
 
+/**
+ * True when `query` is exactly `<persona trigger(s)> <command>` (case-insensitive),
+ * e.g. "@grok kys" / "jarvis amnesia" — not "@grok what is amnesia".
+ */
+function isExactSessionCommand(
+  query: string,
+  persona: { triggers?: string[] },
+  command: string,
+): boolean {
+  let rest = query;
+  const triggers = [...(persona.triggers ?? [])]
+    .filter((t): t is string => typeof t === 'string' && t.length > 0)
+    .sort((a, b) => b.length - a.length);
+  for (const trigger of triggers) {
+    const escaped = trigger.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    rest = rest.replace(new RegExp(escaped, 'gi'), ' ');
+  }
+  return rest.replace(/\s+/g, ' ').trim().toLowerCase() === command.toLowerCase();
+}
+
 const scriptHandlers = {
   girlCockx: async (message: Message): Promise<void> => {
     const xLinkRegex = /https:\/\/(?:x\.com|twitter\.com)\/([^/]+)\/status\/(\d+)(?:\?[^\s]*)?/g;
@@ -87,7 +107,6 @@ const scriptHandlers = {
       ? message.author.username.toLowerCase()
       : 'user';
     const query = message.content || '';
-    const shouldStartNewSession = /\bkys\b/i.test(query);
 
     const contextMsg = message.reference
       ? await message.channel.messages
@@ -97,6 +116,8 @@ const scriptHandlers = {
 
     const persona = await resolvePersona(query);
     const displayName = persona.name;
+    const shouldStartNewSession = isExactSessionCommand(query, persona, 'kys');
+    const shouldAmnesia = isExactSessionCommand(query, persona, 'amnesia');
 
     const NO_MEMORY_PERSONAS = ['Summarizer'];
     const hasMemory = !NO_MEMORY_PERSONAS.includes(displayName);
@@ -120,6 +141,45 @@ const scriptHandlers = {
       } catch (sessionErr) {
         logError('AiChat: Failed to start new session from mention handler:', sessionErr);
         await message.reply('Failed to start a new conversation. Please try again.');
+      }
+      return;
+    }
+
+    if (shouldAmnesia && hasMemory) {
+      try {
+        const result = await (message.client as any).db.aiChat.undoLastTurn(
+          message.author.id,
+          displayName,
+        );
+
+        if (!result.ok) {
+          const emptyEmbed = new EmbedBuilder()
+            .setColor('#FEE75C')
+            .setTitle('Nothing to Forget')
+            .setDescription(
+              result.reason === 'no_session'
+                ? `No active **${displayName}** session to wipe.`
+                : `**${displayName}** session has no messages to forget.`,
+            );
+          await message.reply({ embeds: [emptyEmbed] });
+          return;
+        }
+
+        const preview = result.userMessage.replace(/\s+/g, ' ').trim();
+        const previewSnippet = preview.length > 120 ? `${preview.slice(0, 117)}…` : preview;
+        const amnesiaEmbed = new EmbedBuilder()
+          .setColor('#57F287')
+          .setTitle('Amnesia')
+          .setDescription(
+            `Forgot the last turn from **${displayName}** session **#${result.sessionId}**`
+            + ` (${result.deletedCount} row${result.deletedCount === 1 ? '' : 's'}).`
+            + (previewSnippet ? `\n\n> ${previewSnippet}` : ''),
+          )
+          .setFooter({ text: 'Use "kys" for a fresh session · "amnesia" to forget the last turn' });
+        await message.reply({ embeds: [amnesiaEmbed] });
+      } catch (amnesiaErr) {
+        logError('AiChat: Failed to apply amnesia from mention handler:', amnesiaErr);
+        await message.reply('Failed to forget the last turn. Please try again.');
       }
       return;
     }
@@ -323,7 +383,7 @@ const scriptHandlers = {
           .setColor('#FEE75C')
           .setTitle('⚠ Context limit reached')
           .setDescription(`Trimmed **${trimWarning.trimmedCount}** old message${trimWarning.trimmedCount === 1 ? '' : 's'} to fit this model's context window. The oldest parts of the conversation are no longer visible to me.`)
-          .setFooter({ text: 'Use "kys" to start a fresh session' });
+          .setFooter({ text: 'Use "kys" for a fresh session · "amnesia" to forget the last turn' });
         try {
           await message.reply({ embeds: [trimEmbed], allowedMentions: { repliedUser: false } });
         } catch (warnErr) {
@@ -425,7 +485,7 @@ const scriptHandlers = {
         const warningEmbed = new EmbedBuilder()
           .setColor(warningColor as `#${string}`)
           .setDescription(pctWarning.message)
-          .setFooter({ text: 'Use "kys" to start a fresh session' });
+          .setFooter({ text: 'Use "kys" for a fresh session · "amnesia" to forget the last turn' });
         try {
           await message.reply({ embeds: [warningEmbed], allowedMentions: { repliedUser: false } });
         } catch (warnErr) {

--- a/classes/handlers/keywordsBehaviorHandler.ts
+++ b/classes/handlers/keywordsBehaviorHandler.ts
@@ -21,24 +21,31 @@ import {
 
 const WEBHOOK_NAME = process.env.WEBHOOK_NAME || 'grok-webhook';
 
+/** Collapse whitespace and lowercase for exact trigger+command matching. */
+function normalizeSessionCommandText(text: string): string {
+  return text.replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
 /**
- * True when `query` is exactly `<persona trigger(s)> <command>` (case-insensitive),
- * e.g. "@grok kys" / "jarvis amnesia" — not "@grok what is amnesia".
+ * True when `query` is exactly one `<trigger> <command>` phrase (case-insensitive),
+ * e.g. "@grok kys" / "jarvis amnesia" — not "@grok what is amnesia", bare
+ * "amnesia", or reordered "amnesia @grok".
  */
 function isExactSessionCommand(
   query: string,
   persona: { triggers?: string[] },
   command: string,
 ): boolean {
-  let rest = query;
-  const triggers = [...(persona.triggers ?? [])]
-    .filter((t): t is string => typeof t === 'string' && t.length > 0)
-    .sort((a, b) => b.length - a.length);
-  for (const trigger of triggers) {
-    const escaped = trigger.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    rest = rest.replace(new RegExp(escaped, 'gi'), ' ');
-  }
-  return rest.replace(/\s+/g, ' ').trim().toLowerCase() === command.toLowerCase();
+  const normalizedQuery = normalizeSessionCommandText(query);
+  if (!normalizedQuery) return false;
+  const normalizedCommand = normalizeSessionCommandText(command);
+  if (!normalizedCommand) return false;
+
+  return (persona.triggers ?? []).some((trigger) => {
+    if (typeof trigger !== 'string' || !trigger.trim()) return false;
+    const phrase = normalizeSessionCommandText(`${trigger} ${normalizedCommand}`);
+    return phrase.length > 0 && normalizedQuery === phrase;
+  });
 }
 
 const scriptHandlers = {
@@ -172,8 +179,8 @@ const scriptHandlers = {
           .setTitle('Amnesia')
           .setDescription(
             `Forgot the last turn from **${displayName}** session **#${result.sessionId}**`
-            + ` (${result.deletedCount} row${result.deletedCount === 1 ? '' : 's'}).`
-            + (previewSnippet ? `\n\n> ${previewSnippet}` : ''),
+            + ` (${result.deletedCount} row${result.deletedCount === 1 ? '' : 's'}).${
+              previewSnippet ? `\n\n> ${previewSnippet}` : ''}`,
           )
           .setFooter({ text: 'Use "kys" for a fresh session · "amnesia" to forget the last turn' });
         await message.reply({ embeds: [amnesiaEmbed] });

--- a/database/models/AiChatModel.ts
+++ b/database/models/AiChatModel.ts
@@ -190,6 +190,53 @@ class AiChatModel {
   }
 
   /**
+   * Deletes the most recent user→(tools)→assistant/model turn from the user's
+   * active session for this persona. Tool audit rows between the pair are
+   * removed with it.
+   */
+  async undoLastTurn(
+    userId: string,
+    personaName: string,
+  ): Promise<
+    | { ok: true; sessionId: number; deletedCount: number; userMessage: string }
+    | { ok: false; reason: 'no_session' | 'empty' }
+  > {
+    const session = await this.db.executeSelectQuery(
+      aiChatQueries.GET_ACTIVE_SESSION,
+      [userId, personaName],
+    );
+    if (!session || session.userId !== userId) {
+      return { ok: false, reason: 'no_session' };
+    }
+
+    const lastUser = await this.db.executeSelectQuery(
+      aiChatQueries.GET_LAST_USER_HISTORY,
+      [session.sessionId],
+    );
+    if (!lastUser) {
+      return { ok: false, reason: 'empty' };
+    }
+
+    const deletedCount = await this.db.executeTransaction((rawDb: any) => {
+      const result = rawDb.query(aiChatQueries.DELETE_HISTORY_FROM_ID)
+        .run(session.sessionId, lastUser.id);
+      return Number(result.changes ?? 0);
+    });
+
+    if (deletedCount <= 0) {
+      return { ok: false, reason: 'empty' };
+    }
+
+    log(`AiChat: Undid last turn (${deletedCount} rows) in session ${session.sessionId} for user ${userId}`);
+    return {
+      ok: true,
+      sessionId: session.sessionId,
+      deletedCount,
+      userMessage: typeof lastUser.message === 'string' ? lastUser.message : '',
+    };
+  }
+
+  /**
    * Fetches the last N messages for a session, returned in chronological order (oldest first).
    * Capped at 30 by default per cost constraints.
    */

--- a/database/models/AiChatModel.ts
+++ b/database/models/AiChatModel.ts
@@ -209,30 +209,37 @@ class AiChatModel {
       return { ok: false, reason: 'no_session' };
     }
 
-    const lastUser = await this.db.executeSelectQuery(
-      aiChatQueries.GET_LAST_USER_HISTORY,
-      [session.sessionId],
-    );
-    if (!lastUser) {
-      return { ok: false, reason: 'empty' };
-    }
+    const outcome = await this.db.executeTransaction((rawDb: any) => {
+      const lastUser = rawDb.query(aiChatQueries.GET_LAST_USER_HISTORY)
+        .get(session.sessionId) as { id: number; message: string } | null;
+      if (!lastUser) {
+        return { ok: false as const, reason: 'empty' as const };
+      }
 
-    const deletedCount = await this.db.executeTransaction((rawDb: any) => {
       const result = rawDb.query(aiChatQueries.DELETE_HISTORY_FROM_ID)
         .run(session.sessionId, lastUser.id);
-      return Number(result.changes ?? 0);
+      const deletedCount = Number(result.changes ?? 0);
+      if (deletedCount <= 0) {
+        return { ok: false as const, reason: 'empty' as const };
+      }
+
+      return {
+        ok: true as const,
+        deletedCount,
+        userMessage: typeof lastUser.message === 'string' ? lastUser.message : '',
+      };
     });
 
-    if (deletedCount <= 0) {
+    if (!outcome.ok) {
       return { ok: false, reason: 'empty' };
     }
 
-    log(`AiChat: Undid last turn (${deletedCount} rows) in session ${session.sessionId} for user ${userId}`);
+    log(`AiChat: Undid last turn (${outcome.deletedCount} rows) in session ${session.sessionId} for user ${userId}`);
     return {
       ok: true,
       sessionId: session.sessionId,
-      deletedCount,
-      userMessage: typeof lastUser.message === 'string' ? lastUser.message : '',
+      deletedCount: outcome.deletedCount,
+      userMessage: outcome.userMessage,
     };
   }
 

--- a/database/queries/aiChatQueries.ts
+++ b/database/queries/aiChatQueries.ts
@@ -45,6 +45,14 @@ const aiChatQueries = {
   // History management
   ADD_HISTORY: 'INSERT INTO AiChatHistory (session_id, role, message) VALUES (?, ?, ?)',
   GET_HISTORY: 'SELECT * FROM AiChatHistory WHERE session_id = ? ORDER BY id DESC LIMIT ?',
+  GET_LAST_USER_HISTORY: `
+    SELECT id, message FROM AiChatHistory
+    WHERE session_id = ? AND role = 'user'
+    ORDER BY id DESC LIMIT 1
+  `,
+  // Auto-increment ids are chronological — wiping from the last user row onward
+  // removes that turn's tool audit rows and assistant/model reply with it.
+  DELETE_HISTORY_FROM_ID: 'DELETE FROM AiChatHistory WHERE session_id = ? AND id >= ?',
   DELETE_HISTORY_BY_SESSION: 'DELETE FROM AiChatHistory WHERE session_id = ?',
   DELETE_SESSION: 'DELETE FROM AiChatSession WHERE session_id = ?',
 };

--- a/tests/database/aiChat.test.ts
+++ b/tests/database/aiChat.test.ts
@@ -222,4 +222,62 @@ describe('AiChatModel', () => {
       expect(deactivated.active).toBe(0);
     });
   });
+
+  // ─── undoLastTurn ─────────────────────────────────────────────────────────
+
+  describe('undoLastTurn', () => {
+    it('should delete the last user/tool/assistant turn and keep earlier history', async () => {
+      const userId = '111111111111111111';
+      const session = (await aiChat.getOrCreateSession(userId, 'Grok'))!;
+
+      await aiChat.addHistory(session.sessionId, 'user', 'first');
+      await aiChat.addHistory(session.sessionId, 'assistant', 'first reply');
+      await aiChat.addHistory(session.sessionId, 'user', 'second');
+      await aiChat.addHistory(session.sessionId, 'tool', '{"name":"web_search"}');
+      await aiChat.addHistory(session.sessionId, 'assistant', 'second reply');
+
+      const result = await aiChat.undoLastTurn(userId, 'Grok');
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.sessionId).toBe(session.sessionId);
+      expect(result.deletedCount).toBe(3);
+      expect(result.userMessage).toBe('second');
+
+      const history = await aiChat.getHistory(session.sessionId);
+      expect(history).toHaveLength(2);
+      expect(history[0].message).toBe('first');
+      expect(history[1].message).toBe('first reply');
+    });
+
+    it('should return empty when the active session has no messages', async () => {
+      const userId = '111111111111111111';
+      await aiChat.getOrCreateSession(userId, 'Grok');
+
+      const result = await aiChat.undoLastTurn(userId, 'Grok');
+      expect(result).toEqual({ ok: false, reason: 'empty' });
+    });
+
+    it('should return no_session when the user has no active session for that persona', async () => {
+      const result = await aiChat.undoLastTurn('111111111111111111', 'Grok');
+      expect(result).toEqual({ ok: false, reason: 'no_session' });
+    });
+
+    it('should only undo the active persona session', async () => {
+      const userId = '111111111111111111';
+      const grok = (await aiChat.getOrCreateSession(userId, 'Grok'))!;
+      const gpt = (await aiChat.getOrCreateSession(userId, 'GPT'))!;
+
+      await aiChat.addHistory(grok.sessionId, 'user', 'grok q');
+      await aiChat.addHistory(grok.sessionId, 'assistant', 'grok a');
+      await aiChat.addHistory(gpt.sessionId, 'user', 'gpt q');
+      await aiChat.addHistory(gpt.sessionId, 'assistant', 'gpt a');
+
+      const result = await aiChat.undoLastTurn(userId, 'Grok');
+      expect(result.ok).toBe(true);
+
+      expect(await aiChat.getHistory(grok.sessionId)).toHaveLength(0);
+      expect(await aiChat.getHistory(gpt.sessionId)).toHaveLength(2);
+    });
+  });
 });


### PR DESCRIPTION
- Use `amnesia` to forget the last turn, similar to `kys`. So if the AI rejected something bricking the entire conversation, you can undo that turn instead having to start fresh
- It now only triggers on exact matches, `@grok what is amnesia` won't trigger an undo but `@grok amnesia` will

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `amnesia` command to undo the most recent conversation turn.
  * Added clear responses for successful undo actions, empty sessions, missing sessions, and errors.
  * Added exact matching for the `kys` command, preventing accidental activation from partial matches.
  * Updated context warnings to document both available commands.

* **Bug Fixes**
  * Improved command detection to respond only when trigger phrases are used in the expected format.
  * Ensured undo actions remain isolated to the active persona session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->