### PR TITLE
feat[ai]: optional content-safety moderation for AI chats

### DIFF
--- a/.claude/rules/ai-limits.md
+++ b/.claude/rules/ai-limits.md
@@ -115,6 +115,12 @@ The pause is a read-check-write spanning a multi-second generation, so it is enf
    and the write are one statement. This holds even where no lock is taken, and `addHistory` returns
    whether the row landed.
 
+**Never test `moderationFlagged` on the session row resolved *before* the lock** — a turn queued
+behind one that paused the session would not see the flag on that stale snapshot. Every surface has
+an `isPausedNow()` that re-reads inside the lock; use it both before generating (saves a paid call)
+and again before delivery (the conditional INSERT stops persistence, but nothing else stops a
+webhook send).
+
 `flagSessionModeration` returns whether the write landed. `Database.executeQuery` swallows errors
 and reports `changes: 0` rather than throwing, so callers **must** check: a caller that assumed
 success would tell the user the chat was paused while leaving the row unflagged, and the next

--- a/.claude/rules/ai-limits.md
+++ b/.claude/rules/ai-limits.md
@@ -53,7 +53,26 @@ not in `FREE_MODELS` because it never reaches the code that consults it. **Don't
 `generateContent`** — that would start billing users for being moderated.
 
 **The screen fails open** — an outage, timeout, or unparseable label logs and allows the turn. A
-free classifier must never be able to take down every conversation on the bot.
+free classifier must never be able to take down every conversation on the bot. Budgets are tight for
+the same reason (15s per attempt, 20s overall): the screen runs twice per turn and sits on the
+critical path, so a degraded classifier must fail open fast rather than stall the reply.
+
+### Known limits
+
+- **Generated media is not screened.** The classifier is invoked text-only, so images from
+  `generate_image` and audio from `generate_music` are never inspected. The mention handler screens
+  the *prompts* the model passed to those tools instead (a tool-driven turn can return files with
+  empty `text`, which would otherwise sail through the output screen). The bytes themselves are not
+  covered.
+- **A post-screen trip still costs credits** on every surface — generation has already happened by
+  then. The pre-screen exists to make that the uncommon case.
+- **Only the user's own text is screened for the pause decision** on the mention handler
+  (`ownTurnText`), not the quoted reply context or attached PDF bodies. Screening those would let
+  someone permanently pause a third party's session just by being quoted at. Content induced *by*
+  quoted context is still caught by the output screen.
+- **`/summary` is output-screened only.** Its input is a transcript of other people's channel
+  messages, so pre-screening would block summarising any channel where someone said something spicy
+  — a false-positive surface with no session to protect.
 
 ### Per-surface behaviour
 
@@ -78,6 +97,16 @@ records usage: the tokens were spent before the screen ran.
 (`undoLastTurn` → `reason: 'paused'`) — the tripping turn was never persisted, so it would only eat
 an earlier legitimate turn while implying the pause had lifted. `/ai chatswitch` to a different,
 unflagged session is allowed; that is equivalent to starting a new chat.
+
+`ai_moderation` is a **master switch**: turning it off must restore normal behaviour everywhere at
+once, so every pause check is gated on it — including `undoLastTurn`'s, via its
+`honorModerationPause` argument. Without that, a flagged session would chat normally while still
+refusing amnesia.
+
+`flagSessionModeration` returns whether the write landed. `Database.executeQuery` swallows errors
+and reports `changes: 0` rather than throwing, so callers **must** check: a caller that assumed
+success would tell the user the chat was paused while leaving the row unflagged, and the next
+message would generate normally. Callers refuse the current turn either way and log loudly.
 
 ## Retry
 

--- a/.claude/rules/ai-limits.md
+++ b/.claude/rules/ai-limits.md
@@ -2,12 +2,13 @@
 paths:
   - "utils/ai.ts"
   - "utils/aiPricing.ts"
+  - "utils/aiModeration.ts"
   - "utils/llmRetry.ts"
   - "commands/ai*.ts"
   - "database/models/AiUsageModel.ts"
 ---
 
-# AI usage limits & retry
+# AI usage limits, moderation & retry
 
 `utils/ai.ts`, `utils/aiPricing.ts`, `AiUsageModel`.
 
@@ -31,6 +32,52 @@ stores **credits** (name kept, no rebuild).
 Enforcement is `db.aiUsage.tryReserve(userId, estCredits)` → `release()` in `finally` — an
 in-memory in-flight reservation held for the whole generation so concurrent spam can't all pass the
 check before usage lands. **No dev bypass — everyone is metered.**
+
+## Content-safety moderation
+
+Off by default; `GlobalConfig.ai_moderation = 1` turns it on globally (`utils/aiModeration.ts`).
+When on, **every** session-backed AI turn — every persona, every user, no exemptions — is screened
+twice by the `Moderation` persona (`data/aiPersonas.json`, an NVIDIA Nemotron content-safety
+classifier that takes **no system prompt**): once on the user message before generating, once on the
+user+assistant pair before delivery. Its reply is plain-text labels (`User Safety:` /
+`Response Safety:` / `Safety Categories:`), parsed by `parseModerationOutput`.
+
+A trip sets `AiChatSession.moderation_flagged` (`flagSessionModeration`) — the session is paused
+permanently, `active` deliberately untouched so `getOrCreateSession` keeps returning and refusing it.
+The turn is neither delivered nor persisted; the user gets `MODERATION_PAUSED_MESSAGE` **in the voice
+of the persona they were talking to** and must start a new chat.
+
+**The screen never costs credits.** It calls `createChatCompletionWithRetry` directly, bypassing
+`generateContent` — so no `tryReserve`, no `addUsage`, no entry in the credit ledger at all. It is
+not in `FREE_MODELS` because it never reaches the code that consults it. **Don't route it through
+`generateContent`** — that would start billing users for being moderated.
+
+**The screen fails open** — an outage, timeout, or unparseable label logs and allows the turn. A
+free classifier must never be able to take down every conversation on the bot.
+
+### Per-surface behaviour
+
+| Surface | Session? | On a trip |
+| --- | --- | --- |
+| mention handler (`keywordsBehaviorHandler.ts`) | yes | **pause** |
+| `/ask` (`askSilverwolfAI.ts`) | yes — *shares* the `Silverwolf` session with `@sw` | **pause** |
+| web chat (`site_src/routes/ai-slop-api.ts`) | yes | **pause** |
+| `/summary count`/`time` | no | **reply-and-drop** (`MODERATION_BLOCKED_MESSAGE`) |
+| roleplay (`utils/rpChat.ts` → `rpRuntime.ts`) | spawns, not sessions | **reply-and-drop** (`reason: 'moderation'`) |
+
+`/ask` must stay on pause semantics: it resolves the same `AiChatSession` row as the `@sw` mention
+persona, so reply-and-drop there would be a way to keep talking to a chat mentions had paused.
+
+Roleplay drops the reply but leaves the spawn alive — the offending user turn stays in `RpHistory`,
+so a re-trigger is screened and refused again rather than slipping through. A dropped RP reply still
+records usage: the tokens were spent before the screen ran.
+
+### Escaping a pause
+
+`kys` (new session) is the **only** exit, by design. `amnesia` is refused on a paused session
+(`undoLastTurn` → `reason: 'paused'`) — the tripping turn was never persisted, so it would only eat
+an earlier legitimate turn while implying the pause had lifted. `/ai chatswitch` to a different,
+unflagged session is allowed; that is equivalent to starting a new chat.
 
 ## Retry
 

--- a/.claude/rules/ai-limits.md
+++ b/.claude/rules/ai-limits.md
@@ -103,6 +103,18 @@ once, so every pause check is gated on it — including `undoLastTurn`'s, via it
 `honorModerationPause` argument. Without that, a flagged session would chat normally while still
 refusing amnesia.
 
+### Concurrency
+
+The pause is a read-check-write spanning a multi-second generation, so it is enforced twice over:
+
+1. **`withAiSessionLock(sessionId, …)`** (`utils/aiSessionLock.ts`) wraps the whole
+   check → generate → persist → deliver sequence on all three session surfaces. Two turns in one
+   conversation queue instead of racing. It uses a **separate registry** from `userLocks` — sharing
+   it would stall a user's `/claim` behind their own multi-minute AI reply.
+2. **`ADD_HISTORY` is conditional** on `moderation_flagged = 0` in the INSERT itself, so the check
+   and the write are one statement. This holds even where no lock is taken, and `addHistory` returns
+   whether the row landed.
+
 `flagSessionModeration` returns whether the write landed. `Database.executeQuery` swallows errors
 and reports `changes: 0` rather than throwing, so callers **must** check: a caller that assumed
 success would tell the user the chat was paused while leaving the row unflagged, and the next

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ bot administration is Discord-side only.
 **The website is public — security and performance are first-class. Validate every input, never
 trust client data, keep the CSP tight.**
 
-**Last updated: 2026-08-04**
+**Last updated: 2026-08-11**
 
 > **Maintenance rule.** Edit agent docs only on *substantive architectural* change — new
 > architecture, new auth, new data flows/services, schema or security-model changes, or when
@@ -27,7 +27,7 @@ duplicate their content here.
 | `site_src/**` | `.claude/rules/website.md` — server, middleware order, auth/CSRF, assets, perf |
 | `database/**` | `.claude/rules/database.md` — DAO layering, transactions, settings tables |
 | `utils/rp*`, `commands/ai_rp_*` | `.claude/rules/roleplay.md` — characters, lorebooks, personas |
-| `utils/ai*`, `utils/llmRetry` | `.claude/rules/ai-limits.md` — credit metering, retry policy |
+| `utils/ai*`, `utils/llmRetry` | `.claude/rules/ai-limits.md` — credit metering, moderation, retry policy |
 | `Dockerfile`, `.github/**` | `.claude/rules/deploy.md` — CI/CD, image, volumes |
 
 ## Commands

--- a/classes/handlers/keywordsBehaviorHandler.ts
+++ b/classes/handlers/keywordsBehaviorHandler.ts
@@ -18,8 +18,46 @@ import {
   collectMediaFromMessage, hasQualifyingMedia, tryAcquireMediaSlot, releaseMediaSlot,
   type MediaKind,
 } from '../../utils/aiMedia';
+import {
+  isModerationEnabled, moderateExchange, MODERATION_PAUSED_MESSAGE, type ModerationVerdict,
+} from '../../utils/aiModeration';
 
 const WEBHOOK_NAME = process.env.WEBHOOK_NAME || 'grok-webhook';
+
+/** Fetches (or creates) the shared AI webhook for a channel. */
+async function getAiWebhook(message: Message, avatarURL: string): Promise<any> {
+  const webhooks = await (message.channel as TextChannel).fetchWebhooks();
+  const existing = webhooks.find((wh: any) => wh.name === WEBHOOK_NAME && wh.token);
+  if (existing) return existing;
+  return (message.channel as TextChannel).createWebhook({
+    name: WEBHOOK_NAME,
+    avatar: avatarURL,
+  });
+}
+
+/**
+ * Delivers the content-safety pause notice in the voice of the persona the user
+ * was talking to. Falls back to a plain reply if the webhook is unavailable.
+ */
+async function sendModerationPause(
+  message: Message,
+  displayName: string,
+  avatarURL: string,
+): Promise<void> {
+  try {
+    const webhook = await getAiWebhook(message, avatarURL);
+    await webhook.send({
+      content: MODERATION_PAUSED_MESSAGE,
+      username: displayName,
+      avatarURL,
+      allowedMentions: { parse: [] },
+    });
+  } catch (err) {
+    logError('AiChat: failed to deliver moderation pause via webhook:', err);
+    await message.reply({ content: MODERATION_PAUSED_MESSAGE, allowedMentions: { repliedUser: false } })
+      .catch((e) => { logError('AiChat: moderation pause reply failed:', e); });
+  }
+}
 
 /** Collapse whitespace and lowercase for exact trigger+command matching. */
 function normalizeSessionCommandText(text: string): string {
@@ -158,6 +196,11 @@ const scriptHandlers = {
           message.author.id,
           displayName,
         );
+
+        if (!result.ok && result.reason === 'paused') {
+          await sendModerationPause(message, displayName, persona.avatarURL || message.client.user!.displayAvatarURL());
+          return;
+        }
 
         if (!result.ok) {
           const emptyEmbed = new EmbedBuilder()
@@ -323,6 +366,50 @@ const scriptHandlers = {
       }
     }
 
+    // Content-safety gate (global `ai_moderation` switch). Applies to every
+    // persona and every user alike. Releases the media slot on every early exit
+    // — the normal path frees it in the generation `finally` below.
+    const moderationOn = await isModerationEnabled((message.client as any).db);
+    const pauseChat = async (verdict?: ModerationVerdict) => {
+      if (mediaSlotHeld) {
+        releaseMediaSlot();
+        mediaSlotHeld = false;
+      }
+      mediaParts = [];
+      imageEditParts = [];
+      if (aiSession) {
+        try {
+          await (message.client as any).db.aiChat.flagSessionModeration(
+            aiSession.sessionId,
+            verdict?.categories,
+          );
+        } catch (flagErr) {
+          logError('AiChat: Failed to flag session for moderation:', flagErr);
+        }
+      }
+      await sendModerationPause(message, displayName, avatarURL);
+    };
+
+    if (moderationOn) {
+      // Already paused: refuse before spending anything at all.
+      if (aiSession?.moderationFlagged) {
+        if (mediaSlotHeld) {
+          releaseMediaSlot();
+          mediaSlotHeld = false;
+        }
+        await sendModerationPause(message, displayName, avatarURL);
+        return;
+      }
+
+      // Pre-screen the incoming message so an unsafe prompt never reaches (or
+      // bills) the chat model.
+      const inboundVerdict = await moderateExchange(prompt);
+      if (!inboundVerdict.safe) {
+        await pauseChat(inboundVerdict);
+        return;
+      }
+    }
+
     try {
       const webhooks = await (message.channel as TextChannel).fetchWebhooks();
       let webhook = webhooks.find((wh: any) => wh.name === WEBHOOK_NAME && wh.token);
@@ -374,6 +461,17 @@ const scriptHandlers = {
         }
       }
       const { text, images, toolCalls } = genResult;
+
+      // Post-screen the full exchange — the classifier judges the reply with the
+      // prompt that produced it in context. Nothing from this turn is delivered
+      // or persisted when it trips.
+      if (moderationOn) {
+        const outboundVerdict = await moderateExchange(prompt, text);
+        if (!outboundVerdict.safe) {
+          await pauseChat(outboundVerdict);
+          return;
+        }
+      }
 
       if (!webhook) {
         webhook = await (message.channel as TextChannel).createWebhook({

--- a/classes/handlers/keywordsBehaviorHandler.ts
+++ b/classes/handlers/keywordsBehaviorHandler.ts
@@ -429,9 +429,20 @@ const scriptHandlers = {
         await sendModerationPause(message, displayName, avatarURL, !!aiSession);
       };
 
+      /**
+       * Current pause state, read inside the lock. `aiSession` was captured
+       * before the lock was acquired, so a turn queued behind one that paused
+       * the session would not see the flag on that snapshot.
+       */
+      const isPausedNow = async (): Promise<boolean> => {
+        if (!moderationOn || !aiSession) return false;
+        const fresh = await (message.client as any).db.aiChat.getSessionById(aiSession.sessionId);
+        return !!fresh?.moderationFlagged;
+      };
+
       if (moderationOn) {
         // Already paused: refuse before spending anything at all.
-        if (aiSession?.moderationFlagged) {
+        if (await isPausedNow()) {
           await flagAndNotify();
           return;
         }
@@ -517,6 +528,14 @@ const scriptHandlers = {
           const outboundVerdict = await moderateExchange(ownTurnText, screenedOutput);
           if (!outboundVerdict.safe) {
             await flagAndNotify(outboundVerdict);
+            return;
+          }
+          // A concurrent turn may have paused this session while we were
+          // generating. The conditional ADD_HISTORY already blocks persistence,
+          // but delivery rides a webhook that nothing else guards — without this
+          // the reply still reaches the channel of a paused chat.
+          if (await isPausedNow()) {
+            await flagAndNotify();
             return;
           }
         }

--- a/classes/handlers/keywordsBehaviorHandler.ts
+++ b/classes/handlers/keywordsBehaviorHandler.ts
@@ -19,7 +19,8 @@ import {
   type MediaKind,
 } from '../../utils/aiMedia';
 import {
-  isModerationEnabled, moderateExchange, MODERATION_PAUSED_MESSAGE, type ModerationVerdict,
+  isModerationEnabled, moderateExchange, MODERATION_PAUSED_MESSAGE, MODERATION_BLOCKED_MESSAGE,
+  type ModerationVerdict,
 } from '../../utils/aiModeration';
 
 const WEBHOOK_NAME = process.env.WEBHOOK_NAME || 'grok-webhook';
@@ -36,25 +37,31 @@ async function getAiWebhook(message: Message, avatarURL: string): Promise<any> {
 }
 
 /**
- * Delivers the content-safety pause notice in the voice of the persona the user
- * was talking to. Falls back to a plain reply if the webhook is unavailable.
+ * Delivers the content-safety notice in the voice of the persona the user was
+ * talking to. Falls back to a plain reply if the webhook is unavailable.
+ *
+ * `paused` picks the wording: a memoryless persona has no session to pause, so
+ * telling that user to "start a new chat" would be nonsense — the next message
+ * is already screened from scratch.
  */
 async function sendModerationPause(
   message: Message,
   displayName: string,
   avatarURL: string,
+  paused: boolean = true,
 ): Promise<void> {
+  const content = paused ? MODERATION_PAUSED_MESSAGE : MODERATION_BLOCKED_MESSAGE;
   try {
     const webhook = await getAiWebhook(message, avatarURL);
     await webhook.send({
-      content: MODERATION_PAUSED_MESSAGE,
+      content,
       username: displayName,
       avatarURL,
       allowedMentions: { parse: [] },
     });
   } catch (err) {
     logError('AiChat: failed to deliver moderation pause via webhook:', err);
-    await message.reply({ content: MODERATION_PAUSED_MESSAGE, allowedMentions: { repliedUser: false } })
+    await message.reply({ content, allowedMentions: { repliedUser: false } })
       .catch((e) => { logError('AiChat: moderation pause reply failed:', e); });
   }
 }
@@ -167,6 +174,11 @@ const scriptHandlers = {
     const NO_MEMORY_PERSONAS = ['Summarizer'];
     const hasMemory = !NO_MEMORY_PERSONAS.includes(displayName);
 
+    // Read once, up front: `ai_moderation` is a master switch, so every
+    // moderation-aware branch below (including amnesia) must agree on its value
+    // within a single message.
+    const moderationOn = await isModerationEnabled((message.client as any).db);
+
     if (shouldStartNewSession && hasMemory) {
       try {
         const newSession = await (message.client as any).db.aiChat.startNewSession(
@@ -195,6 +207,7 @@ const scriptHandlers = {
         const result = await (message.client as any).db.aiChat.undoLastTurn(
           message.author.id,
           displayName,
+          moderationOn,
         );
 
         if (!result.ok && result.reason === 'paused') {
@@ -323,6 +336,14 @@ const scriptHandlers = {
       prompt = `${pdfPrefix}User ${username} said: ${query}${mediaSuffix}`;
     }
 
+    // What the *user themselves* wrote, with no quoted reply context and no PDF
+    // body. This — not `prompt` — is what the content-safety screen judges for
+    // the purpose of pausing: `prompt` embeds another user's message when this
+    // is a reply, so screening it would let someone permanently pause a third
+    // party's session just by being quoted at. The model's reply is still
+    // post-screened, which is where content induced by quoted context surfaces.
+    const ownTurnText = `User ${username} said: ${query}`;
+
     log(`Prompt: ${prompt}`);
 
     const avatarURL = persona.avatarURL || message.client.user!.displayAvatarURL();
@@ -367,45 +388,52 @@ const scriptHandlers = {
     }
 
     // Content-safety gate (global `ai_moderation` switch). Applies to every
-    // persona and every user alike. Releases the media slot on every early exit
-    // — the normal path frees it in the generation `finally` below.
-    const moderationOn = await isModerationEnabled((message.client as any).db);
-    const pauseChat = async (verdict?: ModerationVerdict) => {
+    // persona and every user alike. Releases the media slot on every exit — the
+    // normal path frees it in the generation `finally` below.
+    //
+    // `flagAndNotify` is the single exit for every trip, so the cleanup, the
+    // flag write and the notice can never drift apart. `verdict` is omitted when
+    // the session was already flagged by an earlier turn (nothing to re-record).
+    const flagAndNotify = async (verdict?: ModerationVerdict) => {
       if (mediaSlotHeld) {
         releaseMediaSlot();
         mediaSlotHeld = false;
       }
       mediaParts = [];
       imageEditParts = [];
-      if (aiSession) {
+      if (aiSession && verdict) {
         try {
-          await (message.client as any).db.aiChat.flagSessionModeration(
+          const flagged = await (message.client as any).db.aiChat.flagSessionModeration(
             aiSession.sessionId,
-            verdict?.categories,
+            verdict.categories,
           );
+          // The turn is refused either way — but an unflagged session would let
+          // the *next* message through, so this must be loud.
+          if (!flagged) {
+            logError(`AiChat: content-safety pause did not persist for session ${aiSession.sessionId}; session may resume`);
+          }
         } catch (flagErr) {
           logError('AiChat: Failed to flag session for moderation:', flagErr);
         }
       }
-      await sendModerationPause(message, displayName, avatarURL);
+      // A memoryless persona has no session to pause — say "blocked", not
+      // "start a new chat".
+      await sendModerationPause(message, displayName, avatarURL, !!aiSession);
     };
 
     if (moderationOn) {
       // Already paused: refuse before spending anything at all.
       if (aiSession?.moderationFlagged) {
-        if (mediaSlotHeld) {
-          releaseMediaSlot();
-          mediaSlotHeld = false;
-        }
-        await sendModerationPause(message, displayName, avatarURL);
+        await flagAndNotify();
         return;
       }
 
-      // Pre-screen the incoming message so an unsafe prompt never reaches (or
-      // bills) the chat model.
-      const inboundVerdict = await moderateExchange(prompt);
+      // Pre-screen the user's own text so an unsafe prompt never reaches (or
+      // bills) the chat model. Quoted context and PDF bodies are excluded — see
+      // `ownTurnText`.
+      const inboundVerdict = await moderateExchange(ownTurnText);
       if (!inboundVerdict.safe) {
-        await pauseChat(inboundVerdict);
+        await flagAndNotify(inboundVerdict);
         return;
       }
     }
@@ -462,13 +490,25 @@ const scriptHandlers = {
       }
       const { text, images, toolCalls } = genResult;
 
-      // Post-screen the full exchange — the classifier judges the reply with the
-      // prompt that produced it in context. Nothing from this turn is delivered
-      // or persisted when it trips.
+      // Post-screen the exchange — the classifier judges the reply with the turn
+      // that produced it in context. Nothing from this turn is delivered or
+      // persisted when it trips (the credits are still spent; generation has
+      // already happened).
+      //
+      // A tool-driven turn can return generated files with empty `text`, which
+      // would otherwise re-screen the prompt that already passed inbound and
+      // wave the files through. The classifier is text-only here, so screen the
+      // prompts the model asked the tools for instead. The generated bytes
+      // themselves are never screened — documented in .claude/rules/ai-limits.md.
       if (moderationOn) {
-        const outboundVerdict = await moderateExchange(prompt, text);
+        const generationPrompts = (toolCalls ?? [])
+          .filter((tc: any) => tc.name === IMAGE_GEN_TOOL_NAME || tc.name === MUSIC_GEN_TOOL_NAME)
+          .map((tc: any) => String(tc.args?.prompt ?? tc.args?.title ?? ''))
+          .filter(Boolean);
+        const screenedOutput = [text, ...generationPrompts].filter(Boolean).join('\n');
+        const outboundVerdict = await moderateExchange(ownTurnText, screenedOutput);
         if (!outboundVerdict.safe) {
-          await pauseChat(outboundVerdict);
+          await flagAndNotify(outboundVerdict);
           return;
         }
       }

--- a/classes/handlers/keywordsBehaviorHandler.ts
+++ b/classes/handlers/keywordsBehaviorHandler.ts
@@ -22,6 +22,7 @@ import {
   isModerationEnabled, moderateExchange, MODERATION_PAUSED_MESSAGE, MODERATION_BLOCKED_MESSAGE,
   type ModerationVerdict,
 } from '../../utils/aiModeration';
+import { withAiSessionLock } from '../../utils/aiSessionLock';
 
 const WEBHOOK_NAME = process.env.WEBHOOK_NAME || 'grok-webhook';
 
@@ -387,331 +388,342 @@ const scriptHandlers = {
       }
     }
 
-    // Content-safety gate (global `ai_moderation` switch). Applies to every
-    // persona and every user alike. Releases the media slot on every exit — the
-    // normal path frees it in the generation `finally` below.
-    //
-    // `flagAndNotify` is the single exit for every trip, so the cleanup, the
-    // flag write and the notice can never drift apart. `verdict` is omitted when
-    // the session was already flagged by an earlier turn (nothing to re-record).
-    const flagAndNotify = async (verdict?: ModerationVerdict) => {
-      if (mediaSlotHeld) {
-        releaseMediaSlot();
-        mediaSlotHeld = false;
-      }
-      mediaParts = [];
-      imageEditParts = [];
-      if (aiSession && verdict) {
-        try {
-          const flagged = await (message.client as any).db.aiChat.flagSessionModeration(
-            aiSession.sessionId,
-            verdict.categories,
-          );
-          // The turn is refused either way — but an unflagged session would let
-          // the *next* message through, so this must be loud.
-          if (!flagged) {
-            logError(`AiChat: content-safety pause did not persist for session ${aiSession.sessionId}; session may resume`);
-          }
-        } catch (flagErr) {
-          logError('AiChat: Failed to flag session for moderation:', flagErr);
-        }
-      }
-      // A memoryless persona has no session to pause — say "blocked", not
-      // "start a new chat".
-      await sendModerationPause(message, displayName, avatarURL, !!aiSession);
-    };
-
-    if (moderationOn) {
-      // Already paused: refuse before spending anything at all.
-      if (aiSession?.moderationFlagged) {
-        await flagAndNotify();
-        return;
-      }
-
-      // Pre-screen the user's own text so an unsafe prompt never reaches (or
-      // bills) the chat model. Quoted context and PDF bodies are excluded — see
-      // `ownTurnText`.
-      const inboundVerdict = await moderateExchange(ownTurnText);
-      if (!inboundVerdict.safe) {
-        await flagAndNotify(inboundVerdict);
-        return;
-      }
-    }
-
-    try {
-      const webhooks = await (message.channel as TextChannel).fetchWebhooks();
-      let webhook = webhooks.find((wh: any) => wh.name === WEBHOOK_NAME && wh.token);
-
-      const generateOnce = (withMedia: boolean) => generateContent({
-        db: (message.client as any).db,
-        userId: message.author.id,
-        provider: persona.provider,
-        model: persona.model,
-        systemPrompt: persona.systemPrompt ?? '',
-        prompt,
-        history,
-        webSearchEnabled: persona.webSearchEnabled,
-        mediaParts: withMedia ? mediaParts : [],
-        providerRouting: persona.providerRouting,
-        // Image generation is Discord-only (delivery rides this webhook); the
-        // rate limit is keyed to the requesting Discord user. Attached images
-        // ride along as edit sources for the generate_image tool.
-        imageGen: hasMemory
-          ? { userId: message.author.id, db: (message.client as any).db, imageParts: imageEditParts }
-          : undefined,
-        // Music generation rides the same webhook delivery; rate limit keyed
-        // to the requesting Discord user.
-        musicGen: hasMemory
-          ? { userId: message.author.id, db: (message.client as any).db }
-          : undefined,
-      });
-
-      let genResult;
-      let mediaDropped = false;
-      try {
-        genResult = await generateOnce(mediaParts.length > 0);
-      } catch (genErr: any) {
-        if (genErr?.message === 'RATE_LIMIT_EXCEEDED') throw genErr;
-        // A provider rejecting the media (bad codec, too long, …) shouldn't eat
-        // the whole reply — drop attachments and answer text-only.
-        if (mediaParts.length === 0) throw genErr;
-        logError('AiChat: generation with media failed, retrying text-only:', genErr);
-        mediaDropped = true;
-        genResult = await generateOnce(false);
-      } finally {
-        // Buffers are only referenced by these arrays; free the slot as soon
-        // as the provider round-trip is over.
-        mediaParts = [];
-        imageEditParts = [];
+    // The whole turn — pause check, generation, delivery and history writes —
+    // runs under a per-session lock. Those are separate operations, so without
+    // serialization a concurrent turn (another mention, or /ask on the shared
+    // Silverwolf session) could flag the session in between and this one would
+    // still deliver into a paused chat. Memoryless personas have no session to
+    // lock and nothing to persist, so they run unserialized.
+    const runTurn = async () => {
+      // Content-safety gate (global `ai_moderation` switch). Applies to every
+      // persona and every user alike. Releases the media slot on every exit — the
+      // normal path frees it in the generation `finally` below.
+      //
+      // `flagAndNotify` is the single exit for every trip, so the cleanup, the
+      // flag write and the notice can never drift apart. `verdict` is omitted when
+      // the session was already flagged by an earlier turn (nothing to re-record).
+      const flagAndNotify = async (verdict?: ModerationVerdict) => {
         if (mediaSlotHeld) {
           releaseMediaSlot();
           mediaSlotHeld = false;
         }
-      }
-      const { text, images, toolCalls } = genResult;
+        mediaParts = [];
+        imageEditParts = [];
+        if (aiSession && verdict) {
+          try {
+            const flagged = await (message.client as any).db.aiChat.flagSessionModeration(
+              aiSession.sessionId,
+              verdict.categories,
+            );
+            // The turn is refused either way — but an unflagged session would let
+            // the *next* message through, so this must be loud.
+            if (!flagged) {
+              logError(`AiChat: content-safety pause did not persist for session ${aiSession.sessionId}; session may resume`);
+            }
+          } catch (flagErr) {
+            logError('AiChat: Failed to flag session for moderation:', flagErr);
+          }
+        }
+        // A memoryless persona has no session to pause — say "blocked", not
+        // "start a new chat".
+        await sendModerationPause(message, displayName, avatarURL, !!aiSession);
+      };
 
-      // Post-screen the exchange — the classifier judges the reply with the turn
-      // that produced it in context. Nothing from this turn is delivered or
-      // persisted when it trips (the credits are still spent; generation has
-      // already happened).
-      //
-      // A tool-driven turn can return generated files with empty `text`, which
-      // would otherwise re-screen the prompt that already passed inbound and
-      // wave the files through. The classifier is text-only here, so screen the
-      // prompts the model asked the tools for instead. The generated bytes
-      // themselves are never screened — documented in .claude/rules/ai-limits.md.
       if (moderationOn) {
-        const generationPrompts = (toolCalls ?? [])
-          .filter((tc: any) => tc.name === IMAGE_GEN_TOOL_NAME || tc.name === MUSIC_GEN_TOOL_NAME)
-          .map((tc: any) => String(tc.args?.prompt ?? tc.args?.title ?? ''))
-          .filter(Boolean);
-        const screenedOutput = [text, ...generationPrompts].filter(Boolean).join('\n');
-        const outboundVerdict = await moderateExchange(ownTurnText, screenedOutput);
-        if (!outboundVerdict.safe) {
-          await flagAndNotify(outboundVerdict);
+        // Already paused: refuse before spending anything at all.
+        if (aiSession?.moderationFlagged) {
+          await flagAndNotify();
+          return;
+        }
+
+        // Pre-screen the user's own text so an unsafe prompt never reaches (or
+        // bills) the chat model. Quoted context and PDF bodies are excluded — see
+        // `ownTurnText`.
+        const inboundVerdict = await moderateExchange(ownTurnText);
+        if (!inboundVerdict.safe) {
+          await flagAndNotify(inboundVerdict);
           return;
         }
       }
 
-      if (!webhook) {
-        webhook = await (message.channel as TextChannel).createWebhook({
-          name: WEBHOOK_NAME,
-          avatar: avatarURL,
+      try {
+        const webhooks = await (message.channel as TextChannel).fetchWebhooks();
+        let webhook = webhooks.find((wh: any) => wh.name === WEBHOOK_NAME && wh.token);
+
+        const generateOnce = (withMedia: boolean) => generateContent({
+          db: (message.client as any).db,
+          userId: message.author.id,
+          provider: persona.provider,
+          model: persona.model,
+          systemPrompt: persona.systemPrompt ?? '',
+          prompt,
+          history,
+          webSearchEnabled: persona.webSearchEnabled,
+          mediaParts: withMedia ? mediaParts : [],
+          providerRouting: persona.providerRouting,
+          // Image generation is Discord-only (delivery rides this webhook); the
+          // rate limit is keyed to the requesting Discord user. Attached images
+          // ride along as edit sources for the generate_image tool.
+          imageGen: hasMemory
+            ? { userId: message.author.id, db: (message.client as any).db, imageParts: imageEditParts }
+            : undefined,
+          // Music generation rides the same webhook delivery; rate limit keyed
+          // to the requesting Discord user.
+          musicGen: hasMemory
+            ? { userId: message.author.id, db: (message.client as any).db }
+            : undefined,
         });
-      }
 
-      // Prominent pre-reply notice when history was trimmed — so the user sees
-      // it before the wall of AI text, not buried after.
-      const trimWarning = contextWarnings.find((w) => w.wasTrimmed);
-      if (trimWarning) {
-        const trimEmbed = new EmbedBuilder()
-          .setColor('#FEE75C')
-          .setTitle('⚠ Context limit reached')
-          .setDescription(`Trimmed **${trimWarning.trimmedCount}** old message${trimWarning.trimmedCount === 1 ? '' : 's'} to fit this model's context window. The oldest parts of the conversation are no longer visible to me.`)
-          .setFooter({ text: 'Use "kys" for a fresh session · "amnesia" to forget the last turn' });
+        let genResult;
+        let mediaDropped = false;
         try {
-          await message.reply({ embeds: [trimEmbed], allowedMentions: { repliedUser: false } });
-        } catch (warnErr) {
-          logError('Failed to send trim warning embed:', warnErr);
+          genResult = await generateOnce(mediaParts.length > 0);
+        } catch (genErr: any) {
+          if (genErr?.message === 'RATE_LIMIT_EXCEEDED') throw genErr;
+          // A provider rejecting the media (bad codec, too long, …) shouldn't eat
+          // the whole reply — drop attachments and answer text-only.
+          if (mediaParts.length === 0) throw genErr;
+          logError('AiChat: generation with media failed, retrying text-only:', genErr);
+          mediaDropped = true;
+          genResult = await generateOnce(false);
+        } finally {
+          // Buffers are only referenced by these arrays; free the slot as soon
+          // as the provider round-trip is over.
+          mediaParts = [];
+          imageEditParts = [];
+          if (mediaSlotHeld) {
+            releaseMediaSlot();
+            mediaSlotHeld = false;
+          }
         }
-      }
+        const { text, images, toolCalls } = genResult;
 
-      const MAX_LENGTH = 2000;
-      const nonSearchTools = [IMAGE_GEN_TOOL_NAME, MUSIC_GEN_TOOL_NAME, MUSIC_GUIDE_TOOL_NAME];
-      const searchCallCount = (toolCalls ?? []).filter((tc: any) => !nonSearchTools.includes(tc.name)).length;
-      const imageCallHappened = (toolCalls ?? []).some((tc: any) => tc.name === IMAGE_GEN_TOOL_NAME && tc.ok);
-      const musicCallHappened = (toolCalls ?? []).some((tc: any) => tc.name === MUSIC_GEN_TOOL_NAME && tc.ok);
-      const searchPrefix = searchCallCount > 0
-        ? `-# 🔎 searched the web (${searchCallCount})\n`
-        : '';
-      const imagePrefix = imageCallHappened ? '-# 🎨 generated an image\n' : '';
-      const musicPrefix = musicCallHappened ? '-# 🎵 composed music\n' : '';
-      const mediaReadPrefix = mediaPlaceholders.length > 0 && !mediaDropped
-        ? `-# 📎 read ${mediaPlaceholders.length} attachment${mediaPlaceholders.length === 1 ? '' : 's'}\n`
-        : '';
-      const mediaFailPrefix = mediaDropped
-        ? '-# ⚠ the model rejected the attachments — answered without them\n'
-        : '';
-      let remainingText = `${searchPrefix}${imagePrefix}${musicPrefix}${mediaReadPrefix}${mediaFailPrefix}${(text || '').toString()}`;
-      let previousMsg: any = null;
-      let filesToAttach: any[] = images || [];
-
-      let currentChunk = remainingText.slice(0, MAX_LENGTH);
-      remainingText = remainingText.slice(currentChunk.length).trimStart();
-
-      const componentsForFirstMessage: ActionRowBuilder<ButtonBuilder>[] = [];
-      const jumpLinkToOriginal = `https://discord.com/channels/${message.guildId}/${message.channelId}/${message.id}`;
-      const replyButton = new ActionRowBuilder<ButtonBuilder>().addComponents(
-        new ButtonBuilder()
-          .setLabel(`↩ Replying to: ${username}`)
-          .setStyle(ButtonStyle.Link)
-          .setURL(jumpLinkToOriginal),
-      );
-      componentsForFirstMessage.push(replyButton);
-
-      const sentInitial = await webhook!.send({
-        content: currentChunk || (filesToAttach.length > 0 ? '' : '(no content)'),
-        username: displayName,
-        avatarURL,
-        components: componentsForFirstMessage,
-        files: filesToAttach,
-        allowedMentions: { parse: [] },
-      });
-      previousMsg = sentInitial;
-      // Discord CDN URLs of attached generated images — saved to history so the
-      // model has a reference to what it sent (links are signed and expire ~24h).
-      const imageCdnUrls: string[] = filesToAttach.length > 0
-        ? [...(sentInitial.attachments?.values() ?? [])].map((a: any) => a.url).filter(Boolean)
-        : [];
-      filesToAttach = [];
-
-      while (remainingText.length > 0) {
-        currentChunk = remainingText.slice(0, MAX_LENGTH);
-        const breakIndex = Math.max(
-          currentChunk.lastIndexOf('\n'),
-          currentChunk.lastIndexOf(' '),
-        );
-
-        if (breakIndex > 0 && remainingText.length > MAX_LENGTH) {
-          currentChunk = remainingText.slice(0, breakIndex);
+        // Post-screen the exchange — the classifier judges the reply with the turn
+        // that produced it in context. Nothing from this turn is delivered or
+        // persisted when it trips (the credits are still spent; generation has
+        // already happened).
+        //
+        // A tool-driven turn can return generated files with empty `text`, which
+        // would otherwise re-screen the prompt that already passed inbound and
+        // wave the files through. The classifier is text-only here, so screen the
+        // prompts the model asked the tools for instead. The generated bytes
+        // themselves are never screened — documented in .claude/rules/ai-limits.md.
+        if (moderationOn) {
+          const generationPrompts = (toolCalls ?? [])
+            .filter((tc: any) => tc.name === IMAGE_GEN_TOOL_NAME || tc.name === MUSIC_GEN_TOOL_NAME)
+            .map((tc: any) => String(tc.args?.prompt ?? tc.args?.title ?? ''))
+            .filter(Boolean);
+          const screenedOutput = [text, ...generationPrompts].filter(Boolean).join('\n');
+          const outboundVerdict = await moderateExchange(ownTurnText, screenedOutput);
+          if (!outboundVerdict.safe) {
+            await flagAndNotify(outboundVerdict);
+            return;
+          }
         }
 
+        if (!webhook) {
+          webhook = await (message.channel as TextChannel).createWebhook({
+            name: WEBHOOK_NAME,
+            avatar: avatarURL,
+          });
+        }
+
+        // Prominent pre-reply notice when history was trimmed — so the user sees
+        // it before the wall of AI text, not buried after.
+        const trimWarning = contextWarnings.find((w) => w.wasTrimmed);
+        if (trimWarning) {
+          const trimEmbed = new EmbedBuilder()
+            .setColor('#FEE75C')
+            .setTitle('⚠ Context limit reached')
+            .setDescription(`Trimmed **${trimWarning.trimmedCount}** old message${trimWarning.trimmedCount === 1 ? '' : 's'} to fit this model's context window. The oldest parts of the conversation are no longer visible to me.`)
+            .setFooter({ text: 'Use "kys" for a fresh session · "amnesia" to forget the last turn' });
+          try {
+            await message.reply({ embeds: [trimEmbed], allowedMentions: { repliedUser: false } });
+          } catch (warnErr) {
+            logError('Failed to send trim warning embed:', warnErr);
+          }
+        }
+
+        const MAX_LENGTH = 2000;
+        const nonSearchTools = [IMAGE_GEN_TOOL_NAME, MUSIC_GEN_TOOL_NAME, MUSIC_GUIDE_TOOL_NAME];
+        const searchCallCount = (toolCalls ?? []).filter((tc: any) => !nonSearchTools.includes(tc.name)).length;
+        const imageCallHappened = (toolCalls ?? []).some((tc: any) => tc.name === IMAGE_GEN_TOOL_NAME && tc.ok);
+        const musicCallHappened = (toolCalls ?? []).some((tc: any) => tc.name === MUSIC_GEN_TOOL_NAME && tc.ok);
+        const searchPrefix = searchCallCount > 0
+          ? `-# 🔎 searched the web (${searchCallCount})\n`
+          : '';
+        const imagePrefix = imageCallHappened ? '-# 🎨 generated an image\n' : '';
+        const musicPrefix = musicCallHappened ? '-# 🎵 composed music\n' : '';
+        const mediaReadPrefix = mediaPlaceholders.length > 0 && !mediaDropped
+          ? `-# 📎 read ${mediaPlaceholders.length} attachment${mediaPlaceholders.length === 1 ? '' : 's'}\n`
+          : '';
+        const mediaFailPrefix = mediaDropped
+          ? '-# ⚠ the model rejected the attachments — answered without them\n'
+          : '';
+        let remainingText = `${searchPrefix}${imagePrefix}${musicPrefix}${mediaReadPrefix}${mediaFailPrefix}${(text || '').toString()}`;
+        let previousMsg: any = null;
+        let filesToAttach: any[] = images || [];
+
+        let currentChunk = remainingText.slice(0, MAX_LENGTH);
         remainingText = remainingText.slice(currentChunk.length).trimStart();
 
-        const componentsForFollowUp: ActionRowBuilder<ButtonBuilder>[] = [];
-        const jumpLinkToPrevious = `https://discord.com/channels/${message.guildId}/${message.channelId}/${previousMsg.id}`;
-        const previousButton = new ActionRowBuilder<ButtonBuilder>().addComponents(
+        const componentsForFirstMessage: ActionRowBuilder<ButtonBuilder>[] = [];
+        const jumpLinkToOriginal = `https://discord.com/channels/${message.guildId}/${message.channelId}/${message.id}`;
+        const replyButton = new ActionRowBuilder<ButtonBuilder>().addComponents(
           new ButtonBuilder()
-            .setLabel('⬅ Previous')
+            .setLabel(`↩ Replying to: ${username}`)
             .setStyle(ButtonStyle.Link)
-            .setURL(jumpLinkToPrevious),
+            .setURL(jumpLinkToOriginal),
         );
-        componentsForFollowUp.push(previousButton);
+        componentsForFirstMessage.push(replyButton);
 
-        // eslint-disable-next-line no-await-in-loop
-        const sent = await webhook!.send({
-          content: currentChunk,
+        const sentInitial = await webhook!.send({
+          content: currentChunk || (filesToAttach.length > 0 ? '' : '(no content)'),
           username: displayName,
           avatarURL,
-          components: componentsForFollowUp,
+          components: componentsForFirstMessage,
+          files: filesToAttach,
           allowedMentions: { parse: [] },
         });
-        previousMsg = sent;
-      }
+        previousMsg = sentInitial;
+        // Discord CDN URLs of attached generated images — saved to history so the
+        // model has a reference to what it sent (links are signed and expire ~24h).
+        const imageCdnUrls: string[] = filesToAttach.length > 0
+          ? [...(sentInitial.attachments?.values() ?? [])].map((a: any) => a.url).filter(Boolean)
+          : [];
+        filesToAttach = [];
 
-      // Post-reply context-usage embed (percentage). Skip if we only had a
-      // trim-only warning — that was already shown loudly before the reply.
-      const pctWarning = contextWarnings.find((w) => w.level >= 75 || (w.level >= 50 && !w.wasTrimmed));
-      if (pctWarning) {
-        let warningColor = '#5865F2'; // blue for 50%
-        if (pctWarning.level >= 95) warningColor = '#ED4245'; // red
-        else if (pctWarning.level >= 75) warningColor = '#FEE75C'; // yellow
+        while (remainingText.length > 0) {
+          currentChunk = remainingText.slice(0, MAX_LENGTH);
+          const breakIndex = Math.max(
+            currentChunk.lastIndexOf('\n'),
+            currentChunk.lastIndexOf(' '),
+          );
 
-        const warningEmbed = new EmbedBuilder()
-          .setColor(warningColor as `#${string}`)
-          .setDescription(pctWarning.message)
-          .setFooter({ text: 'Use "kys" for a fresh session · "amnesia" to forget the last turn' });
-        try {
-          await message.reply({ embeds: [warningEmbed], allowedMentions: { repliedUser: false } });
-        } catch (warnErr) {
-          logError('Failed to send context warning embed:', warnErr);
+          if (breakIndex > 0 && remainingText.length > MAX_LENGTH) {
+            currentChunk = remainingText.slice(0, breakIndex);
+          }
+
+          remainingText = remainingText.slice(currentChunk.length).trimStart();
+
+          const componentsForFollowUp: ActionRowBuilder<ButtonBuilder>[] = [];
+          const jumpLinkToPrevious = `https://discord.com/channels/${message.guildId}/${message.channelId}/${previousMsg.id}`;
+          const previousButton = new ActionRowBuilder<ButtonBuilder>().addComponents(
+            new ButtonBuilder()
+              .setLabel('⬅ Previous')
+              .setStyle(ButtonStyle.Link)
+              .setURL(jumpLinkToPrevious),
+          );
+          componentsForFollowUp.push(previousButton);
+
+          // eslint-disable-next-line no-await-in-loop
+          const sent = await webhook!.send({
+            content: currentChunk,
+            username: displayName,
+            avatarURL,
+            components: componentsForFollowUp,
+            allowedMentions: { parse: [] },
+          });
+          previousMsg = sent;
         }
-      }
 
-      const hasToolCalls = !!(toolCalls && toolCalls.length > 0);
-      const hasImages = !!(images && images.length > 0);
-      if (hasMemory && aiSession && (text || hasToolCalls || hasImages)) {
-        const aiRole = persona.provider === 'openrouter' ? 'assistant' : 'model';
-        try {
-          await (message.client as any).db.aiChat.addHistory(aiSession.sessionId, 'user', prompt);
-          if (hasToolCalls) {
-            // Persist tool exchanges between the user message and the final assistant
-            // text so chronological order is preserved. These rows are audit-only;
-            // they're filtered out when history is replayed to the model.
-            for (const tc of toolCalls) {
-              // eslint-disable-next-line no-await-in-loop
+        // Post-reply context-usage embed (percentage). Skip if we only had a
+        // trim-only warning — that was already shown loudly before the reply.
+        const pctWarning = contextWarnings.find((w) => w.level >= 75 || (w.level >= 50 && !w.wasTrimmed));
+        if (pctWarning) {
+          let warningColor = '#5865F2'; // blue for 50%
+          if (pctWarning.level >= 95) warningColor = '#ED4245'; // red
+          else if (pctWarning.level >= 75) warningColor = '#FEE75C'; // yellow
+
+          const warningEmbed = new EmbedBuilder()
+            .setColor(warningColor as `#${string}`)
+            .setDescription(pctWarning.message)
+            .setFooter({ text: 'Use "kys" for a fresh session · "amnesia" to forget the last turn' });
+          try {
+            await message.reply({ embeds: [warningEmbed], allowedMentions: { repliedUser: false } });
+          } catch (warnErr) {
+            logError('Failed to send context warning embed:', warnErr);
+          }
+        }
+
+        const hasToolCalls = !!(toolCalls && toolCalls.length > 0);
+        const hasImages = !!(images && images.length > 0);
+        if (hasMemory && aiSession && (text || hasToolCalls || hasImages)) {
+          const aiRole = persona.provider === 'openrouter' ? 'assistant' : 'model';
+          try {
+            await (message.client as any).db.aiChat.addHistory(aiSession.sessionId, 'user', prompt);
+            if (hasToolCalls) {
+              // Persist tool exchanges between the user message and the final assistant
+              // text so chronological order is preserved. These rows are audit-only;
+              // they're filtered out when history is replayed to the model.
+              for (const tc of toolCalls) {
+                // eslint-disable-next-line no-await-in-loop
+                await (message.client as any).db.aiChat.addHistory(
+                  aiSession.sessionId,
+                  'tool',
+                  JSON.stringify(tc),
+                );
+              }
+            }
+            if (text) {
+              await (message.client as any).db.aiChat.addHistory(aiSession.sessionId, aiRole, text);
+            } else if (hasImages) {
+              const imageMeta = JSON.stringify(images.map((img: any) => ({ name: img.name })));
               await (message.client as any).db.aiChat.addHistory(
                 aiSession.sessionId,
-                'tool',
-                JSON.stringify(tc),
+                aiRole,
+                `[attachment-only response] ${imageMeta}`,
               );
             }
-          }
-          if (text) {
-            await (message.client as any).db.aiChat.addHistory(aiSession.sessionId, aiRole, text);
-          } else if (hasImages) {
-            const imageMeta = JSON.stringify(images.map((img: any) => ({ name: img.name })));
-            await (message.client as any).db.aiChat.addHistory(
-              aiSession.sessionId,
-              aiRole,
-              `[attachment-only response] ${imageMeta}`,
-            );
-          }
-          if (hasImages && imageCdnUrls.length > 0) {
-            await (message.client as any).db.aiChat.addHistory(
-              aiSession.sessionId,
-              aiRole,
-              `[generated file attached: ${imageCdnUrls.join(' ')}] (note: this link expires within ~24 hours)`,
-            );
-          }
+            if (hasImages && imageCdnUrls.length > 0) {
+              await (message.client as any).db.aiChat.addHistory(
+                aiSession.sessionId,
+                aiRole,
+                `[generated file attached: ${imageCdnUrls.join(' ')}] (note: this link expires within ~24 hours)`,
+              );
+            }
 
-          if (historyLoaded && !hadRawHistory && text) {
-            (message.client as any).db.aiChat.getHistory(aiSession.sessionId, 100)
-              .then((savedHistory: { role: string; message: string }[]) => generateTitleForHistory(savedHistory))
-              .then((title: string | null) => {
-                if (title) {
-                  return (message.client as any).db.aiChat.updateTitle(aiSession.sessionId, title);
-                }
-                return undefined;
-              })
-              .catch((titleErr: unknown) => {
-                logError('AiChat: Failed to generate session title:', titleErr);
-              });
+            if (historyLoaded && !hadRawHistory && text) {
+              (message.client as any).db.aiChat.getHistory(aiSession.sessionId, 100)
+                .then((savedHistory: { role: string; message: string }[]) => generateTitleForHistory(savedHistory))
+                .then((title: string | null) => {
+                  if (title) {
+                    return (message.client as any).db.aiChat.updateTitle(aiSession.sessionId, title);
+                  }
+                  return undefined;
+                })
+                .catch((titleErr: unknown) => {
+                  logError('AiChat: Failed to generate session title:', titleErr);
+                });
+            }
+          } catch (saveErr) {
+            logError('AiChat: Failed to save history:', saveErr);
           }
-        } catch (saveErr) {
-          logError('AiChat: Failed to save history:', saveErr);
         }
+      } catch (err: any) {
+        if (mediaSlotHeld) {
+          releaseMediaSlot();
+          mediaSlotHeld = false;
+        }
+        if (err?.message === 'RATE_LIMIT_EXCEEDED') {
+          const db = (message.client as any).db;
+          const content = await getRateLimitErrorMessage(message.author.id, db, {
+            reason: err.reason,
+            reservedCredits: err.reservedCredits,
+            remainingCredits: err.remainingCredits,
+          });
+          await message.reply(content);
+          return;
+        }
+        logError('AI unified handler error', err);
+        await message.reply(
+          'Either, our code is fucked, their API is fucked, or you are just fucked. Please try again later.',
+        );
       }
-    } catch (err: any) {
-      if (mediaSlotHeld) {
-        releaseMediaSlot();
-        mediaSlotHeld = false;
-      }
-      if (err?.message === 'RATE_LIMIT_EXCEEDED') {
-        const db = (message.client as any).db;
-        const content = await getRateLimitErrorMessage(message.author.id, db, {
-          reason: err.reason,
-          reservedCredits: err.reservedCredits,
-          remainingCredits: err.remainingCredits,
-        });
-        await message.reply(content);
-        return;
-      }
-      logError('AI unified handler error', err);
-      await message.reply(
-        'Either, our code is fucked, their API is fucked, or you are just fucked. Please try again later.',
-      );
-    }
+    };
+
+    if (aiSession) await withAiSessionLock(aiSession.sessionId, runTurn);
+    else await runTurn();
   },
 
   stealSticker: async (message: Message): Promise<void> => {

--- a/commands/askSilverwolfAI.ts
+++ b/commands/askSilverwolfAI.ts
@@ -54,11 +54,26 @@ class AskSilverwolfAI extends Command {
       const moderationOn = await isModerationEnabled(this.client.db);
       const pauseSession = async (categories?: string) => {
         try {
-          await this.client.db.aiChat.flagSessionModeration(aiSession.sessionId, categories);
+          const flagged = await this.client.db.aiChat.flagSessionModeration(
+            aiSession.sessionId,
+            categories,
+          );
+          // This turn is refused regardless, but an unflagged session would let
+          // the next one through — that must not be silent.
+          if (!flagged) {
+            logError(`AiChat: content-safety pause did not persist for session ${aiSession.sessionId}; session may resume`);
+          }
         } catch (flagErr) {
           logError('AiChat: Failed to flag session for moderation:', flagErr);
         }
         await interaction.editReply({ content: MODERATION_PAUSED_MESSAGE, embeds: [] });
+      };
+
+      /** Re-read the pause state; a concurrent turn may have flagged it since. */
+      const isPausedNow = async (): Promise<boolean> => {
+        if (!moderationOn) return false;
+        const fresh = await this.client.db.aiChat.getSessionById(aiSession.sessionId);
+        return !!fresh?.moderationFlagged;
       };
 
       if (moderationOn) {
@@ -100,6 +115,12 @@ class AskSilverwolfAI extends Command {
         const outbound = await moderateExchange(prompt, text);
         if (!outbound.safe) {
           await pauseSession(outbound.categories);
+          return;
+        }
+        // A concurrent turn may have paused this session while we were
+        // generating; don't deliver or persist into a chat that is now paused.
+        if (await isPausedNow()) {
+          await interaction.editReply({ content: MODERATION_PAUSED_MESSAGE, embeds: [] });
           return;
         }
       }

--- a/commands/askSilverwolfAI.ts
+++ b/commands/askSilverwolfAI.ts
@@ -4,6 +4,7 @@ import { log, logError } from '../utils/log';
 import { getPersonaByName, generateContent, generateTitleForHistory } from '../utils/ai';
 import { trimHistoryToFit } from '../utils/tokenizer';
 import { handleRateLimitError } from '../utils/discordRateLimit';
+import { isModerationEnabled, moderateExchange, MODERATION_PAUSED_MESSAGE } from '../utils/aiModeration';
 
 const PERSONA_NAME = 'Silverwolf';
 
@@ -47,6 +48,31 @@ class AskSilverwolfAI extends Command {
         return;
       }
 
+      // /ask shares the "Silverwolf" session with the `@sw` mention persona, so
+      // it gets the full pause treatment — reply-and-drop here would be a way to
+      // keep talking to a chat that mentions had already paused.
+      const moderationOn = await isModerationEnabled(this.client.db);
+      const pauseSession = async (categories?: string) => {
+        try {
+          await this.client.db.aiChat.flagSessionModeration(aiSession.sessionId, categories);
+        } catch (flagErr) {
+          logError('AiChat: Failed to flag session for moderation:', flagErr);
+        }
+        await interaction.editReply({ content: MODERATION_PAUSED_MESSAGE, embeds: [] });
+      };
+
+      if (moderationOn) {
+        if (aiSession.moderationFlagged) {
+          await interaction.editReply({ content: MODERATION_PAUSED_MESSAGE, embeds: [] });
+          return;
+        }
+        const inbound = await moderateExchange(prompt);
+        if (!inbound.safe) {
+          await pauseSession(inbound.categories);
+          return;
+        }
+      }
+
       const rawHistory = await this.client.db.aiChat.getHistory(aiSession.sessionId, 100);
       const hadRawHistory = rawHistory.length > 0;
       const filteredHistory = rawHistory.filter((h: { role: string }) => h.role !== 'tool');
@@ -69,6 +95,14 @@ class AskSilverwolfAI extends Command {
         history,
         webSearchEnabled: persona.webSearchEnabled,
       });
+
+      if (moderationOn) {
+        const outbound = await moderateExchange(prompt, text);
+        if (!outbound.safe) {
+          await pauseSession(outbound.categories);
+          return;
+        }
+      }
 
       const processedText = (text || '').replace('(Trailblazer)', username);
       const searchPrefix = toolCalls && toolCalls.length > 0

--- a/commands/askSilverwolfAI.ts
+++ b/commands/askSilverwolfAI.ts
@@ -84,7 +84,10 @@ class AskSilverwolfAI extends Command {
         };
 
         if (moderationOn) {
-          if (aiSession.moderationFlagged) {
+          // Fresh read, not the pre-lock snapshot: a turn queued behind one that
+          // paused the session would otherwise pass this check and run a paid
+          // generation before the delivery guard caught it.
+          if (await isPausedNow()) {
             await interaction.editReply({ content: MODERATION_PAUSED_MESSAGE, embeds: [] });
             return;
           }

--- a/commands/askSilverwolfAI.ts
+++ b/commands/askSilverwolfAI.ts
@@ -5,6 +5,7 @@ import { getPersonaByName, generateContent, generateTitleForHistory } from '../u
 import { trimHistoryToFit } from '../utils/tokenizer';
 import { handleRateLimitError } from '../utils/discordRateLimit';
 import { isModerationEnabled, moderateExchange, MODERATION_PAUSED_MESSAGE } from '../utils/aiModeration';
+import { withAiSessionLock } from '../utils/aiSessionLock';
 
 const PERSONA_NAME = 'Silverwolf';
 
@@ -51,132 +52,139 @@ class AskSilverwolfAI extends Command {
       // /ask shares the "Silverwolf" session with the `@sw` mention persona, so
       // it gets the full pause treatment — reply-and-drop here would be a way to
       // keep talking to a chat that mentions had already paused.
-      const moderationOn = await isModerationEnabled(this.client.db);
-      const pauseSession = async (categories?: string) => {
-        try {
-          const flagged = await this.client.db.aiChat.flagSessionModeration(
-            aiSession.sessionId,
-            categories,
-          );
-          // This turn is refused regardless, but an unflagged session would let
-          // the next one through — that must not be silent.
-          if (!flagged) {
-            logError(`AiChat: content-safety pause did not persist for session ${aiSession.sessionId}; session may resume`);
-          }
-        } catch (flagErr) {
-          logError('AiChat: Failed to flag session for moderation:', flagErr);
-        }
-        await interaction.editReply({ content: MODERATION_PAUSED_MESSAGE, embeds: [] });
-      };
-
-      /** Re-read the pause state; a concurrent turn may have flagged it since. */
-      const isPausedNow = async (): Promise<boolean> => {
-        if (!moderationOn) return false;
-        const fresh = await this.client.db.aiChat.getSessionById(aiSession.sessionId);
-        return !!fresh?.moderationFlagged;
-      };
-
-      if (moderationOn) {
-        if (aiSession.moderationFlagged) {
-          await interaction.editReply({ content: MODERATION_PAUSED_MESSAGE, embeds: [] });
-          return;
-        }
-        const inbound = await moderateExchange(prompt);
-        if (!inbound.safe) {
-          await pauseSession(inbound.categories);
-          return;
-        }
-      }
-
-      const rawHistory = await this.client.db.aiChat.getHistory(aiSession.sessionId, 100);
-      const hadRawHistory = rawHistory.length > 0;
-      const filteredHistory = rawHistory.filter((h: { role: string }) => h.role !== 'tool');
-      const { trimmedHistory: history, warnings: contextWarnings } = await trimHistoryToFit(
-        persona.provider,
-        persona.model,
-        persona.systemPrompt ?? '',
-        filteredHistory,
-        prompt,
-        persona.webSearchEnabled,
-      );
-
-      const { text, toolCalls } = await generateContent({
-        db: this.client.db,
-        userId: interaction.user.id,
-        provider: persona.provider,
-        model: persona.model,
-        systemPrompt: persona.systemPrompt ?? '',
-        prompt,
-        history,
-        webSearchEnabled: persona.webSearchEnabled,
-      });
-
-      if (moderationOn) {
-        const outbound = await moderateExchange(prompt, text);
-        if (!outbound.safe) {
-          await pauseSession(outbound.categories);
-          return;
-        }
-        // A concurrent turn may have paused this session while we were
-        // generating; don't deliver or persist into a chat that is now paused.
-        if (await isPausedNow()) {
-          await interaction.editReply({ content: MODERATION_PAUSED_MESSAGE, embeds: [] });
-          return;
-        }
-      }
-
-      const processedText = (text || '').replace('(Trailblazer)', username);
-      const searchPrefix = toolCalls && toolCalls.length > 0
-        ? `-# 🔎 searched the web (${toolCalls.length})\n`
-        : '';
-      const description = `${searchPrefix}${processedText}`;
-
-      log(`Original: ${text}`);
-      log(`Processed: ${processedText}`);
-
-      const embed = new EmbedBuilder()
-        .setTitle('Silverwolf Ai says:')
-        .setDescription(description.slice(0, 4096))
-        .setColor(0x0099ff)
-        .setFooter({ text: 'Powered by ChatTGP', iconURL: 'https://media.discordapp.net/attachments/969953667597893675/1272422507533828106/Qzrb7Us.png?ex=66baeb4e&is=66b999ce&hm=cf4e7ed0da32e823e5ceb90cd94b1abf3e54cc19f447e38a0aef572af68cd04b&=&format=webp&quality=lossless&width=899&height=899' });
-
-      await interaction.editReply({ content: null, embeds: [embed] });
-
-      const trimWarning = contextWarnings.find((w) => w.wasTrimmed);
-      if (trimWarning) {
-        const trimEmbed = new EmbedBuilder()
-          .setColor('#FEE75C')
-          .setTitle('Context limit reached')
-          .setDescription(`Trimmed **${trimWarning.trimmedCount}** old message${trimWarning.trimmedCount === 1 ? '' : 's'} to fit this model's context window. Use \`reset: True\` or \`/ai chatnew\` to start fresh.`);
-        await interaction.followUp({ embeds: [trimEmbed] }).catch((err: unknown) => {
-          logError('Failed to send trim warning:', err);
-        });
-      }
-
-      const aiRole = persona.provider === 'openrouter' ? 'assistant' : 'model';
-      await this.client.db.aiChat.addHistory(aiSession.sessionId, 'user', prompt);
-      if (toolCalls?.length) {
-        for (const tc of toolCalls) {
-          await this.client.db.aiChat.addHistory(aiSession.sessionId, 'tool', JSON.stringify(tc));
-        }
-      }
-      if (text) {
-        await this.client.db.aiChat.addHistory(aiSession.sessionId, aiRole, text);
-      }
-
-      if (!hadRawHistory && text) {
-        this.client.db.aiChat.getHistory(aiSession.sessionId, 100)
-          .then((savedHistory: { role: string; message: string }[]) => generateTitleForHistory(savedHistory))
-          .then((title: string | null) => {
-            if (title) {
-              return this.client.db.aiChat.updateTitle(aiSession.sessionId, title);
+      // Everything from the pause check through generation, delivery and the
+      // history writes runs under a per-session lock. The check and the writes
+      // are separate operations, so without serialization a concurrent /ask or
+      // @sw mention could flag the session in between and this turn would still
+      // land in a paused chat.
+      await withAiSessionLock(aiSession.sessionId, async () => {
+        const moderationOn = await isModerationEnabled(this.client.db);
+        const pauseSession = async (categories?: string) => {
+          try {
+            const flagged = await this.client.db.aiChat.flagSessionModeration(
+              aiSession.sessionId,
+              categories,
+            );
+            // This turn is refused regardless, but an unflagged session would let
+            // the next one through — that must not be silent.
+            if (!flagged) {
+              logError(`AiChat: content-safety pause did not persist for session ${aiSession.sessionId}; session may resume`);
             }
-            return undefined;
-          })
-          .catch((titleErr: unknown) => {
-            logError('AiChat: Failed to generate session title:', titleErr);
+          } catch (flagErr) {
+            logError('AiChat: Failed to flag session for moderation:', flagErr);
+          }
+          await interaction.editReply({ content: MODERATION_PAUSED_MESSAGE, embeds: [] });
+        };
+
+        /** Re-read the pause state; a concurrent turn may have flagged it since. */
+        const isPausedNow = async (): Promise<boolean> => {
+          if (!moderationOn) return false;
+          const fresh = await this.client.db.aiChat.getSessionById(aiSession.sessionId);
+          return !!fresh?.moderationFlagged;
+        };
+
+        if (moderationOn) {
+          if (aiSession.moderationFlagged) {
+            await interaction.editReply({ content: MODERATION_PAUSED_MESSAGE, embeds: [] });
+            return;
+          }
+          const inbound = await moderateExchange(prompt);
+          if (!inbound.safe) {
+            await pauseSession(inbound.categories);
+            return;
+          }
+        }
+
+        const rawHistory = await this.client.db.aiChat.getHistory(aiSession.sessionId, 100);
+        const hadRawHistory = rawHistory.length > 0;
+        const filteredHistory = rawHistory.filter((h: { role: string }) => h.role !== 'tool');
+        const { trimmedHistory: history, warnings: contextWarnings } = await trimHistoryToFit(
+          persona.provider,
+          persona.model,
+          persona.systemPrompt ?? '',
+          filteredHistory,
+          prompt,
+          persona.webSearchEnabled,
+        );
+
+        const { text, toolCalls } = await generateContent({
+          db: this.client.db,
+          userId: interaction.user.id,
+          provider: persona.provider,
+          model: persona.model,
+          systemPrompt: persona.systemPrompt ?? '',
+          prompt,
+          history,
+          webSearchEnabled: persona.webSearchEnabled,
+        });
+
+        if (moderationOn) {
+          const outbound = await moderateExchange(prompt, text);
+          if (!outbound.safe) {
+            await pauseSession(outbound.categories);
+            return;
+          }
+          // A concurrent turn may have paused this session while we were
+          // generating; don't deliver or persist into a chat that is now paused.
+          if (await isPausedNow()) {
+            await interaction.editReply({ content: MODERATION_PAUSED_MESSAGE, embeds: [] });
+            return;
+          }
+        }
+
+        const processedText = (text || '').replace('(Trailblazer)', username);
+        const searchPrefix = toolCalls && toolCalls.length > 0
+          ? `-# 🔎 searched the web (${toolCalls.length})\n`
+          : '';
+        const description = `${searchPrefix}${processedText}`;
+
+        log(`Original: ${text}`);
+        log(`Processed: ${processedText}`);
+
+        const embed = new EmbedBuilder()
+          .setTitle('Silverwolf Ai says:')
+          .setDescription(description.slice(0, 4096))
+          .setColor(0x0099ff)
+          .setFooter({ text: 'Powered by ChatTGP', iconURL: 'https://media.discordapp.net/attachments/969953667597893675/1272422507533828106/Qzrb7Us.png?ex=66baeb4e&is=66b999ce&hm=cf4e7ed0da32e823e5ceb90cd94b1abf3e54cc19f447e38a0aef572af68cd04b&=&format=webp&quality=lossless&width=899&height=899' });
+
+        await interaction.editReply({ content: null, embeds: [embed] });
+
+        const trimWarning = contextWarnings.find((w) => w.wasTrimmed);
+        if (trimWarning) {
+          const trimEmbed = new EmbedBuilder()
+            .setColor('#FEE75C')
+            .setTitle('Context limit reached')
+            .setDescription(`Trimmed **${trimWarning.trimmedCount}** old message${trimWarning.trimmedCount === 1 ? '' : 's'} to fit this model's context window. Use \`reset: True\` or \`/ai chatnew\` to start fresh.`);
+          await interaction.followUp({ embeds: [trimEmbed] }).catch((err: unknown) => {
+            logError('Failed to send trim warning:', err);
           });
-      }
+        }
+
+        const aiRole = persona.provider === 'openrouter' ? 'assistant' : 'model';
+        await this.client.db.aiChat.addHistory(aiSession.sessionId, 'user', prompt);
+        if (toolCalls?.length) {
+          for (const tc of toolCalls) {
+            await this.client.db.aiChat.addHistory(aiSession.sessionId, 'tool', JSON.stringify(tc));
+          }
+        }
+        if (text) {
+          await this.client.db.aiChat.addHistory(aiSession.sessionId, aiRole, text);
+        }
+
+        if (!hadRawHistory && text) {
+          this.client.db.aiChat.getHistory(aiSession.sessionId, 100)
+            .then((savedHistory: { role: string; message: string }[]) => generateTitleForHistory(savedHistory))
+            .then((title: string | null) => {
+              if (title) {
+                return this.client.db.aiChat.updateTitle(aiSession.sessionId, title);
+              }
+              return undefined;
+            })
+            .catch((titleErr: unknown) => {
+              logError('AiChat: Failed to generate session title:', titleErr);
+            });
+        }
+      });
     } catch (error: any) {
       if (error?.message === 'RATE_LIMIT_EXCEEDED') {
         await handleRateLimitError(interaction, this.client.db, {

--- a/commands/summary_count.ts
+++ b/commands/summary_count.ts
@@ -1,6 +1,7 @@
 import { EmbedBuilder } from 'discord.js';
 import { Command } from './classes/Command';
 import { generateContent, getPersonaByName } from '../utils/ai';
+import { isModerationEnabled, moderateExchange, MODERATION_BLOCKED_MESSAGE } from '../utils/aiModeration';
 import { log, logError } from '../utils/log';
 import { handleRateLimitError } from '../utils/discordRateLimit';
 import { fetchMessagesByCount } from '../utils/fetch';
@@ -80,6 +81,16 @@ class Summary extends Command {
       logError('Failed to generate summary:', error);
       await interaction.editReply('Failed to generate summary. Please try again later.');
       return;
+    }
+
+    // Content-safety screen. /summary is a one-shot with no session to pause,
+    // so a trip is reply-and-drop: the summary is discarded, nothing persists.
+    if (await isModerationEnabled(this.client.db)) {
+      const verdict = await moderateExchange(content, summary.text);
+      if (!verdict.safe) {
+        await interaction.editReply(MODERATION_BLOCKED_MESSAGE);
+        return;
+      }
     }
 
     const chunks = splitForEmbed(summary.text);

--- a/commands/summary_time.ts
+++ b/commands/summary_time.ts
@@ -1,6 +1,7 @@
 import { EmbedBuilder } from 'discord.js';
 import { Command } from './classes/Command';
 import { generateContent, getPersonaByName } from '../utils/ai';
+import { isModerationEnabled, moderateExchange, MODERATION_BLOCKED_MESSAGE } from '../utils/aiModeration';
 import { log, logError } from '../utils/log';
 import { handleRateLimitError } from '../utils/discordRateLimit';
 import { fetchMessagesByTime } from '../utils/fetch';
@@ -94,6 +95,16 @@ class Summary extends Command {
       logError('Failed to generate summary:', error);
       await interaction.editReply('Failed to generate summary. Please try again later.');
       return;
+    }
+
+    // Content-safety screen. /summary is a one-shot with no session to pause,
+    // so a trip is reply-and-drop: the summary is discarded, nothing persists.
+    if (await isModerationEnabled(this.client.db)) {
+      const verdict = await moderateExchange(content, summary.text);
+      if (!verdict.safe) {
+        await interaction.editReply(MODERATION_BLOCKED_MESSAGE);
+        return;
+      }
     }
 
     const chunks = splitForEmbed(summary.text);

--- a/data/aiPersonas.json
+++ b/data/aiPersonas.json
@@ -58,6 +58,12 @@
       "systemPromptFile": "data/SummarizerSystemPrompt.txt"
     },
     {
+      "name": "Moderation",
+      "triggers": [],
+      "provider": "openrouter",
+      "model": "nvidia/nemotron-3.5-content-safety:free"
+    },
+    {
       "name": "Imgen",
       "triggers": [],
       "provider": "openrouter",

--- a/database/models/AiChatModel.ts
+++ b/database/models/AiChatModel.ts
@@ -1,7 +1,10 @@
 import { stripModelTimestampPrefix } from '../../utils/ai';
-import { log } from '../../utils/log';
+import { log, logError } from '../../utils/log';
 import aiChatQueries from '../queries/aiChatQueries';
 import type Database from '../Database';
+
+/** Audit field, not a control value — long enough for the full category list. */
+const MAX_MODERATION_CATEGORY_CHARS = 500;
 
 /** Model for managing per-user, per-persona AI chat sessions and history. */
 class AiChatModel {
@@ -152,13 +155,33 @@ class AiChatModel {
    * Marks a session as paused by the content-safety screen. Idempotent; the
    * session keeps its `active` flag so the user can still read the history and
    * so `getOrCreateSession` keeps returning it (and keeps refusing).
+   *
+   * Returns whether the pause actually persisted. `executeQuery` swallows DB
+   * errors and reports `changes: 0` rather than throwing, so a caller that
+   * assumed success would tell the user the chat was paused while leaving the
+   * row unflagged — and the very next message would generate normally.
    */
-  async flagSessionModeration(sessionId: number, categories?: string | null): Promise<void> {
-    await this.db.executeQuery(
+  async flagSessionModeration(sessionId: number, categories?: string | null): Promise<boolean> {
+    const id = Math.trunc(Number(sessionId));
+    if (!Number.isFinite(id) || !Number.isInteger(id) || id <= 0) {
+      logError(`AiChat: refusing to flag invalid session id ${String(sessionId)}`);
+      return false;
+    }
+    // Categories are free-form classifier output stored for audit only; trim and
+    // cap rather than whitelisting, since the model's taxonomy is its own and a
+    // new category label should be recorded, not silently dropped.
+    const trimmed = categories?.trim().slice(0, MAX_MODERATION_CATEGORY_CHARS) || null;
+
+    const result = await this.db.executeQuery(
       aiChatQueries.FLAG_SESSION_MODERATION,
-      [categories?.trim() || null, sessionId],
+      [trimmed, id],
     );
-    log(`AiChat: Session ${sessionId} paused by content-safety screen${categories ? ` (${categories})` : ''}`);
+    if (Number(result.changes ?? 0) !== 1) {
+      logError(`AiChat: failed to persist content-safety pause for session ${id} (no row changed)`);
+      return false;
+    }
+    log(`AiChat: Session ${id} paused by content-safety screen${trimmed ? ` (${trimmed})` : ''}`);
+    return true;
   }
 
   /**
@@ -210,6 +233,7 @@ class AiChatModel {
   async undoLastTurn(
     userId: string,
     personaName: string,
+    honorModerationPause: boolean = true,
   ): Promise<
     | { ok: true; sessionId: number; deletedCount: number; userMessage: string }
     | { ok: false; reason: 'no_session' | 'empty' | 'paused' }
@@ -224,7 +248,11 @@ class AiChatModel {
     // A paused session never persisted the turn that tripped the filter, so
     // amnesia here would silently eat an *earlier*, legitimate turn — and must
     // never be mistaken for a way out of the pause. `kys` is the only exit.
-    if (session.moderationFlagged) {
+    //
+    // Gated on the caller's view of the `ai_moderation` switch: it is a master
+    // switch, so turning it off must restore normal behaviour everywhere at
+    // once. Otherwise a flagged session would chat normally but refuse amnesia.
+    if (honorModerationPause && session.moderationFlagged) {
       return { ok: false, reason: 'paused' };
     }
 

--- a/database/models/AiChatModel.ts
+++ b/database/models/AiChatModel.ts
@@ -149,6 +149,19 @@ class AiChatModel {
   }
 
   /**
+   * Marks a session as paused by the content-safety screen. Idempotent; the
+   * session keeps its `active` flag so the user can still read the history and
+   * so `getOrCreateSession` keeps returning it (and keeps refusing).
+   */
+  async flagSessionModeration(sessionId: number, categories?: string | null): Promise<void> {
+    await this.db.executeQuery(
+      aiChatQueries.FLAG_SESSION_MODERATION,
+      [categories?.trim() || null, sessionId],
+    );
+    log(`AiChat: Session ${sessionId} paused by content-safety screen${categories ? ` (${categories})` : ''}`);
+  }
+
+  /**
    * Switches the active session for a user/persona to a specific session.
    * Deactivates all current sessions for that user/persona first, then activates the target.
    */
@@ -199,7 +212,7 @@ class AiChatModel {
     personaName: string,
   ): Promise<
     | { ok: true; sessionId: number; deletedCount: number; userMessage: string }
-    | { ok: false; reason: 'no_session' | 'empty' }
+    | { ok: false; reason: 'no_session' | 'empty' | 'paused' }
   > {
     const session = await this.db.executeSelectQuery(
       aiChatQueries.GET_ACTIVE_SESSION,
@@ -207,6 +220,12 @@ class AiChatModel {
     );
     if (!session || session.userId !== userId) {
       return { ok: false, reason: 'no_session' };
+    }
+    // A paused session never persisted the turn that tripped the filter, so
+    // amnesia here would silently eat an *earlier*, legitimate turn — and must
+    // never be mistaken for a way out of the pause. `kys` is the only exit.
+    if (session.moderationFlagged) {
+      return { ok: false, reason: 'paused' };
     }
 
     const outcome = await this.db.executeTransaction((rawDb: any) => {

--- a/database/models/AiChatModel.ts
+++ b/database/models/AiChatModel.ts
@@ -217,12 +217,21 @@ class AiChatModel {
 
   /**
    * Appends a message to the session's history.
+   *
+   * No-ops when the session has been paused by the content-safety screen — the
+   * guard lives in the INSERT itself, so a turn that was already generating when
+   * another turn paused the session cannot write into it. Returns whether the
+   * row was written.
    */
-  async addHistory(sessionId: number, role: 'user' | 'model' | 'assistant' | 'tool', message: string): Promise<void> {
+  async addHistory(sessionId: number, role: 'user' | 'model' | 'assistant' | 'tool', message: string): Promise<boolean> {
     const stored = role === 'model' || role === 'assistant'
       ? stripModelTimestampPrefix(message)
       : message;
-    await this.db.executeQuery(aiChatQueries.ADD_HISTORY, [sessionId, role, stored]);
+    const result = await this.db.executeQuery(
+      aiChatQueries.ADD_HISTORY,
+      [sessionId, role, stored, sessionId],
+    );
+    return Number(result.changes ?? 0) > 0;
   }
 
   /**

--- a/database/queries/aiChatQueries.ts
+++ b/database/queries/aiChatQueries.ts
@@ -47,7 +47,17 @@ const aiChatQueries = {
   FLAG_SESSION_MODERATION: 'UPDATE AiChatSession SET moderation_flagged = 1, moderation_categories = ? WHERE session_id = ?',
 
   // History management
-  ADD_HISTORY: 'INSERT INTO AiChatHistory (session_id, role, message) VALUES (?, ?, ?)',
+  // Conditional on the session not being paused by the content-safety screen.
+  // The check and the insert are one statement, so a turn that was in flight
+  // when another turn paused the session cannot persist into it — this holds on
+  // every surface, including ones that don't take the per-session lock.
+  ADD_HISTORY: `
+    INSERT INTO AiChatHistory (session_id, role, message)
+    SELECT ?, ?, ?
+    WHERE EXISTS (
+      SELECT 1 FROM AiChatSession WHERE session_id = ? AND moderation_flagged = 0
+    )
+  `,
   GET_HISTORY: 'SELECT * FROM AiChatHistory WHERE session_id = ? ORDER BY id DESC LIMIT ?',
   GET_LAST_USER_HISTORY: `
     SELECT id, message FROM AiChatHistory

--- a/database/queries/aiChatQueries.ts
+++ b/database/queries/aiChatQueries.ts
@@ -41,6 +41,10 @@ const aiChatQueries = {
   RENAME_SESSION: 'UPDATE AiChatSession SET title = ? WHERE session_id = ?',
   ACTIVATE_SESSION: 'UPDATE AiChatSession SET active = 1 WHERE session_id = ?',
   END_ALL_USER_PERSONA_SESSIONS: 'UPDATE AiChatSession SET active = 0 WHERE user_id = ? AND persona_name = ?',
+  // Content-safety pause. `active` is deliberately left alone: deactivating
+  // would make getOrCreateSession silently hand out a fresh session on the very
+  // next message, which is the opposite of pausing.
+  FLAG_SESSION_MODERATION: 'UPDATE AiChatSession SET moderation_flagged = 1, moderation_categories = ? WHERE session_id = ?',
 
   // History management
   ADD_HISTORY: 'INSERT INTO AiChatHistory (session_id, role, message) VALUES (?, ?, ?)',

--- a/database/tables/aiChatSessionTable.ts
+++ b/database/tables/aiChatSessionTable.ts
@@ -12,6 +12,12 @@ export interface AiChatSessionRow {
   // (web never sets active=1, so it can't collide with the bot's per-persona
   // active-session unique index).
   source: string;
+  // 1 once the content-safety screen (utils/aiModeration.ts) rejected a turn in
+  // this session. Permanently pauses it — the session stays active/visible so
+  // the user still sees their history, but no further turns are generated.
+  moderation_flagged: number;
+  /** Comma-separated safety categories from the screen, when it reported any. */
+  moderation_categories: string | null;
 }
 
 const aiChatSessionTable: TableDefinition = {
@@ -24,6 +30,8 @@ const aiChatSessionTable: TableDefinition = {
     { name: 'created_at', type: 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP' },
     { name: 'title', type: 'TEXT DEFAULT NULL' },
     { name: 'source', type: "TEXT NOT NULL DEFAULT 'discord'" },
+    { name: 'moderation_flagged', type: 'INTEGER NOT NULL DEFAULT 0' },
+    { name: 'moderation_categories', type: 'TEXT DEFAULT NULL' },
   ],
   primaryKey: ['session_id'],
   specialConstraints: [],

--- a/site_src/pages/games/ai-slop.ts
+++ b/site_src/pages/games/ai-slop.ts
@@ -989,6 +989,12 @@ export function AiSlopPage(opts: {
       toolCallCount: d.toolCallCount,
     });
 
+    // Safety filters paused this chat: the reply above is the pause notice, and
+    // the turn was not saved. Further sends on this session are refused.
+    if (d.moderationPaused) {
+      setError('This chat has been paused by safety filters. Start a new chat to continue.');
+    }
+
     if (wasNew) {
       addSessionToSidebar(d.personaName, d.sessionId, d.title || 'Chat ' + d.sessionId);
       setHead(d.title || ('Chat ' + d.sessionId), d.personaName);

--- a/site_src/pages/games/ai-slop.ts
+++ b/site_src/pages/games/ai-slop.ts
@@ -682,6 +682,8 @@ export function AiSlopPage(opts: {
   let currentPersona = PERSONAS[0];
   let hasMessages = false;
   let sending = false;
+  // Set when the server reports this session was paused by safety filters.
+  let sessionPaused = false;
 
   function escapeHtml(s) {
     return String(s).replace(/[&<>"']/g, (ch) => {
@@ -703,9 +705,16 @@ export function AiSlopPage(opts: {
 
   function setSending(s) {
     sending = s;
-    sendBtn.disabled = s;
-    textarea.disabled = s;
+    // A session paused by safety filters stays locked regardless of send state:
+    // further submissions would only render optimistic turns the server refuses.
+    sendBtn.disabled = s || sessionPaused;
+    textarea.disabled = s || sessionPaused;
     modelSel.disabled = s || hasMessages || currentSessionId != null;
+  }
+
+  function setSessionPaused(p) {
+    sessionPaused = p;
+    setSending(sending);
   }
 
   function updateSelectorLock() {
@@ -884,6 +893,7 @@ export function AiSlopPage(opts: {
   function newChat() {
     currentSessionId = null;
     hasMessages = false;
+    setSessionPaused(false);
     setHead('New chat', currentPersona);
     renderEmptyState();
     setError('');
@@ -894,6 +904,9 @@ export function AiSlopPage(opts: {
 
   async function loadSession(sessionId, fallbackPersona) {
     setError('');
+    // The lock is per-session; switching away from a paused chat unlocks the
+    // composer (the server re-checks the target session on send regardless).
+    setSessionPaused(false);
     let data;
     try {
       const r = await fetch('/games/ai-slop/session/' + encodeURIComponent(sessionId) + '/messages');
@@ -992,6 +1005,7 @@ export function AiSlopPage(opts: {
     // Safety filters paused this chat: the reply above is the pause notice, and
     // the turn was not saved. Further sends on this session are refused.
     if (d.moderationPaused) {
+      setSessionPaused(true);
       setError('This chat has been paused by safety filters. Start a new chat to continue.');
     }
 

--- a/site_src/routes/ai-slop-api.ts
+++ b/site_src/routes/ai-slop-api.ts
@@ -11,6 +11,9 @@ import {
   WEEKLY_LIMIT,
 } from '../../utils/ai';
 import { trimHistoryToFit } from '../../utils/tokenizer';
+import {
+  isModerationEnabled, moderateExchange, MODERATION_PAUSED_MESSAGE, type ModerationVerdict,
+} from '../../utils/aiModeration';
 import { type AppEnv, authedGameRequest, readGameBody } from '../shared';
 import { isAllowedPersona } from './ai-slop-personas';
 
@@ -137,6 +140,37 @@ export function registerAiSlopApiRoutes(app: Hono<AppEnv>, silverwolf: Silverwol
       if (!persona) return c.json({ ok: false, error: 'persona_not_found' }, 400);
     }
 
+    // Content-safety gate (global `ai_moderation` switch). The pause notice is
+    // returned as the assistant's own reply so it renders in the persona's
+    // bubble, matching the Discord surface; the turn itself is never persisted.
+    const moderationOn = await isModerationEnabled(silverwolf.db);
+    const pausedResponse = (sessionId: number) => c.json({
+      ok: true,
+      data: {
+        sessionId,
+        personaName: session.personaName,
+        assistant: MODERATION_PAUSED_MESSAGE,
+        toolCallCount: 0,
+        moderationPaused: true,
+      },
+    });
+    const pauseSession = async (verdict: ModerationVerdict) => {
+      try {
+        await silverwolf.db.aiChat.flagSessionModeration(session.sessionId, verdict.categories);
+      } catch (flagErr) {
+        logError('[ai-slop] failed to flag session for moderation:', flagErr);
+      }
+    };
+
+    if (moderationOn) {
+      if (session.moderationFlagged) return pausedResponse(session.sessionId);
+      const inboundVerdict = await moderateExchange(messageRaw);
+      if (!inboundVerdict.safe) {
+        await pauseSession(inboundVerdict);
+        return pausedResponse(session.sessionId);
+      }
+    }
+
     let assistantText = '';
     let title: string | undefined;
     try {
@@ -174,6 +208,15 @@ export function registerAiSlopApiRoutes(app: Hono<AppEnv>, silverwolf: Silverwol
         webSearchEnabled: persona.webSearchEnabled,
       });
       assistantText = (result.text || '').toString();
+
+      // Post-screen the full exchange before anything is delivered or persisted.
+      if (moderationOn) {
+        const outboundVerdict = await moderateExchange(messageRaw, assistantText);
+        if (!outboundVerdict.safe) {
+          await pauseSession(outboundVerdict);
+          return pausedResponse(session.sessionId);
+        }
+      }
 
       // Persist: user → tool audit rows (if any) → assistant. Match the bot's order.
       await silverwolf.db.aiChat.addHistory(session.sessionId, 'user', messageRaw);

--- a/site_src/routes/ai-slop-api.ts
+++ b/site_src/routes/ai-slop-api.ts
@@ -14,6 +14,7 @@ import { trimHistoryToFit } from '../../utils/tokenizer';
 import {
   isModerationEnabled, moderateExchange, MODERATION_PAUSED_MESSAGE, type ModerationVerdict,
 } from '../../utils/aiModeration';
+import { withAiSessionLock } from '../../utils/aiSessionLock';
 import { type AppEnv, authedGameRequest, readGameBody } from '../shared';
 import { isAllowedPersona } from './ai-slop-personas';
 
@@ -140,175 +141,181 @@ export function registerAiSlopApiRoutes(app: Hono<AppEnv>, silverwolf: Silverwol
       if (!persona) return c.json({ ok: false, error: 'persona_not_found' }, 400);
     }
 
-    // Content-safety gate (global `ai_moderation` switch). The pause notice is
-    // returned as the assistant's own reply so it renders in the persona's
-    // bubble, matching the Discord surface; the turn itself is never persisted.
-    const moderationOn = await isModerationEnabled(silverwolf.db);
-    const pausedResponse = (sessionId: number) => c.json({
-      ok: true,
-      data: {
-        sessionId,
-        personaName: session.personaName,
-        assistant: MODERATION_PAUSED_MESSAGE,
-        toolCallCount: 0,
-        moderationPaused: true,
-      },
-    });
-    const pauseSession = async (verdict: ModerationVerdict) => {
-      try {
-        const flagged = await silverwolf.db.aiChat.flagSessionModeration(
-          session.sessionId,
-          verdict.categories,
-        );
-        // This turn is refused regardless, but an unflagged session would let
-        // the next one through — that must not be silent.
-        if (!flagged) {
-          logError(`[ai-slop] content-safety pause did not persist for session ${session.sessionId}; session may resume`);
-        }
-      } catch (flagErr) {
-        logError('[ai-slop] failed to flag session for moderation:', flagErr);
-      }
-    };
-
-    /** Re-read the pause state; a concurrent send may have flagged it since. */
-    const isPausedNow = async (): Promise<boolean> => {
-      if (!moderationOn) return false;
-      const fresh = await silverwolf.db.aiChat.getSessionById(session.sessionId);
-      return !!fresh?.moderationFlagged;
-    };
-
-    if (moderationOn) {
-      if (session.moderationFlagged) return pausedResponse(session.sessionId);
-      const inboundVerdict = await moderateExchange(messageRaw);
-      if (!inboundVerdict.safe) {
-        await pauseSession(inboundVerdict);
-        return pausedResponse(session.sessionId);
-      }
-    }
-
-    let assistantText = '';
-    let title: string | undefined;
-    try {
-      // Load history, filter tool rows (audit-only), then trim to fit context.
-      const rawHistory = isFirstTurn
-        ? []
-        : await silverwolf.db.aiChat.getHistory(session.sessionId, HISTORY_FETCH_LIMIT);
-      const filtered = rawHistory.filter((h: { role: string }) => h.role !== 'tool');
-
-      let historyForAi: { role: string; message: string }[] = filtered as any;
-      try {
-        const { trimmedHistory } = await trimHistoryToFit(
-          persona.provider,
-          persona.model,
-          persona.systemPrompt ?? '',
-          filtered as any,
-          messageRaw,
-          persona.webSearchEnabled,
-        );
-        historyForAi = trimmedHistory;
-      } catch (trimErr) {
-        // System+prompt alone exceeds budget — surface a clean error.
-        logWarning(`[ai-slop] history trim failed: ${(trimErr as Error).message}`);
-        return c.json({ ok: false, error: 'message_too_long' }, 400);
-      }
-
-      const result = await generateContent({
-        db: silverwolf.db,
-        userId: auth.discordId,
-        provider: persona.provider,
-        model: persona.model,
-        systemPrompt: persona.systemPrompt ?? '',
-        prompt: messageRaw,
-        history: historyForAi,
-        webSearchEnabled: persona.webSearchEnabled,
-      });
-      assistantText = (result.text || '').toString();
-
-      // Post-screen the full exchange before anything is delivered or persisted.
-      if (moderationOn) {
-        const outboundVerdict = await moderateExchange(messageRaw, assistantText);
-        if (!outboundVerdict.safe) {
-          await pauseSession(outboundVerdict);
-          return pausedResponse(session.sessionId);
-        }
-        // A concurrent send may have paused this session while we were
-        // generating; don't deliver or persist into a chat that is now paused.
-        if (await isPausedNow()) return pausedResponse(session.sessionId);
-      }
-
-      // Persist: user → tool audit rows (if any) → assistant. Match the bot's order.
-      await silverwolf.db.aiChat.addHistory(session.sessionId, 'user', messageRaw);
-      if (result.toolCalls && result.toolCalls.length > 0) {
-        for (const tc of result.toolCalls) {
-          // eslint-disable-next-line no-await-in-loop
-          await silverwolf.db.aiChat.addHistory(
-            session.sessionId,
-            'tool',
-            JSON.stringify(tc),
-          );
-        }
-      }
-      const aiRole = persona.provider === 'openrouter' ? 'assistant' : 'model';
-      if (assistantText) {
-        await silverwolf.db.aiChat.addHistory(session.sessionId, aiRole, assistantText);
-      }
-
-      if (isFirstTurn && assistantText) {
-        try {
-          const history = await silverwolf.db.aiChat.getHistory(session.sessionId, 100);
-          title = (await generateTitleForHistory(history)) ?? undefined;
-          if (title) await silverwolf.db.aiChat.updateTitle(session.sessionId, title);
-        } catch (titleErr) {
-          logError('[ai-slop] title generation failed:', titleErr);
-          const fallback = messageRaw.slice(0, 50).trim().slice(0, MAX_TITLE_CHARS).trim();
-          if (fallback) {
-            title = fallback;
-            await silverwolf.db.aiChat.updateTitle(session.sessionId, fallback);
-          }
-        }
-      }
-
-      return c.json({
+    // Everything from the pause check through persistence and the reply runs
+    // under a per-session lock. The check and the history insert are separate
+    // operations, so without serialization a concurrent send could flag the
+    // session in between and this turn would still land in a paused chat.
+    return withAiSessionLock(session.sessionId, async () => {
+      // Content-safety gate (global `ai_moderation` switch). The pause notice is
+      // returned as the assistant's own reply so it renders in the persona's
+      // bubble, matching the Discord surface; the turn itself is never persisted.
+      const moderationOn = await isModerationEnabled(silverwolf.db);
+      const pausedResponse = (sessionId: number) => c.json({
         ok: true,
         data: {
-          sessionId: session.sessionId,
+          sessionId,
           personaName: session.personaName,
-          assistant: assistantText,
-          toolCallCount: result.toolCalls?.length ?? 0,
-          title,
+          assistant: MODERATION_PAUSED_MESSAGE,
+          toolCallCount: 0,
+          moderationPaused: true,
         },
       });
-    } catch (err: any) {
-      if (err?.message === 'RATE_LIMIT_EXCEEDED') {
-        const dailyUsage = await silverwolf.db.aiUsage.getDailyUsage(auth.discordId);
-        const weeklyUsage = await silverwolf.db.aiUsage.getWeeklyUsage(auth.discordId);
-        let reason: 'daily' | 'weekly';
-        if (err.reason === 'daily' || err.reason === 'weekly') {
-          reason = err.reason;
-        } else if (dailyUsage >= DAILY_LIMIT) {
-          reason = 'daily';
-        } else if (weeklyUsage >= WEEKLY_LIMIT) {
-          reason = 'weekly';
-        } else {
-          reason = (dailyUsage / DAILY_LIMIT) >= (weeklyUsage / WEEKLY_LIMIT) ? 'daily' : 'weekly';
+      const pauseSession = async (verdict: ModerationVerdict) => {
+        try {
+          const flagged = await silverwolf.db.aiChat.flagSessionModeration(
+            session.sessionId,
+            verdict.categories,
+          );
+          // This turn is refused regardless, but an unflagged session would let
+          // the next one through — that must not be silent.
+          if (!flagged) {
+            logError(`[ai-slop] content-safety pause did not persist for session ${session.sessionId}; session may resume`);
+          }
+        } catch (flagErr) {
+          logError('[ai-slop] failed to flag session for moderation:', flagErr);
         }
-        return c.json({
-          ok: false,
-          error: 'rate_limited' as const,
-          reason,
-          reservedCredits: err.reservedCredits,
-          remainingCredits: err.remainingCredits,
-          dailyUsage,
-          weeklyUsage,
-        }, 429);
+      };
+
+      /** Re-read the pause state; a concurrent send may have flagged it since. */
+      const isPausedNow = async (): Promise<boolean> => {
+        if (!moderationOn) return false;
+        const fresh = await silverwolf.db.aiChat.getSessionById(session.sessionId);
+        return !!fresh?.moderationFlagged;
+      };
+
+      if (moderationOn) {
+        if (session.moderationFlagged) return pausedResponse(session.sessionId);
+        const inboundVerdict = await moderateExchange(messageRaw);
+        if (!inboundVerdict.safe) {
+          await pauseSession(inboundVerdict);
+          return pausedResponse(session.sessionId);
+        }
       }
-      logError('[ai-slop] send failed:', err);
-      // If this was a brand-new session and the AI call failed without producing
-      // any history, leave the empty session in place rather than rolling back —
-      // the user can retry the same chat. They can also delete it from the
-      // sidebar.
-      return c.json({ ok: false, error: 'server' }, 500);
-    }
+
+      let assistantText = '';
+      let title: string | undefined;
+      try {
+        // Load history, filter tool rows (audit-only), then trim to fit context.
+        const rawHistory = isFirstTurn
+          ? []
+          : await silverwolf.db.aiChat.getHistory(session.sessionId, HISTORY_FETCH_LIMIT);
+        const filtered = rawHistory.filter((h: { role: string }) => h.role !== 'tool');
+
+        let historyForAi: { role: string; message: string }[] = filtered as any;
+        try {
+          const { trimmedHistory } = await trimHistoryToFit(
+            persona.provider,
+            persona.model,
+            persona.systemPrompt ?? '',
+            filtered as any,
+            messageRaw,
+            persona.webSearchEnabled,
+          );
+          historyForAi = trimmedHistory;
+        } catch (trimErr) {
+          // System+prompt alone exceeds budget — surface a clean error.
+          logWarning(`[ai-slop] history trim failed: ${(trimErr as Error).message}`);
+          return c.json({ ok: false, error: 'message_too_long' }, 400);
+        }
+
+        const result = await generateContent({
+          db: silverwolf.db,
+          userId: auth.discordId,
+          provider: persona.provider,
+          model: persona.model,
+          systemPrompt: persona.systemPrompt ?? '',
+          prompt: messageRaw,
+          history: historyForAi,
+          webSearchEnabled: persona.webSearchEnabled,
+        });
+        assistantText = (result.text || '').toString();
+
+        // Post-screen the full exchange before anything is delivered or persisted.
+        if (moderationOn) {
+          const outboundVerdict = await moderateExchange(messageRaw, assistantText);
+          if (!outboundVerdict.safe) {
+            await pauseSession(outboundVerdict);
+            return pausedResponse(session.sessionId);
+          }
+          // A concurrent send may have paused this session while we were
+          // generating; don't deliver or persist into a chat that is now paused.
+          if (await isPausedNow()) return pausedResponse(session.sessionId);
+        }
+
+        // Persist: user → tool audit rows (if any) → assistant. Match the bot's order.
+        await silverwolf.db.aiChat.addHistory(session.sessionId, 'user', messageRaw);
+        if (result.toolCalls && result.toolCalls.length > 0) {
+          for (const tc of result.toolCalls) {
+            // eslint-disable-next-line no-await-in-loop
+            await silverwolf.db.aiChat.addHistory(
+              session.sessionId,
+              'tool',
+              JSON.stringify(tc),
+            );
+          }
+        }
+        const aiRole = persona.provider === 'openrouter' ? 'assistant' : 'model';
+        if (assistantText) {
+          await silverwolf.db.aiChat.addHistory(session.sessionId, aiRole, assistantText);
+        }
+
+        if (isFirstTurn && assistantText) {
+          try {
+            const history = await silverwolf.db.aiChat.getHistory(session.sessionId, 100);
+            title = (await generateTitleForHistory(history)) ?? undefined;
+            if (title) await silverwolf.db.aiChat.updateTitle(session.sessionId, title);
+          } catch (titleErr) {
+            logError('[ai-slop] title generation failed:', titleErr);
+            const fallback = messageRaw.slice(0, 50).trim().slice(0, MAX_TITLE_CHARS).trim();
+            if (fallback) {
+              title = fallback;
+              await silverwolf.db.aiChat.updateTitle(session.sessionId, fallback);
+            }
+          }
+        }
+
+        return c.json({
+          ok: true,
+          data: {
+            sessionId: session.sessionId,
+            personaName: session.personaName,
+            assistant: assistantText,
+            toolCallCount: result.toolCalls?.length ?? 0,
+            title,
+          },
+        });
+      } catch (err: any) {
+        if (err?.message === 'RATE_LIMIT_EXCEEDED') {
+          const dailyUsage = await silverwolf.db.aiUsage.getDailyUsage(auth.discordId);
+          const weeklyUsage = await silverwolf.db.aiUsage.getWeeklyUsage(auth.discordId);
+          let reason: 'daily' | 'weekly';
+          if (err.reason === 'daily' || err.reason === 'weekly') {
+            reason = err.reason;
+          } else if (dailyUsage >= DAILY_LIMIT) {
+            reason = 'daily';
+          } else if (weeklyUsage >= WEEKLY_LIMIT) {
+            reason = 'weekly';
+          } else {
+            reason = (dailyUsage / DAILY_LIMIT) >= (weeklyUsage / WEEKLY_LIMIT) ? 'daily' : 'weekly';
+          }
+          return c.json({
+            ok: false,
+            error: 'rate_limited' as const,
+            reason,
+            reservedCredits: err.reservedCredits,
+            remainingCredits: err.remainingCredits,
+            dailyUsage,
+            weeklyUsage,
+          }, 429);
+        }
+        logError('[ai-slop] send failed:', err);
+        // If this was a brand-new session and the AI call failed without producing
+        // any history, leave the empty session in place rather than rolling back —
+        // the user can retry the same chat. They can also delete it from the
+        // sidebar.
+        return c.json({ ok: false, error: 'server' }, 500);
+      }
+    });
   });
 
   app.post('/games/ai-slop/session/rename', async (c) => {

--- a/site_src/routes/ai-slop-api.ts
+++ b/site_src/routes/ai-slop-api.ts
@@ -156,10 +156,25 @@ export function registerAiSlopApiRoutes(app: Hono<AppEnv>, silverwolf: Silverwol
     });
     const pauseSession = async (verdict: ModerationVerdict) => {
       try {
-        await silverwolf.db.aiChat.flagSessionModeration(session.sessionId, verdict.categories);
+        const flagged = await silverwolf.db.aiChat.flagSessionModeration(
+          session.sessionId,
+          verdict.categories,
+        );
+        // This turn is refused regardless, but an unflagged session would let
+        // the next one through — that must not be silent.
+        if (!flagged) {
+          logError(`[ai-slop] content-safety pause did not persist for session ${session.sessionId}; session may resume`);
+        }
       } catch (flagErr) {
         logError('[ai-slop] failed to flag session for moderation:', flagErr);
       }
+    };
+
+    /** Re-read the pause state; a concurrent send may have flagged it since. */
+    const isPausedNow = async (): Promise<boolean> => {
+      if (!moderationOn) return false;
+      const fresh = await silverwolf.db.aiChat.getSessionById(session.sessionId);
+      return !!fresh?.moderationFlagged;
     };
 
     if (moderationOn) {
@@ -216,6 +231,9 @@ export function registerAiSlopApiRoutes(app: Hono<AppEnv>, silverwolf: Silverwol
           await pauseSession(outboundVerdict);
           return pausedResponse(session.sessionId);
         }
+        // A concurrent send may have paused this session while we were
+        // generating; don't deliver or persist into a chat that is now paused.
+        if (await isPausedNow()) return pausedResponse(session.sessionId);
       }
 
       // Persist: user → tool audit rows (if any) → assistant. Match the bot's order.

--- a/site_src/routes/ai-slop-api.ts
+++ b/site_src/routes/ai-slop-api.ts
@@ -184,7 +184,10 @@ export function registerAiSlopApiRoutes(app: Hono<AppEnv>, silverwolf: Silverwol
       };
 
       if (moderationOn) {
-        if (session.moderationFlagged) return pausedResponse(session.sessionId);
+        // Fresh read, not the pre-lock snapshot: a send queued behind one that
+        // paused the session would otherwise pass this check and run a paid
+        // generation before the delivery guard caught it.
+        if (await isPausedNow()) return pausedResponse(session.sessionId);
         const inboundVerdict = await moderateExchange(messageRaw);
         if (!inboundVerdict.safe) {
           await pauseSession(inboundVerdict);

--- a/tests/database/aiChatModeration.test.ts
+++ b/tests/database/aiChatModeration.test.ts
@@ -1,0 +1,114 @@
+import Database from '../../database/Database';
+import type AiChatModel from '../../database/models/AiChatModel';
+
+// The content-safety pause is enforced partly in SQL (ADD_HISTORY is conditional
+// on moderation_flagged = 0), so it needs a real database to verify.
+describe('AiChatModel content-safety pause', () => {
+  let db: Database;
+  let aiChat: AiChatModel;
+
+  beforeAll(async () => {
+    db = new Database(`./tests/temp/testAiChatModeration-${Date.now()}.db`);
+    await db.ready;
+    aiChat = db.aiChat;
+  });
+
+  afterAll(() => {
+    db.db.close();
+  });
+
+  beforeEach(async () => {
+    await db.executeQuery('DELETE FROM AiChatHistory');
+    await db.executeQuery('DELETE FROM AiChatSession');
+  });
+
+  async function newSession(userId = 'u-mod') {
+    const session = await aiChat.getOrCreateSession(userId, 'Grok');
+    return session!.sessionId as number;
+  }
+
+  describe('flagSessionModeration', () => {
+    it('flags the session and reports success', async () => {
+      const sessionId = await newSession();
+      expect(await aiChat.flagSessionModeration(sessionId, 'Violence')).toBe(true);
+
+      const row = await aiChat.getSessionById(sessionId);
+      expect(row!.moderationFlagged).toBe(1);
+      expect(row!.moderationCategories).toBe('Violence');
+    });
+
+    it('leaves the session active so getOrCreateSession keeps refusing it', async () => {
+      const sessionId = await newSession();
+      await aiChat.flagSessionModeration(sessionId);
+
+      const row = await aiChat.getSessionById(sessionId);
+      expect(row!.active).toBe(1);
+      // Same row comes back rather than a fresh, unflagged one.
+      const again = await aiChat.getOrCreateSession('u-mod', 'Grok');
+      expect(again!.sessionId).toBe(sessionId);
+      expect(again!.moderationFlagged).toBe(1);
+    });
+
+    it('reports failure for a session that does not exist', async () => {
+      expect(await aiChat.flagSessionModeration(999999)).toBe(false);
+    });
+
+    it('reports failure for an invalid session id instead of writing', async () => {
+      expect(await aiChat.flagSessionModeration(0)).toBe(false);
+      expect(await aiChat.flagSessionModeration(-1)).toBe(false);
+      expect(await aiChat.flagSessionModeration(NaN)).toBe(false);
+    });
+
+    it('normalizes blank categories to null', async () => {
+      const sessionId = await newSession();
+      await aiChat.flagSessionModeration(sessionId, '   ');
+      expect((await aiChat.getSessionById(sessionId))!.moderationCategories).toBeNull();
+    });
+  });
+
+  describe('addHistory', () => {
+    it('writes normally while the session is unflagged', async () => {
+      const sessionId = await newSession();
+      expect(await aiChat.addHistory(sessionId, 'user', 'hello')).toBe(true);
+      expect(await aiChat.getHistory(sessionId)).toHaveLength(1);
+    });
+
+    // The race this closes: a turn that began before another turn paused the
+    // session must not be able to persist into it afterwards.
+    it('refuses to write into a paused session', async () => {
+      const sessionId = await newSession();
+      await aiChat.addHistory(sessionId, 'user', 'before');
+      await aiChat.flagSessionModeration(sessionId, 'Violence');
+
+      expect(await aiChat.addHistory(sessionId, 'user', 'after')).toBe(false);
+      expect(await aiChat.addHistory(sessionId, 'assistant', 'reply')).toBe(false);
+
+      const history = await aiChat.getHistory(sessionId);
+      expect(history).toHaveLength(1);
+      expect(history[0].message).toBe('before');
+    });
+  });
+
+  describe('undoLastTurn', () => {
+    it('is refused on a paused session', async () => {
+      const sessionId = await newSession();
+      await aiChat.addHistory(sessionId, 'user', 'hello');
+      await aiChat.flagSessionModeration(sessionId);
+
+      const result = await aiChat.undoLastTurn('u-mod', 'Grok');
+      expect(result).toEqual({ ok: false, reason: 'paused' });
+      // The earlier legitimate turn is still there.
+      expect(await aiChat.getHistory(sessionId)).toHaveLength(1);
+    });
+
+    it('proceeds when the master switch is off', async () => {
+      const sessionId = await newSession();
+      await aiChat.addHistory(sessionId, 'user', 'hello');
+      await aiChat.flagSessionModeration(sessionId);
+
+      const result = await aiChat.undoLastTurn('u-mod', 'Grok', false);
+      expect(result.ok).toBe(true);
+      expect(await aiChat.getHistory(sessionId)).toHaveLength(0);
+    });
+  });
+});

--- a/tests/utils/aiModeration.test.ts
+++ b/tests/utils/aiModeration.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'bun:test';
+import { parseModerationOutput } from '../../utils/aiModeration';
+import { GLOBAL_CONFIG_KEYS, validateGlobalConfigValue } from '../../utils/globalConfig';
+
+// The four strings below are verbatim responses from
+// nvidia/nemotron-3.5-content-safety:free, captured against OpenRouter.
+describe('parseModerationOutput', () => {
+  test('user-only screen, benign — no Response Safety line', () => {
+    expect(parseModerationOutput('User Safety: safe')).toEqual({ safe: true });
+  });
+
+  test('full exchange, benign', () => {
+    expect(parseModerationOutput('User Safety: safe\nResponse Safety: safe')).toEqual({ safe: true });
+  });
+
+  test('user-only screen, unsafe', () => {
+    expect(parseModerationOutput(
+      'User Safety: unsafe\nSafety Categories: Guns and Illegal Weapons, Criminal Planning/Confessions',
+    )).toEqual({
+      safe: false,
+      flaggedSide: 'user',
+      categories: 'Guns and Illegal Weapons, Criminal Planning/Confessions',
+    });
+  });
+
+  test('full exchange, unsafe on both sides — reports the user side', () => {
+    expect(parseModerationOutput(
+      'User Safety: unsafe\nResponse Safety: unsafe\nSafety Categories: Harassment, Criminal Planning/Confessions, Violence',
+    )).toEqual({
+      safe: false,
+      flaggedSide: 'user',
+      categories: 'Harassment, Criminal Planning/Confessions, Violence',
+    });
+  });
+
+  test('safe prompt with an unsafe reply is attributed to the response', () => {
+    expect(parseModerationOutput('User Safety: safe\nResponse Safety: unsafe\nSafety Categories: Violence')).toEqual({
+      safe: false,
+      flaggedSide: 'response',
+      categories: 'Violence',
+    });
+  });
+
+  test('strips a reasoning-mode <think> block before reading labels', () => {
+    expect(parseModerationOutput(
+      '<think>The user is asking about weapons. User Safety: safe is wrong here.</think>\nUser Safety: unsafe',
+    )).toEqual({ safe: false, flaggedSide: 'user', categories: undefined });
+  });
+
+  test('fails open on empty or unparseable output', () => {
+    expect(parseModerationOutput('')).toEqual({ safe: true });
+    expect(parseModerationOutput('   ')).toEqual({ safe: true });
+    expect(parseModerationOutput('I cannot classify this.')).toEqual({ safe: true });
+    expect(parseModerationOutput('User Safety: perhaps')).toEqual({ safe: true });
+  });
+});
+
+describe('ai_moderation global config key', () => {
+  test('is a 0/1 boolean key', () => {
+    expect(validateGlobalConfigValue(GLOBAL_CONFIG_KEYS.AI_MODERATION, '0')).toBeNull();
+    expect(validateGlobalConfigValue(GLOBAL_CONFIG_KEYS.AI_MODERATION, '1')).toBeNull();
+    expect(validateGlobalConfigValue(GLOBAL_CONFIG_KEYS.AI_MODERATION, 'on')).not.toBeNull();
+  });
+});

--- a/tests/utils/aiModeration.test.ts
+++ b/tests/utils/aiModeration.test.ts
@@ -47,6 +47,28 @@ describe('parseModerationOutput', () => {
     )).toEqual({ safe: false, flaggedSide: 'user', categories: undefined });
   });
 
+  test('handles a dangling </think> with no opening tag', () => {
+    // Some models emit only the closer because the opener is in the chat
+    // template. Everything before it is reasoning that may quote a label.
+    expect(parseModerationOutput(
+      'The user asks about knives. User Safety: safe would be wrong.\n</think>\nUser Safety: unsafe\nSafety Categories: Violence',
+    )).toEqual({ safe: false, flaggedSide: 'user', categories: 'Violence' });
+  });
+
+  test('reads the last label occurrence, not the first', () => {
+    expect(parseModerationOutput('User Safety: safe\nUser Safety: unsafe')).toEqual({
+      safe: false,
+      flaggedSide: 'user',
+      categories: undefined,
+    });
+  });
+
+  test('a safe verdict after a dangling think block stays safe', () => {
+    expect(parseModerationOutput(
+      'Considering whether User Safety: unsafe applies.\n</think>\nUser Safety: safe\nResponse Safety: safe',
+    )).toEqual({ safe: true });
+  });
+
   test('fails open on empty or unparseable output', () => {
     expect(parseModerationOutput('')).toEqual({ safe: true });
     expect(parseModerationOutput('   ')).toEqual({ safe: true });

--- a/utils/aiModeration.ts
+++ b/utils/aiModeration.ts
@@ -48,7 +48,16 @@ const MAX_SCREENED_CHARS = 8000;
 const MODERATION_MAX_TOKENS = 512;
 
 /** Classification is on the critical path of every message; don't wait long. */
-const MODERATION_TIMEOUT_MS = 30_000;
+const MODERATION_TIMEOUT_MS = 15_000;
+
+/**
+ * Total budget across retries, deliberately close to the per-attempt timeout.
+ * `createChatCompletionWithRetry` retries on 429/5xx/network, and the screen runs
+ * twice per turn — a generous overall budget would let a degraded free classifier
+ * add minutes of latency before the turn fails open. This leaves room for one
+ * fast retry on a transient blip and no more.
+ */
+const MODERATION_OVERALL_TIMEOUT_MS = 20_000;
 
 export interface ModerationVerdict {
   /** False when the exchange must not continue — the only field callers must act on. */
@@ -78,15 +87,31 @@ function truncate(text: string): string {
   return trimmed.length > MAX_SCREENED_CHARS ? trimmed.slice(0, MAX_SCREENED_CHARS) : trimmed;
 }
 
-/** Strips a reasoning-mode `<think>…</think>` preamble from the classifier output. */
+/**
+ * Strips a reasoning-mode `<think>…</think>` preamble from the classifier output.
+ *
+ * Handles the dangling-closer case too: some models emit only `</think>` because
+ * the opening tag lives in the chat template. Everything before that closer is
+ * reasoning — and a trace routinely *quotes* a label ("...so User Safety: unsafe
+ * would be wrong here"), so failing to cut it lets `readLabel` pick a sentence
+ * out of the model's deliberation instead of its verdict.
+ */
 function stripThinking(raw: string): string {
-  return raw.replace(/<think>[\s\S]*?(?:<\/think>|$)/gi, '').trim();
+  const stripped = raw.replace(/<think>[\s\S]*?(?:<\/think>|$)/gi, '').trim();
+  const closeIdx = stripped.toLowerCase().lastIndexOf('</think>');
+  return closeIdx === -1 ? stripped : stripped.slice(closeIdx + '</think>'.length).trim();
 }
 
+/**
+ * Reads a label line. Takes the **last** match: the verdict is emitted at the
+ * end, so if any reasoning survived stripping, the final occurrence is the one
+ * that counts.
+ */
 function readLabel(raw: string, label: string): string | null {
   const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const match = raw.match(new RegExp(`^\\s*${escaped}\\s*:\\s*(.+)$`, 'im'));
-  return match ? match[1].trim() : null;
+  const matches = [...raw.matchAll(new RegExp(`^\\s*${escaped}\\s*:\\s*(.+)$`, 'img'))];
+  if (matches.length === 0) return null;
+  return matches[matches.length - 1][1].trim();
 }
 
 /**
@@ -153,9 +178,19 @@ export async function moderateExchange(
       model: persona.model,
       messages,
       max_tokens: MODERATION_MAX_TOKENS,
-    }, { timeoutMs: MODERATION_TIMEOUT_MS, overallTimeoutMs: MODERATION_TIMEOUT_MS * 2 });
+    }, {
+      timeoutMs: MODERATION_TIMEOUT_MS,
+      overallTimeoutMs: MODERATION_OVERALL_TIMEOUT_MS,
+    });
 
-    const verdict = parseModerationOutput(completion.choices?.[0]?.message?.content ?? '');
+    const rawOutput = completion.choices?.[0]?.message?.content ?? '';
+    const verdict = parseModerationOutput(rawOutput);
+    // A non-empty reply with no label means a truncated or malformed
+    // classification (e.g. a reasoning trace that ate the whole token budget).
+    // That fails open by design — but silently, so say so.
+    if (rawOutput.trim() && !/User Safety\s*:/i.test(rawOutput)) {
+      logWarning('[moderation] classifier returned no recognisable label; failing open');
+    }
     if (!verdict.safe) {
       log(`[moderation] flagged ${verdict.flaggedSide} turn${verdict.categories ? ` (${verdict.categories})` : ''}`);
     }

--- a/utils/aiModeration.ts
+++ b/utils/aiModeration.ts
@@ -1,0 +1,167 @@
+import type Database from '../database/Database';
+import { getOpenRouterClient, getPersonaByName } from './ai';
+import { createChatCompletionWithRetry } from './llmRetry';
+import { GLOBAL_CONFIG_KEYS } from './globalConfig';
+import { log, logError, logWarning } from './log';
+
+/**
+ * Content-safety screening for AI chats (`ai_moderation` in GlobalConfig).
+ *
+ * When enabled, every AI turn on a session-backed surface is screened by the
+ * "Moderation" persona — an NVIDIA Nemotron content-safety classifier, which
+ * takes no system prompt: you hand it the raw exchange and it emits plain-text
+ * labels, e.g.
+ *
+ *   User Safety: unsafe
+ *   Response Safety: safe
+ *   Safety Categories: Violence, Threat
+ *
+ * `Response Safety` is only emitted when an assistant turn was supplied, and a
+ * reasoning-mode model may wrap a `<think>` block around it all, so both are
+ * treated as optional.
+ *
+ * Screening runs twice per turn: on the user message alone before generating
+ * (so an unsafe prompt never reaches — or bills — the chat model), then on the
+ * user+assistant pair before the reply is delivered.
+ */
+
+/**
+ * Shown on session-backed surfaces, in the voice of the persona they were
+ * talking to. The session is paused for good — hence "start a new chat".
+ */
+export const MODERATION_PAUSED_MESSAGE = 'safety filters have paused this chat, please start a new chat';
+
+/**
+ * Shown on one-shot surfaces (`/summary`) that have no session to pause: the
+ * output is dropped and the next invocation starts clean, so telling the user
+ * to "start a new chat" would be nonsense.
+ */
+export const MODERATION_BLOCKED_MESSAGE = 'safety filters blocked this response.';
+
+/** Persona in data/aiPersonas.json holding the classifier's provider + model. */
+const MODERATION_PERSONA = 'Moderation';
+
+/** The classifier only needs enough text to judge; long PDFs/transcripts are cut. */
+const MAX_SCREENED_CHARS = 8000;
+
+/** Labels are a handful of lines — plus an optional reasoning trace. */
+const MODERATION_MAX_TOKENS = 512;
+
+/** Classification is on the critical path of every message; don't wait long. */
+const MODERATION_TIMEOUT_MS = 30_000;
+
+export interface ModerationVerdict {
+  /** False when the exchange must not continue — the only field callers must act on. */
+  safe: boolean;
+  /** Which side tripped the filter (undefined when `safe`). */
+  flaggedSide?: 'user' | 'response';
+  /** Comma-separated categories the classifier reported, when it reported any. */
+  categories?: string;
+}
+
+const SAFE_VERDICT: ModerationVerdict = { safe: true };
+
+/** True when the `ai_moderation` global switch is on. Defaults to off. */
+export async function isModerationEnabled(db: Database | undefined | null): Promise<boolean> {
+  if (!db) return false;
+  try {
+    const value = await db.globalConfig.getGlobalConfig(GLOBAL_CONFIG_KEYS.AI_MODERATION);
+    return value === '1';
+  } catch (err) {
+    logError('[moderation] failed to read ai_moderation config; treating as off:', err);
+    return false;
+  }
+}
+
+function truncate(text: string): string {
+  const trimmed = (text ?? '').toString().trim();
+  return trimmed.length > MAX_SCREENED_CHARS ? trimmed.slice(0, MAX_SCREENED_CHARS) : trimmed;
+}
+
+/** Strips a reasoning-mode `<think>…</think>` preamble from the classifier output. */
+function stripThinking(raw: string): string {
+  return raw.replace(/<think>[\s\S]*?(?:<\/think>|$)/gi, '').trim();
+}
+
+function readLabel(raw: string, label: string): string | null {
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = raw.match(new RegExp(`^\\s*${escaped}\\s*:\\s*(.+)$`, 'im'));
+  return match ? match[1].trim() : null;
+}
+
+/**
+ * Parses the classifier's plain-text labels. Anything that isn't a recognisable
+ * "unsafe" is treated as safe — an unparseable response is a broken classifier,
+ * not a verdict, and must not silently pause every chat on the bot.
+ */
+export function parseModerationOutput(rawOutput: string): ModerationVerdict {
+  const raw = stripThinking(rawOutput || '');
+  if (!raw) return SAFE_VERDICT;
+
+  const userSafety = readLabel(raw, 'User Safety')?.toLowerCase();
+  const responseSafety = readLabel(raw, 'Response Safety')?.toLowerCase();
+  const categories = readLabel(raw, 'Safety Categories') ?? undefined;
+
+  if (userSafety?.startsWith('unsafe')) {
+    return { safe: false, flaggedSide: 'user', categories };
+  }
+  if (responseSafety?.startsWith('unsafe')) {
+    return { safe: false, flaggedSide: 'response', categories };
+  }
+  return SAFE_VERDICT;
+}
+
+/**
+ * Screens one exchange. `assistantText` is omitted for the pre-generation pass.
+ *
+ * Fails open: a classifier outage, timeout, or garbled reply logs a warning and
+ * returns safe. Blocking every AI conversation on the availability of a free
+ * model would be a far worse failure than missing a screen.
+ */
+export async function moderateExchange(
+  userText: string,
+  assistantText?: string,
+): Promise<ModerationVerdict> {
+  const userContent = truncate(userText);
+  const assistantContent = truncate(assistantText ?? '');
+  if (!userContent && !assistantContent) return SAFE_VERDICT;
+
+  const persona = await getPersonaByName(MODERATION_PERSONA);
+  if (!persona) {
+    logWarning(`[moderation] no "${MODERATION_PERSONA}" persona configured; skipping screen`);
+    return SAFE_VERDICT;
+  }
+  if (persona.provider !== 'openrouter') {
+    logWarning(`[moderation] persona provider "${persona.provider}" unsupported; skipping screen`);
+    return SAFE_VERDICT;
+  }
+  if (!process.env.OPENROUTER_API_KEY) {
+    logWarning('[moderation] OPENROUTER_API_KEY not set; skipping screen');
+    return SAFE_VERDICT;
+  }
+
+  // No system prompt — the classifier's chat template supplies its own.
+  const messages: { role: 'user' | 'assistant'; content: string }[] = [
+    { role: 'user', content: userContent },
+  ];
+  if (assistantContent) {
+    messages.push({ role: 'assistant', content: assistantContent });
+  }
+
+  try {
+    const completion = await createChatCompletionWithRetry(getOpenRouterClient(), {
+      model: persona.model,
+      messages,
+      max_tokens: MODERATION_MAX_TOKENS,
+    }, { timeoutMs: MODERATION_TIMEOUT_MS, overallTimeoutMs: MODERATION_TIMEOUT_MS * 2 });
+
+    const verdict = parseModerationOutput(completion.choices?.[0]?.message?.content ?? '');
+    if (!verdict.safe) {
+      log(`[moderation] flagged ${verdict.flaggedSide} turn${verdict.categories ? ` (${verdict.categories})` : ''}`);
+    }
+    return verdict;
+  } catch (err) {
+    logError('[moderation] screen failed; allowing the turn through:', err);
+    return SAFE_VERDICT;
+  }
+}

--- a/utils/aiModeration.ts
+++ b/utils/aiModeration.ts
@@ -187,8 +187,10 @@ export async function moderateExchange(
     const verdict = parseModerationOutput(rawOutput);
     // A non-empty reply with no label means a truncated or malformed
     // classification (e.g. a reasoning trace that ate the whole token budget).
-    // That fails open by design — but silently, so say so.
-    if (rawOutput.trim() && !/User Safety\s*:/i.test(rawOutput)) {
+    // That fails open by design — but silently, so say so. Test the *cleaned*
+    // output: a label quoted inside a `<think>` preamble is not a verdict, and
+    // testing the raw text would let it suppress this warning.
+    if (rawOutput.trim() && !/User Safety\s*:/i.test(stripThinking(rawOutput))) {
       logWarning('[moderation] classifier returned no recognisable label; failing open');
     }
     if (!verdict.safe) {

--- a/utils/aiSessionLock.ts
+++ b/utils/aiSessionLock.ts
@@ -1,0 +1,26 @@
+import { withUserLock } from './userLock';
+
+/**
+ * Per-AI-session serialization.
+ *
+ * Content-safety pausing is a read-check-write across separate operations: a
+ * turn reads `moderation_flagged`, generates (seconds to minutes), then writes
+ * history and delivers. Without serialization a concurrent turn can flag the
+ * session in that gap, and the in-flight turn still lands — persisting into and
+ * replying from a chat that is now paused. Re-reading before the write narrows
+ * that window but cannot close it, because the read and the insert are not
+ * atomic.
+ *
+ * Holding this lock for the whole check → generate → persist → deliver sequence
+ * closes it. Two messages to the same conversation queue instead of racing,
+ * which is the desired behaviour for a chat session regardless of moderation.
+ *
+ * Deliberately a **separate registry** from `userLocks`: those chain the economy
+ * mutations, and an LLM call can run for minutes — sharing the registry would
+ * stall a user's `/claim` behind their own AI reply.
+ */
+const aiSessionLocks = new Map<string, Promise<any>>();
+
+export function withAiSessionLock<T>(sessionId: number, inner: () => Promise<T>): Promise<T> {
+  return withUserLock(aiSessionLocks, `ai-session:${sessionId}`, inner);
+}

--- a/utils/globalConfig.ts
+++ b/utils/globalConfig.ts
@@ -7,6 +7,7 @@ export const GLOBAL_CONFIG_KEYS = {
   ALLOWED_SERVERS: 'allowed_servers',
   BIRTHDAY_CHANNELS: 'birthday_channels',
   FOOTBALL_CHANNELS: 'football_channels',
+  AI_MODERATION: 'ai_moderation',
 } as const;
 
 export const GLOBAL_CHANNEL_LIST_KEYS = [
@@ -57,6 +58,11 @@ export const DOCUMENTED_GLOBAL_CONFIG_KEYS: {
     description: 'Channels that receive World Cup match announcements',
     defaultValue: 'none',
   },
+  {
+    key: GLOBAL_CONFIG_KEYS.AI_MODERATION,
+    description: 'Content-safety screening of AI chats. 0 = off, 1 = on (flagged chats are paused)',
+    defaultValue: '0',
+  },
 ];
 
 /** Keys managed via `/globalconfig set` (not list keys managed by register commands). */
@@ -68,6 +74,7 @@ export const SETTABLE_GLOBAL_VALUE_KEYS = DOCUMENTED_GLOBAL_CONFIG_KEYS.filter(
 const BOOLEAN_VALUE_KEYS = new Set<string>([
   GLOBAL_CONFIG_KEYS.FOOTBALL,
   GLOBAL_CONFIG_KEYS.BANNED,
+  GLOBAL_CONFIG_KEYS.AI_MODERATION,
 ]);
 
 const DOCUMENTED_KEY_SET = new Set<string>(DOCUMENTED_GLOBAL_CONFIG_KEYS.map((entry) => entry.key));

--- a/utils/rpChat.ts
+++ b/utils/rpChat.ts
@@ -3,6 +3,7 @@ import { countTokensOpenRouterMessages, countTokensOpenRouter } from './tokenize
 import { applyUserVar } from './rpIdentity';
 import { creditsForTokens, ESTIMATED_COMPLETION_TOKENS } from './aiPricing';
 import { createChatCompletionWithRetry } from './llmRetry';
+import { isModerationEnabled, moderateExchange } from './aiModeration';
 import {
   collectTriggeredContexts, findRecallMarkers, stripRecallMarkers, formatRecallMarker,
   INJECTION_MAX_TOKENS,
@@ -281,7 +282,7 @@ Output ONLY the updated memory wrapped exactly as ${MEMORY_OPEN}...${MEMORY_CLOS
 
 export type RpReplyResult =
   | { ok: true; text: string }
-  | { ok: false; reason: 'compaction_failed' | 'rate_limited' }
+  | { ok: false; reason: 'compaction_failed' | 'rate_limited' | 'moderation' }
   | { ok: false; reason: 'error' };
 
 async function loadTail(db: any, spawnId: number, afterId: number): Promise<RpHistoryTurn[]> {
@@ -368,6 +369,17 @@ export async function generateRpReply(
       if (isLimited) {
         return { ok: false, reason: 'rate_limited' };
       }
+    }
+
+    // Content-safety pre-screen on the turn that triggered this reply. Roleplay
+    // has no session to pause (spawns are long-lived and shared), so this is
+    // reply-and-drop: refuse this reply, leave the spawn alive. The offending
+    // turn stays in history, so a re-trigger is screened and refused again
+    // rather than silently slipping through.
+    const moderationOn = await isModerationEnabled(db);
+    if (moderationOn && lastUserTurn?.message) {
+      const inbound = await moderateExchange(lastUserTurn.message);
+      if (!inbound.safe) return { ok: false, reason: 'moderation' };
     }
 
     let totalPromptTokens = 0;
@@ -493,6 +505,15 @@ export async function generateRpReply(
 
     if (!text) return { ok: false, reason: 'error' };
 
+    // Post-screen the exchange before the line reaches the channel. Dropped
+    // replies are never delivered or persisted — but the tokens were already
+    // spent, so usage is still recorded below.
+    let moderationDropped = false;
+    if (moderationOn) {
+      const outbound = await moderateExchange(lastUserTurn?.message ?? '', text);
+      moderationDropped = !outbound.safe;
+    }
+
     // Log AI usage for all active human users involved in the tail
     const activeUsers = [...new Set(
       tail
@@ -505,6 +526,8 @@ export async function generateRpReply(
     for (const userId of activeUsers) {
       await db.aiUsage.addUsage(userId, RP_MODEL, totalPromptTokens, totalCompletionTokens);
     }
+
+    if (moderationDropped) return { ok: false, reason: 'moderation' };
 
     return { ok: true, text };
   } catch (err) {

--- a/utils/rpRuntime.ts
+++ b/utils/rpRuntime.ts
@@ -202,6 +202,13 @@ async function respondAsCharacter(
       return;
     }
 
+    if (result.reason === 'moderation') {
+      const notice = `⚠️ **${row.charName}** can't respond to that — safety filters blocked the exchange.`;
+      if (opts.notify) await opts.notify(notice);
+      else await channel.send({ content: notice, allowedMentions: { parse: [] } }).catch(() => {});
+      return;
+    }
+
     if (result.reason === 'compaction_failed') {
       const notice = `⚠️ **${row.charName}** has run out of context and automatic compaction failed. `
         + 'Mention them again to retry — if it keeps failing the oldest messages will be dropped instead.';


### PR DESCRIPTION
Adds an opt-in content-safety screen for AI chats, off by default.

## What

New `ai_moderation` global config key (`0`/`1`, default `0`). When enabled, **every** AI turn — every persona, every user, no exemptions — is screened by `nvidia/nemotron-3.5-content-safety:free` via a new non-invokable `Moderation` persona in `data/aiPersonas.json`.

```bash
/globalconfig set key:ai_moderation value:1
```

The classifier takes **no system prompt**: you hand it the raw exchange as ordinary `user`/`assistant` messages and it returns plain-text labels.

Screening runs **twice per turn** — on the user message alone before generating (so an unsafe prompt never reaches or bills the chat model), then on the user+assistant pair before delivery, so the reply is judged with the prompt that produced it in context.

## Per-surface behaviour

| Surface | Session? | On a trip |
| --- | --- | --- |
| mention handler | yes | **pause** |
| `/ask` | yes — *shares* the `Silverwolf` session with `@sw` | **pause** |
| web chat (`/games/ai-slop`) | yes | **pause** |
| `/summary count`/`time` | no | **reply-and-drop** |
| roleplay | spawns, not sessions | **reply-and-drop** |

**Pause** sets `AiChatSession.moderation_flagged`; the turn is neither delivered nor persisted, and the user gets `safety filters have paused this chat, please start a new chat` **in the voice of the persona they were talking to** (via the same webhook name/avatar on Discord; as the assistant's own bubble on web).

**Reply-and-drop** discards the output and posts a notice, leaving the surface usable.

## Notes for reviewers

Three deliberate calls worth a look:

**`active` is left untouched when flagging.** Deactivating would make `getOrCreateSession` hand out a fresh session on the very next message — the exact opposite of pausing. `kys` remains the intended escape hatch.

**`/ask` gets pause, not reply-and-drop.** It resolves the *same* `AiChatSession` row as the `@sw` mention persona, so dropping there would have been a way to keep talking to a chat that mentions had already paused.

**The screen fails open.** An outage, timeout, or unparseable label logs and allows the turn through. A free classifier being able to silently kill every conversation on the bot is the worse failure mode.

### Costs no credits

`moderateExchange` calls `createChatCompletionWithRetry` directly, bypassing `generateContent` — which is the only place `tryReserve`/`addUsage` live. No reservation, no ledger entry. It is deliberately *not* in `FREE_MODELS`, since it never reaches the code that consults that set; adding it would be dead config implying a billing route that doesn't exist. Documented invariant: don't route the classifier through `generateContent`.

One exception: a roleplay reply dropped by the *post*-screen already burned its tokens, so usage is still recorded. The pre-screen exists to avoid that in the common case.

### Escaping a pause

`kys` (new session) is the only exit, by design. `amnesia` is now refused on a paused session (`undoLastTurn` → `reason: 'paused'`) — the tripping turn was never persisted, so undoing would have silently eaten an *earlier, legitimate* turn while implying the pause had lifted. `/ai chatswitch` to a different unflagged session is allowed; that's equivalent to starting a new chat.

The flag is permanent per session and there's no dev command to clear it. If false positives warrant an unflag escape hatch, that's a small follow-up — left out rather than assumed.

## Response format

I smoke-tested the model against OpenRouter rather than guessing at the format. `Response Safety` appears **only** when an assistant turn is supplied; `Safety Categories` only when something trips. Real captured outputs, now the test fixtures:

| input | output |
| --- | --- |
| benign, user only | `User Safety: safe` |
| benign pair | `User Safety: safe\nResponse Safety: safe` |
| bomb instructions, user only | `User Safety: unsafe\nSafety Categories: Guns and Illegal Weapons, Criminal Planning/Confessions` |
| violent reply | `User Safety: unsafe\nResponse Safety: unsafe\nSafety Categories: Harassment, ...` |

The parser also strips a `<think>` block in case reasoning mode is ever enabled, and treats anything unrecognisable as safe.

## Schema

One new column pair on `AiChatSession` (`moderation_flagged`, `moderation_categories`), picked up automatically by the `ALTER TABLE` path in `Database.init()` — no migration needed.

## Deploy note

`/globalconfig set` builds its key choices from `SETTABLE_GLOBAL_VALUE_KEYS`, so `ai_moderation` appears automatically with no change to the command files. But choices are baked into the registration payload at boot — **the bot must restart before the new option shows up in Discord**, and clients may need a hard reload to drop the cached picker.

## Testing

- `bun run typecheck` clean
- `bun run lint` clean on all touched files (pre-existing errors elsewhere untouched)
- `bun test` — 371 pass, 0 fail, including 13 new parser/config tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable AI content moderation across chat, roleplay, summaries, and AI Slop.
  * Unsafe prompts and generated replies are blocked with safety notices.
  * Flagged sessions are paused and require starting a new chat.
  * Added moderation status and category tracking.
* **Bug Fixes**
  * Prevented unsafe content from being delivered or saved.
  * Improved paused-session and concurrent request handling.
* **Documentation**
  * Documented moderation settings and behavior.
* **Tests**
  * Added coverage for moderation parsing and configuration validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->